### PR TITLE
Windows: installer fix + code-signing tooling + installer-first downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,5 +119,6 @@ jobs:
             Xplorer ${{ steps.ver.outputs.v }} — AI-native Chromium fork.
             **macOS** (Apple Silicon arm64 + Intel x86_64) and **Windows x64** builds included.
             - macOS: open the DMG for your Mac and drag Xplorer to Applications.
-            - Windows: unzip `Xplorer-windows-x64.zip` and run `Xplorer.exe`.
+            - Windows: run `Xplorer-windows-x64-installer.exe` (installs + creates shortcuts), or unzip the portable `Xplorer-windows-x64.zip` and run `Xplorer.exe`.
+              The Windows build isn't code-signed yet, so SmartScreen warns — click **More info → Run anyway** (and allow it in Defender if prompted).
             See RELEASE.md (macOS) / RELEASE.windows.md (Windows) and AGENTS.md for connecting agents.

--- a/README.md
+++ b/README.md
@@ -191,18 +191,20 @@ Full endpoint reference: [`docs/AGENT_API.md`](docs/AGENT_API.md).
 
 Latest builds — these links always point at the **newest release**. macOS builds
 are Developer ID–signed & notarized (open without Gatekeeper warnings); the
-Windows build is an unsigned portable zip (SmartScreen may warn — choose **More
-info → Run anyway**).
+Windows build isn't code‑signed yet (SmartScreen may warn — choose **More info →
+Run anyway**, and allow it in Defender if prompted).
 
 | Platform | Direct download |
 |----------|-----------------|
 | **macOS — Apple Silicon** (M1/M2/M3/M4) | [**Xplorer-macos-arm64.dmg**](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-macos-arm64.dmg) · [.zip](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-macos-arm64.zip) |
 | **macOS — Intel** | [**Xplorer-macos-x86_64.dmg**](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-macos-x86_64.dmg) · [.zip](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-macos-x86_64.zip) |
-| **Windows x64** (10/11) | [**Xplorer-windows-x64.zip**](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-windows-x64.zip) |
+| **Windows x64** (10/11) | [**Xplorer-windows-x64-installer.exe**](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-windows-x64-installer.exe) · [.zip](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-windows-x64.zip) |
 
-macOS: open the DMG and drag **Xplorer** to Applications. Windows: unzip and run
-**`Xplorer\Xplorer.exe`** (portable, no installer). All releases + checksums on
-the [Releases](https://github.com/daniel-farina/xplorer/releases) page, or
+macOS: open the DMG and drag **Xplorer** to Applications. Windows: run the
+**installer** (`Xplorer-windows-x64-installer.exe` — creates Start‑menu & Desktop
+shortcuts), or grab the portable **`.zip`** and run **`Xplorer\Xplorer.exe`**. All
+releases + checksums on the
+[Releases](https://github.com/daniel-farina/xplorer/releases) page, or
 [build it yourself](#develop-locally).
 
 ---

--- a/RELEASE.windows.md
+++ b/RELEASE.windows.md
@@ -154,18 +154,39 @@ Produces in `xplorer\dist\`:
 
 ---
 
-## 5. (Optional) Code signing
+## 5. Code signing (fixes "unknown publisher" + SmartScreen/Defender)
 
-Windows has no notarization requirement, but unsigned binaries trip SmartScreen.
-To sign, use `signtool` (the Authenticode analog of `codesign`) on `Xplorer.exe`,
-`chrome.dll`, and `mini_installer.exe` with an OV/EV certificate, e.g.:
+Unsigned binaries are the cause of: SmartScreen "unknown publisher", the
+"Windows protected your PC" block, **and** Defender sometimes quarantining a DLL
+from the download — which then surfaces as a missing-DLL **error on launch**.
+The fix is a real Authenticode code-signing certificate; a self-signed cert does
+*not* help SmartScreen.
+
+**Certificate options** (you obtain this from a CA — DigiCert, Sectigo, SSL.com,
+GlobalSign, Certum):
+- **EV (Extended Validation)** — *instant* SmartScreen reputation (no warning
+  from day one). Ships on a USB hardware token or cloud HSM (Azure Key Vault).
+  Best choice. ~$300–700/yr.
+- **OV (Organization Validation)** — cheaper (~$200–400/yr) but SmartScreen
+  reputation accrues over downloads/time (early users still warned for a while).
+  Now also delivered on a token/HSM (no more exportable PFX for new issuances).
+
+**Signing** (`scripts/sign_win.ps1`, wraps `signtool` / `AzureSignTool` with
+SHA-256 + RFC-3161 timestamp). Sign in this order so the zip *and* installer
+contain signed binaries:
 
 ```powershell
-signtool sign /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 /a `
-  out\xplorer_x64\chrome.exe out\xplorer_x64\chrome.dll
+.\build.ps1 -Src C:\src\chromium\src                       # 1. build chrome
+.\scripts\sign_win.ps1 -OutDir ...\out\xplorer_x64 <cert>  # 2. sign binaries
+.\build.ps1 -Src C:\src\chromium\src -Installer            # 3. installer repacks signed bins
+.\scripts\sign_win.ps1 -OutDir ...\out\xplorer_x64 -InstallerOnly <cert>  # 4. sign installer
+.\scripts\package.ps1 -OutDir ...\out\xplorer_x64 -Installer             # 5. package
 ```
 
-Sign **before** packaging so the zip/installer contain signed binaries.
+`<cert>` is one of:
+- PFX file: `-PfxPath cert.pfx -PfxPassword '…'`
+- Azure Key Vault (cloud HSM, CI-friendly): `-KeyVaultUrl … -KeyVaultCert … -KeyVaultClientId … -KeyVaultClientSecret … -KeyVaultTenantId …` (needs `dotnet tool install --global AzureSignTool`)
+- Hardware token: plug it in and omit the cert args — `signtool /a` auto-selects from the cert store.
 
 ---
 

--- a/build.ps1
+++ b/build.ps1
@@ -70,6 +70,12 @@ try {
   if ($LASTEXITCODE -ne 0) { throw "autoninja chrome failed (exit $LASTEXITCODE)" }
 
   if ($Installer) {
+    # Stage the companion UI into the out dir so mini_installer packages it
+    # (chrome.release ships it to <ChromeDir>\companion\ui, where the gateway's
+    # UiDir() resolves it; without it the installed app's /search etc. 401).
+    robocopy (Join-Path $Xplorer "companion\ui") (Join-Path $outPath "companion\ui") /E /NFL /NDL /NJH /NJS /NP | Out-Null
+    if ($LASTEXITCODE -ge 8) { throw "robocopy failed staging companion\ui for installer (exit $LASTEXITCODE)" }
+    $global:LASTEXITCODE = 0
     Write-Host "autoninja -C out\$OutDir mini_installer ..."
     & autoninja -C "out\$OutDir" mini_installer
     if ($LASTEXITCODE -ne 0) { throw "autoninja mini_installer failed (exit $LASTEXITCODE)" }

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -941,6 +941,23 @@ def main(src: Path):
     # Native browser-chrome Xplorer pill toolbar (scaffold).
     patch_native_toolbar(src)
 
+    # Bundle the Grok companion UI into the Windows installer's version dir
+    # (next to chrome.dll) so the gateway's UiDir() resolves it via DIR_MODULE on
+    # installed builds; without it the installed app's /search (and other UI
+    # routes) return the gateway's 401. The version dir is fully extracted by
+    # setup (a ChromeDir-root subdir is not), so it must live there. Windows-only
+    # (mini_installer); harmless on macOS, which doesn't read this file. The
+    # build/packaging step stages companion/ui into the out dir to be picked up.
+    chrome_release = src / "chrome/installer/mini_installer/chrome.release"
+    if chrome_release.exists():
+        edit(
+            chrome_release,
+            "chrome_proxy.exe: %(ChromeDir)s\\\n",
+            "chrome_proxy.exe: %(ChromeDir)s\\\n"
+            "# XPLORER: companion UI in the version dir (gateway UiDir/DIR_MODULE).\n"
+            "companion\\ui\\*.*: %(VersionDir)s\\companion\\ui\\\n",
+        )
+
     print("Integration edits applied.")
 
 

--- a/scripts/release_win.ps1
+++ b/scripts/release_win.ps1
@@ -28,7 +28,7 @@ param(
   [ValidateSet("x64", "arm64")][string]$Arch = "x64",
   [string]$Version = "dev",
   [string]$Src = (Join-Path (Split-Path $PSScriptRoot -Parent) "..\chromium\src"),
-  [switch]$Installer
+  [switch]$NoInstaller   # a release builds the mini_installer by default
 )
 
 $ErrorActionPreference = "Stop"
@@ -40,13 +40,13 @@ Write-Host "==> apply ($Arch)"
 
 Write-Host "==> build ($Arch)"
 $buildArgs = @{ Src = $Src; Arch = $Arch }
-if ($Installer) { $buildArgs.Installer = $true }
+if (-not $NoInstaller) { $buildArgs.Installer = $true }
 & (Join-Path $Xplorer "build.ps1") @buildArgs
 
 Write-Host "==> package ($Arch)"
 $outDir = Join-Path $Src "out\xplorer_$Arch"
 $pkgArgs = @{ OutDir = $outDir; Version = $Version; Arch = $Arch }
-if ($Installer) { $pkgArgs.Installer = $true }
+if (-not $NoInstaller) { $pkgArgs.Installer = $true }
 & (Join-Path $Xplorer "scripts\package.ps1") @pkgArgs
 
 Write-Host "==> done ($Arch $Version). Artifacts in $Xplorer\dist"

--- a/scripts/release_win.ps1
+++ b/scripts/release_win.ps1
@@ -17,11 +17,14 @@
 .PARAMETER Src
   Chromium src checkout. Defaults to ..\chromium\src.
 
-.PARAMETER Installer
-  Also build + package mini_installer.exe.
+.PARAMETER NoInstaller
+  Skip the mini_installer.exe build + packaging. By default a release builds and
+  packages the installer (Xplorer-windows-x64-installer.exe) alongside the
+  portable zip; pass -NoInstaller for a zip-only build.
 
 .EXAMPLE
-  .\scripts\release_win.ps1 -Arch x64 -Version v0.5.0
+  .\scripts\release_win.ps1 -Arch x64 -Version v0.5.0            # zip + installer
+  .\scripts\release_win.ps1 -Arch x64 -Version v0.5.0 -NoInstaller   # zip only
 #>
 [CmdletBinding()]
 param(

--- a/scripts/sign_win.ps1
+++ b/scripts/sign_win.ps1
@@ -1,0 +1,94 @@
+<#
+.SYNOPSIS
+  Authenticode-sign Xplorer's Windows binaries (SHA-256 + RFC-3161 timestamp).
+
+.DESCRIPTION
+  Unsigned downloads trigger SmartScreen "unknown publisher" + Defender blocks
+  (and Defender may quarantine an unsigned DLL, which then surfaces as a
+  missing-DLL error on launch). Signing with a real Authenticode cert fixes all
+  of that. EV certs get instant SmartScreen reputation; OV reputation accrues.
+
+  Run order for a signed release:
+    1. .\build.ps1 -Src <src>            # build chrome
+    2. .\scripts\sign_win.ps1 -OutDir <out> <cert args>   # sign the binaries
+    3. .\build.ps1 -Src <src> -Installer # mini_installer repacks SIGNED binaries
+    4. .\scripts\sign_win.ps1 -OutDir <out> -InstallerOnly <cert args>  # sign installer
+    5. .\scripts\package.ps1 -OutDir <out> -Installer     # zip + installer artifacts
+
+  Two cert backends:
+    * PFX file:        -PfxPath cert.pfx -PfxPassword '...'
+    * Azure Key Vault: -KeyVaultUrl https://<vault>.vault.azure.net
+                       -KeyVaultCert <name> -KeyVaultClientId <id>
+                       -KeyVaultClientSecret <secret> -KeyVaultTenantId <tenant>
+      (Key Vault uses AzureSignTool: dotnet tool install --global AzureSignTool.
+       This is the CI-friendly path for cloud-HSM EV certs. A USB hardware token
+       instead uses signtool /a on the machine with the token plugged in.)
+
+.NOTES
+  signtool.exe ships with the Windows SDK (Debugging/Signing tools).
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)][string]$OutDir,
+  [string]$PfxPath,
+  [string]$PfxPassword,
+  [string]$KeyVaultUrl,
+  [string]$KeyVaultCert,
+  [string]$KeyVaultClientId,
+  [string]$KeyVaultClientSecret,
+  [string]$KeyVaultTenantId,
+  [string]$TimestampUrl = "http://timestamp.digicert.com",
+  [switch]$InstallerOnly
+)
+
+$ErrorActionPreference = "Stop"
+$OutDir = [System.IO.Path]::GetFullPath($OutDir)
+
+# Our binaries (NOT the Microsoft-signed VC runtime / dxcompiler, which are
+# already signed). chrome.exe is signed in place; package.ps1 renames it to
+# Xplorer.exe afterward (the signature travels with the bytes).
+$ourBinaries = @(
+  'chrome.exe', 'chrome.dll', 'chrome_elf.dll', 'chrome_proxy.exe',
+  'elevation_service.exe', 'notification_helper.exe', 'chrome_pwa_launcher.exe',
+  'libEGL.dll', 'libGLESv2.dll', 'vk_swiftshader.dll', 'vulkan-1.dll'
+)
+$installerBinaries = @('mini_installer.exe', 'setup.exe')
+
+$targets = if ($InstallerOnly) { $installerBinaries } else { $ourBinaries }
+$files = foreach ($b in $targets) {
+  $p = Join-Path $OutDir $b
+  if (Test-Path $p) { $p } else { Write-Warning "skip (not built): $b" }
+}
+if (-not $files) { throw "No target binaries found in $OutDir" }
+
+if ($KeyVaultUrl) {
+  # Azure Key Vault (cloud HSM) via AzureSignTool.
+  $astCmd = Get-Command azuresigntool -ErrorAction SilentlyContinue
+  $azuresigntool = if ($astCmd) { $astCmd.Source } else { $null }
+  if (-not $azuresigntool) { throw "AzureSignTool not found. Install: dotnet tool install --global AzureSignTool" }
+  foreach ($f in $files) {
+    & $azuresigntool sign -kvu $KeyVaultUrl -kvc $KeyVaultCert `
+      -kvi $KeyVaultClientId -kvs $KeyVaultClientSecret -kvt $KeyVaultTenantId `
+      -tr $TimestampUrl -td sha256 -fd sha256 -v "$f"
+    if ($LASTEXITCODE -ne 0) { throw "AzureSignTool failed on $f" }
+  }
+}
+else {
+  # signtool (PFX file, or a hardware token via the cert store with /a).
+  $signtool = Get-ChildItem "C:\Program Files (x86)\Windows Kits\10\bin" -Recurse -Filter signtool.exe -ErrorAction SilentlyContinue |
+    Where-Object { $_.FullName -match '\\x64\\' } | Sort-Object FullName -Descending | Select-Object -First 1
+  if (-not $signtool) { throw "signtool.exe not found (install the Windows SDK Signing Tools)" }
+  $args = @('sign', '/fd', 'sha256', '/tr', $TimestampUrl, '/td', 'sha256')
+  if ($PfxPath) {
+    $args += @('/f', $PfxPath)
+    if ($PfxPassword) { $args += @('/p', $PfxPassword) }
+  } else {
+    $args += '/a'  # auto-select from the cert store (e.g. a plugged-in token)
+  }
+  foreach ($f in $files) {
+    & $signtool.FullName @args "$f"
+    if ($LASTEXITCODE -ne 0) { throw "signtool failed on $f" }
+  }
+}
+
+Write-Host "Signed $($files.Count) binary file(s). Verify with: signtool verify /pa /v <file>"

--- a/site/index.html
+++ b/site/index.html
@@ -77,7 +77,7 @@
         No extensions, no copy-paste. Just ask.
       </p>
       <div class="hero__cta">
-        <a class="btn btn--primary" href="https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-macos-arm64.dmg" target="_blank" rel="noopener">
+        <a class="btn btn--primary" id="hero-download" data-os-default="mac" href="https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-macos-arm64.dmg" target="_blank" rel="noopener">
           <svg class="os-apple" viewBox="0 0 24 24" aria-hidden="true"><path d="M17.05 12.04c-.03-2.42 1.98-3.58 2.07-3.64-1.13-1.65-2.89-1.88-3.51-1.9-1.49-.15-2.91.88-3.67.88-.76 0-1.93-.86-3.18-.84-1.63.02-3.14.95-3.98 2.41-1.7 2.95-.43 7.31 1.21 9.71.8 1.17 1.76 2.49 3.01 2.44 1.21-.05 1.67-.78 3.13-.78 1.46 0 1.87.78 3.15.76 1.3-.02 2.13-1.19 2.93-2.37.92-1.36 1.3-2.67 1.32-2.74-.03-.01-2.53-.97-2.56-3.85zM14.62 5.34c.67-.81 1.12-1.94.99-3.06-.96.04-2.12.64-2.81 1.45-.62.72-1.16 1.87-1.02 2.97 1.07.08 2.17-.55 2.84-1.36z"/></svg>
           Download for macOS
         </a>
@@ -94,7 +94,7 @@
           <svg class="os-apple" viewBox="0 0 24 24" aria-hidden="true"><path d="M17.05 12.04c-.03-2.42 1.98-3.58 2.07-3.64-1.13-1.65-2.89-1.88-3.51-1.9-1.49-.15-2.91.88-3.67.88-.76 0-1.93-.86-3.18-.84-1.63.02-3.14.95-3.98 2.41-1.7 2.95-.43 7.31 1.21 9.71.8 1.17 1.76 2.49 3.01 2.44 1.21-.05 1.67-.78 3.13-.78 1.46 0 1.87.78 3.15.76 1.3-.02 2.13-1.19 2.93-2.37.92-1.36 1.3-2.67 1.32-2.74-.03-.01-2.53-.97-2.56-3.85zM14.62 5.34c.67-.81 1.12-1.94.99-3.06-.96.04-2.12.64-2.81 1.45-.62.72-1.16 1.87-1.02 2.97 1.07.08 2.17-.55 2.84-1.36z"/></svg>
           macOS <span class="platform-chip__note">Intel</span>
         </a>
-        <a class="platform-chip" href="https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-windows-x64.zip" target="_blank" rel="noopener">
+        <a class="platform-chip" href="https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-windows-x64-installer.exe" target="_blank" rel="noopener">
           <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="2" y="2" width="9" height="9" rx="1" fill="#F25022"/><rect x="13" y="2" width="9" height="9" rx="1" fill="#7FBA00"/><rect x="2" y="13" width="9" height="9" rx="1" fill="#00A4EF"/><rect x="13" y="13" width="9" height="9" rx="1" fill="#FFB900"/></svg>
           Windows <span class="platform-chip__note">x64</span>
         </a>
@@ -376,8 +376,11 @@ curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9334/tabs
           <h3>Windows</h3>
           <p class="download-card__sub">x64 · Windows 10/11</p>
           <div class="download-card__buttons">
-            <a class="btn btn--primary" href="https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-windows-x64.zip" target="_blank" rel="noopener">
-              Download Zip
+            <a class="btn btn--primary" href="https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-windows-x64-installer.exe" target="_blank" rel="noopener">
+              Download Installer
+            </a>
+            <a class="btn btn--ghost" href="https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-windows-x64.zip" target="_blank" rel="noopener">
+              Zip
             </a>
           </div>
         </article>
@@ -664,6 +667,46 @@ curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9334/tabs
       document.addEventListener('keydown', function (e) {
         if (e.key === 'Escape') setOpen(false);
       });
+    })();
+  </script>
+
+  <!-- OS detection: point the hero CTA (and surface the chip) at the current OS. -->
+  <script>
+    (function () {
+      var REL = 'https://github.com/daniel-farina/xplorer/releases/latest/download/';
+      // Default in the markup is macOS (Apple Silicon DMG) so no-JS visitors get a
+      // working link; we only rewrite when we can confidently detect Windows/Linux.
+      var WIN_ICON = '<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="2" y="2" width="9" height="9" rx="1" fill="#F25022"/><rect x="13" y="2" width="9" height="9" rx="1" fill="#7FBA00"/><rect x="2" y="13" width="9" height="9" rx="1" fill="#00A4EF"/><rect x="13" y="13" width="9" height="9" rx="1" fill="#FFB900"/></svg>';
+
+      function detectOS() {
+        var d = navigator.userAgentData;
+        var plat = (d && d.platform) || navigator.platform || '';
+        var s = (plat + ' ' + (navigator.userAgent || '')).toLowerCase();
+        if (/win/.test(s)) return 'windows';
+        if (/mac|iphone|ipad|ipod/.test(s)) return 'mac';
+        if (/linux|android|cros/.test(s)) return 'linux';
+        return 'other';
+      }
+
+      var os = detectOS();
+      var btn = document.getElementById('hero-download');
+      if (btn && os === 'windows') {
+        btn.href = REL + 'Xplorer-windows-x64-installer.exe';
+        btn.innerHTML = WIN_ICON + ' Download for Windows';
+      }
+      // macOS / Linux / unknown keep the macOS DMG default (no native Linux build yet).
+
+      // Move the chip matching the visitor's OS to the front of the row.
+      try {
+        var chips = document.querySelector('.hero__platforms');
+        if (chips && os !== 'other') {
+          var needle = os === 'windows' ? 'windows' : 'macos';
+          var match = [].filter.call(chips.querySelectorAll('.platform-chip[href]'), function (a) {
+            return a.getAttribute('href').toLowerCase().indexOf(needle) !== -1;
+          })[0];
+          if (match && match !== chips.firstElementChild) chips.insertBefore(match, chips.firstElementChild);
+        }
+      } catch (e) {}
     })();
   </script>
 </body>

--- a/src/chrome/browser/agent_gateway/grok_native.cc
+++ b/src/chrome/browser/agent_gateway/grok_native.cc
@@ -211,12 +211,25 @@ base::FilePath UiDir() {
   // self-contained on any machine. Without this, a downloaded build has no UI
   // on disk and every UI navigation (e.g. /search) falls through to the
   // auth-required path -> 401.
+#if BUILDFLAG(IS_WIN)
+  // The gateway runs inside chrome.dll, which the installer places in the
+  // versioned dir (Application\<version>\); the companion UI ships there too
+  // (chrome.release: %(VersionDir)s\companion\ui). DIR_MODULE is chrome.dll's
+  // dir — the version dir for an install, or the flat dir for the portable zip
+  // and dev builds — so this one check covers all three layouts. (DIR_EXE is
+  // chrome.exe's dir, the parent dir for an install, handled as a fallback.)
+  base::FilePath module_dir;
+  if (base::PathService::Get(base::DIR_MODULE, &module_dir)) {
+    base::FilePath bundled =
+        module_dir.AppendASCII("companion").AppendASCII("ui");
+    if (base::DirectoryExists(bundled))
+      return bundled;
+  }
+#endif
   base::FilePath exe_dir;
   if (base::PathService::Get(base::DIR_EXE, &exe_dir)) {
 #if BUILDFLAG(IS_WIN)
-    // Windows has no .app bundle: chrome.exe and its resources are flat in the
-    // install dir, so the UI sits at <exe_dir>\companion\ui (the packaging
-    // step copies companion/ui beside the executable).
+    // Portable zip: chrome.exe and the UI are flat in the same dir.
     base::FilePath bundled =
         exe_dir.AppendASCII("companion").AppendASCII("ui");
 #else


### PR DESCRIPTION
Brings the Windows release work onto `master`. Four commits (clean fast-forward, 9 files):

- **windows: add Authenticode signing tooling + installer/signing docs** (`scripts/sign_win.ps1`, `RELEASE.windows.md`) — signtool/AzureSignTool wrapper (PFX or Key Vault). No secrets embedded; all cert material is runtime-supplied.
- **windows: bundle companion UI in the installer (fix installed-app 401)** — `apply_integration.py` ships `companion/ui` to the version dir, `build.ps1` stages it before `mini_installer`, and `grok_native.cc` resolves it via `DIR_MODULE`. Fixes `/search` etc. returning 401 on the installed app.
- **site+readme: lead Windows downloads with the installer; detect OS on hero CTA** — landing page + README now point Windows users at `Xplorer-windows-x64-installer.exe` (zip kept as secondary); hero CTA detects the visitor's OS (verified on Windows). `release_win.ps1` builds the installer by default; release.yml notes the build isn't signed yet.
- **release_win.ps1: fix stale `-Installer` help after the `-NoInstaller` flip.**

## Verification
- Downloaded the published v0.7.0 installer from GitHub, sha256-matched, clean-installed it, and confirmed the gateway + `/search`/`/settings` return 200 (401 bug gone).
- OS detection verified live in the installed Xplorer: hero CTA → "Download for Windows" → installer.exe.
- Pre-merge adversarial review (3 lenses: secrets/PII, correctness, public-appropriateness): **0 blockers**; no secrets/PII; macOS build path unaffected; download links match `package.ps1` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)