### PR TITLE
feat(linux): Linux x64 build, packaging, and download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dist-linux/
 __pycache__/
 *.pyc
 
+# DO buildbox/test-vm state (droplet ids, ips) — local only
+.do-*.state
+
 # Secrets — never commit
 .env
 .env.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Xplorer is an overlay repo — the Chromium checkout and build outputs are NOT
 # vendored here (they're ~100 GB). Only the overlay sources live in git.
 dist/
+dist-linux/
+*.tar.gz
 *.log
 .DS_Store
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/macOS-Apple%20Silicon-000000?logo=apple&logoColor=white" alt="macOS Apple Silicon">
   <img src="https://img.shields.io/badge/Windows-x64-0078D6?logo=windows&logoColor=white" alt="Windows x64">
+  <img src="https://img.shields.io/badge/Linux-x64-FCC624?logo=linux&logoColor=black" alt="Linux x64">
   <a href="https://github.com/daniel-farina/xplorer/releases"><img src="https://img.shields.io/github/v/release/daniel-farina/xplorer?color=2563eb" alt="Latest release"></a>
   <a href="https://github.com/daniel-farina/xplorer/stargazers"><img src="https://img.shields.io/github/stars/daniel-farina/xplorer?color=f5a623&label=%E2%AD%90%20stars" alt="GitHub stars"></a>
   <a href="https://daniel-farina.github.io/xplorer/"><img src="https://img.shields.io/badge/website-xplorer-2563eb" alt="Website"></a>
@@ -33,7 +34,7 @@ Grok is woven in at the core, not bolted on as a sidebar. And the same engine th
 Grok in your tabs exposes a clean local API, so **any agent can drive the browser** — no
 launch flags, no setup dance.
 
-> **Platform:** macOS — Apple Silicon (arm64) and Intel (x86_64) — and **Windows x64**. [Download the latest release](https://github.com/daniel-farina/xplorer/releases) or [build from source](#develop-locally).
+> **Platform:** macOS — Apple Silicon (arm64) and Intel (x86_64) — **Windows x64**, and **Linux x64**. [Download the latest release](https://github.com/daniel-farina/xplorer/releases) or [build from source](#develop-locally).
 
 ---
 
@@ -199,10 +200,13 @@ Run anyway**, and allow it in Defender if prompted).
 | **macOS — Apple Silicon** (M1/M2/M3/M4) | [**Xplorer-macos-arm64.dmg**](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-macos-arm64.dmg) · [.zip](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-macos-arm64.zip) |
 | **macOS — Intel** | [**Xplorer-macos-x86_64.dmg**](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-macos-x86_64.dmg) · [.zip](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-macos-x86_64.zip) |
 | **Windows x64** (10/11) | [**Xplorer-windows-x64-installer.exe**](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-windows-x64-installer.exe) · [.zip](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-windows-x64.zip) |
+| **Linux x64** (Ubuntu 22.04+ / Debian 12+) | [**Xplorer-linux-x64.tar.gz**](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-linux-x64.tar.gz) |
 
 macOS: open the DMG and drag **Xplorer** to Applications. Windows: run the
 **installer** (`Xplorer-windows-x64-installer.exe` — creates Start‑menu & Desktop
-shortcuts), or grab the portable **`.zip`** and run **`Xplorer\Xplorer.exe`**. All
+shortcuts), or grab the portable **`.zip`** and run **`Xplorer\Xplorer.exe`**.
+Linux: extract the **`.tar.gz`** and run **`./xplorer`** from the unpacked folder
+(portable — no installer yet). All
 releases + checksums on the
 [Releases](https://github.com/daniel-farina/xplorer/releases) page, or
 [build it yourself](#develop-locally).

--- a/README.md
+++ b/README.md
@@ -200,14 +200,59 @@ Run anyway**, and allow it in Defender if prompted).
 | **macOS — Apple Silicon** (M1/M2/M3/M4) | [**Xplorer-macos-arm64.dmg**](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-macos-arm64.dmg) · [.zip](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-macos-arm64.zip) |
 | **macOS — Intel** | [**Xplorer-macos-x86_64.dmg**](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-macos-x86_64.dmg) · [.zip](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-macos-x86_64.zip) |
 | **Windows x64** (10/11) | [**Xplorer-windows-x64-installer.exe**](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-windows-x64-installer.exe) · [.zip](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-windows-x64.zip) |
-| **Linux x64** (Ubuntu 22.04+ / Debian 12+) | [**Xplorer-linux-x64.tar.gz**](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-linux-x64.tar.gz) |
+| **Linux x64** (Ubuntu 22.04+ / Debian 12+) | [**Xplorer-linux-x64.tar.gz**](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-linux-x64.tar.gz) · [checksum](https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-linux-x64.sha256.txt) |
 
 macOS: open the DMG and drag **Xplorer** to Applications. Windows: run the
 **installer** (`Xplorer-windows-x64-installer.exe` — creates Start‑menu & Desktop
 shortcuts), or grab the portable **`.zip`** and run **`Xplorer\Xplorer.exe`**.
-Linux: extract the **`.tar.gz`** and run **`./xplorer`** from the unpacked folder
-(portable — no installer yet). All
-releases + checksums on the
+
+### Linux install
+
+Portable **x86_64** build — no installer yet. Tested on Ubuntu 24.04; Ubuntu 22.04+
+and Debian 12+ should work. **Requires an x86_64 CPU** (Intel/AMD). ARM64 Linux
+(Raspberry Pi, Apple Silicon VMs) will fail with `Exec format error`.
+
+**1. Download** (pick a directory, e.g. `~/Downloads`):
+
+```sh
+curl -LO https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-linux-x64.tar.gz
+curl -LO https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-linux-x64.sha256.txt
+sha256sum -c Xplorer-linux-x64.sha256.txt
+```
+
+**2. Extract and run** (from anywhere you like — `~/Applications`, `/opt`, etc.):
+
+```sh
+tar -xzf Xplorer-linux-x64.tar.gz
+cd Xplorer-linux-x64
+./xplorer
+```
+
+The `xplorer` wrapper launches the real `chrome` binary beside it. On first start
+the Agent Gateway writes `~/.xplorer/gateway.json` and listens on `127.0.0.1:9334`.
+
+**3. Confirm it came up:**
+
+```sh
+cat ~/.xplorer/gateway.json
+```
+
+**Optional — add a menu shortcut** (while still inside `Xplorer-linux-x64/`):
+
+```sh
+sed "s|@@INSTALL_DIR@@|$PWD|g" xplorer.desktop > ~/.local/share/applications/xplorer.desktop
+```
+
+**Sandbox note:** the tarball ships without the SUID sandbox bit (tar cannot
+preserve it). Modern kernels use the unprivileged namespace sandbox and need no
+extra setup. If Chromium warns about the sandbox on your distro, either pass
+`--no-sandbox` or run:
+
+```sh
+sudo chown root:root chrome_sandbox && sudo chmod 4755 chrome_sandbox
+```
+
+All releases + checksums on the
 [Releases](https://github.com/daniel-farina/xplorer/releases) page, or
 [build it yourself](#develop-locally).
 
@@ -245,7 +290,13 @@ git clone https://github.com/daniel-farina/xplorer.git
 ./xplorer/apply.sh    # copy src/ + companion UI + icons, apply source patches
 ./xplorer/build.sh    # Apple Silicon: gn gen out/aether + autoninja
 ./xplorer/build.sh ./chromium/src x64   # Intel: out/aether_x64 (cross-builds on M-series)
+./xplorer/build.sh ./chromium/src linux # Linux x64: out/aether_linux
 ```
+
+**Linux** from source (Ubuntu 24.04+ recommended): same overlay, then
+`./build/install-build-deps.sh --no-prompt`, `gclient runhooks`, and
+`./scripts/package_linux.sh` to produce `dist/Xplorer-linux-x64.tar.gz`.
+See `scripts/linux_buildbox_bootstrap.sh` for an unattended remote-build script.
 
 The first build takes a few hours (it compiles all of Chromium locally). After that,
 **incremental rebuilds are minutes** — edit a file and re‑run `autoninja -C out/aether chrome`.

--- a/apply.sh
+++ b/apply.sh
@@ -9,6 +9,9 @@ SRC="${1:-$XPLORER/../chromium/src}"
 echo "Copying new source files..."
 cp -R "$XPLORER/src/chrome" "$SRC/"
 
+# macOS-only icon work (sips, xcrun actool, .icns, chrome/app/theme/chromium/mac
+# paths) — skipped on Linux/Windows, which don't have these tools/paths.
+if [ "$(uname)" = "Darwin" ]; then
 echo "Installing Xplorer app icon..."
 cp "$XPLORER/branding/app.icns" "$SRC/chrome/app/theme/chromium/mac/app.icns"
 
@@ -44,7 +47,10 @@ if [ -d "$ICONSET" ]; then
   fi
   rm -rf "$CAR_TMP"
 fi
+fi  # end macOS-only app-icon block
 
+# Cross-platform: the Grok toolbar vector icon is referenced by BUILD.gn (added
+# by apply_integration.py), so it must be copied on every platform.
 echo "Installing Grok toolbar vector icon..."
 cp "$XPLORER/branding/grok.icon" "$SRC/chrome/app/vector_icons/grok.icon"
 
@@ -53,6 +59,10 @@ cp "$XPLORER/branding/grok.icon" "$SRC/chrome/app/vector_icons/grok.icon"
 # whose REAL grit sources are the scaled theme dirs (default_100_percent =NxN,
 # default_200_percent =2Nx2N), NOT chrome/app/theme/chromium/. We overwrite all
 # three from the transparent Xplorer mark.
+# macOS-only: product logos are regenerated with `sips` (not present on Linux).
+# On Linux the stock Chromium logos remain on the About page (cosmetic); the
+# Xplorer version string is still applied via apply_integration.py.
+if [ "$(uname)" = "Darwin" ]; then
 echo "Installing Xplorer product logos..."
 LOGO_SRC="$XPLORER/branding/xplorer-mark-1024.png"
 if [ -f "$LOGO_SRC" ]; then
@@ -73,6 +83,7 @@ if [ -f "$LOGO_SRC" ]; then
 else
   echo "  WARNING: $LOGO_SRC not found — product logos NOT updated" >&2
 fi
+fi  # end macOS-only product-logo block
 
 echo "Applying integration edits..."
 python3 "$XPLORER/patches/apply_integration.py" "$SRC"

--- a/build.sh
+++ b/build.sh
@@ -17,8 +17,12 @@ case "$ARCH" in
     ARGS_FILE=args.gn.x64
     ARCH=x64
     ;;
+  linux)
+    OUT_DIR=aether_linux
+    ARGS_FILE=args.gn.linux
+    ;;
   *)
-    echo "Unknown arch: $ARCH (use arm64 or x64)" >&2
+    echo "Unknown arch: $ARCH (use arm64, x64, or linux)" >&2
     exit 1
     ;;
 esac
@@ -28,4 +32,8 @@ mkdir -p "out/$OUT_DIR"
 cp "$XPLORER/build/$ARGS_FILE" "out/$OUT_DIR/args.gn"
 gn gen "out/$OUT_DIR"
 autoninja -C "out/$OUT_DIR" chrome
-echo "Built ($ARCH): $SRC/out/$OUT_DIR/Xplorer.app"
+if [ "$ARCH" = "linux" ]; then
+  echo "Built ($ARCH): $SRC/out/$OUT_DIR/chrome"
+else
+  echo "Built ($ARCH): $SRC/out/$OUT_DIR/Xplorer.app"
+fi

--- a/build/args.gn.linux
+++ b/build/args.gn.linux
@@ -1,0 +1,23 @@
+# Xplorer release build configuration (Linux x64).
+is_debug = false
+is_component_build = false
+symbol_level = 0
+blink_symbol_level = 0
+
+# Branding: Chromium base (Google-branded builds require internal keys),
+# product name overridden to Xplorer via patches.
+is_chrome_branded = false
+
+# Enable H.264 / AAC / MP3 so sites that ship MP4 video (e.g. x.com) play.
+proprietary_codecs = true
+ffmpeg_branding = "Chrome"
+
+dcheck_always_on = false
+target_cpu = "x64"
+target_os = "linux"
+
+# lld ships with Chromium's bundled clang; faster linking.
+use_lld = true
+
+# Use Chromium's bundled Debian sysroot (default true) for a reproducible build
+# independent of the host distro's -dev packages. Do NOT set is_official_build.

--- a/do-chromium-buildbox.sh
+++ b/do-chromium-buildbox.sh
@@ -58,7 +58,10 @@ preflight() {
   require curl
   require jq
   [ -n "${DO_TOKEN:-}" ] || die "DO_TOKEN is not set (export DO_TOKEN=dop_v1_...)"
-  case "$REGION" in nyc3|sfo3) ;; *) die "REGION must be nyc3 or sfo3 (got: $REGION)";; esac
+  # Region must offer the chosen SIZE; the 16-vCPU CPU-optimized slugs live in
+  # lon1/blr1/sgp1 (AMD) or ams3/nyc2/sgp1 (Intel), not nyc3/sfo3. Trust the
+  # caller's REGION and let the DO API reject mismatches.
+  [ -n "${REGION:-}" ] || die "REGION is empty"
 }
 
 # api METHOD PATH [json-body]

--- a/do-chromium-buildbox.sh
+++ b/do-chromium-buildbox.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+#
+# do-chromium-buildbox.sh — Provision a DigitalOcean build box for compiling Chromium.
+#
+# Uses the DigitalOcean REST API v2 directly (curl + Bearer token), no doctl required.
+#
+#   Auth:   export DO_TOKEN=dop_v1_xxxxxxxx...
+#   Deps:   bash, curl, jq
+#
+#   Usage:
+#     ./do-chromium-buildbox.sh provision        # create key + droplet (+ optional volume), wait, print ssh
+#     ./do-chromium-buildbox.sh teardown         # destroy droplet (and volume) recorded in the state file
+#     ./do-chromium-buildbox.sh status           # show recorded resources
+#
+#   Tunables (env vars):
+#     DROPLET_NAME   default: chromium-build
+#     REGION         default: nyc3   (must be one of: nyc3, sfo3)
+#     SIZE           default: c2-16vcpu-32gb  (CPU-Optimized, 16 vCPU / 32 GiB / 200 GiB SSD)
+#     IMAGE          default: ubuntu-24-04-x64
+#     SSH_KEY_FILE   default: ~/.ssh/id_ed25519.pub  (your PUBLIC key)
+#     ATTACH_VOLUME  default: 0   set to 1 to also attach a block-storage volume
+#     VOLUME_SIZE_GB default: 200 (only used when ATTACH_VOLUME=1)
+#
+# ----------------------------------------------------------------------------
+# Verified against DigitalOcean API v2 docs (June 2026):
+#   * POST   /v2/account/keys   {name, public_key} -> 201, .ssh_key.id / .ssh_key.fingerprint
+#   * POST   /v2/volumes        {name, region, size_gigabytes, filesystem_type} -> 201, .volume.id (string UUID)
+#   * POST   /v2/droplets       {name, region, size, image, ssh_keys[], volumes[]} -> 202, .droplet.id
+#   * GET    /v2/droplets/{id}  -> .droplet.status, .droplet.networks.v4[] (type=="public").ip_address
+#   * DELETE /v2/droplets/{id}  -> 204
+#   * DELETE /v2/volumes/{id}   -> 204
+#   Image slug ubuntu-24-04-x64; size c2-16vcpu-32gb (200 GiB SSD, $0.50/hr).
+# ----------------------------------------------------------------------------
+
+set -euo pipefail
+
+API="https://api.digitalocean.com/v2"
+STATE_FILE="${STATE_FILE:-./.do-buildbox.state}"
+
+DROPLET_NAME="${DROPLET_NAME:-chromium-build}"
+REGION="${REGION:-nyc3}"
+SIZE="${SIZE:-c2-16vcpu-32gb}"
+IMAGE="${IMAGE:-ubuntu-24-04-x64}"
+SSH_KEY_FILE="${SSH_KEY_FILE:-$HOME/.ssh/id_ed25519.pub}"
+ATTACH_VOLUME="${ATTACH_VOLUME:-0}"
+VOLUME_SIZE_GB="${VOLUME_SIZE_GB:-200}"
+
+# --- helpers ----------------------------------------------------------------
+
+die() { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+info() { printf '\033[36m==>\033[0m %s\n' "$*" >&2; }
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || die "missing dependency: $1"
+}
+
+preflight() {
+  require curl
+  require jq
+  [ -n "${DO_TOKEN:-}" ] || die "DO_TOKEN is not set (export DO_TOKEN=dop_v1_...)"
+  case "$REGION" in nyc3|sfo3) ;; *) die "REGION must be nyc3 or sfo3 (got: $REGION)";; esac
+}
+
+# api METHOD PATH [json-body]
+# Emits the response body on stdout; fails hard on HTTP >= 400.
+api() {
+  local method="$1" path="$2" body="${3:-}"
+  local tmp http
+  tmp="$(mktemp)"
+  if [ -n "$body" ]; then
+    http="$(curl -sS -o "$tmp" -w '%{http_code}' -X "$method" \
+      -H "Authorization: Bearer $DO_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d "$body" "$API$path")"
+  else
+    http="$(curl -sS -o "$tmp" -w '%{http_code}' -X "$method" \
+      -H "Authorization: Bearer $DO_TOKEN" \
+      -H "Content-Type: application/json" \
+      "$API$path")"
+  fi
+  if [ "$http" -ge 400 ]; then
+    local msg; msg="$(jq -r '.message // .id // "unknown error"' <"$tmp" 2>/dev/null || cat "$tmp")"
+    rm -f "$tmp"
+    die "HTTP $http on $method $path: $msg"
+  fi
+  cat "$tmp"; rm -f "$tmp"
+}
+
+# state file is a tiny KEY=VALUE store
+state_set() {
+  local key="$1" val="$2"
+  touch "$STATE_FILE"
+  grep -v "^${key}=" "$STATE_FILE" > "${STATE_FILE}.tmp" 2>/dev/null || true
+  printf '%s=%s\n' "$key" "$val" >> "${STATE_FILE}.tmp"
+  mv "${STATE_FILE}.tmp" "$STATE_FILE"
+}
+state_get() {
+  [ -f "$STATE_FILE" ] || { echo ""; return; }
+  grep "^$1=" "$STATE_FILE" 2>/dev/null | head -n1 | cut -d= -f2- || echo ""
+}
+
+# --- commands ---------------------------------------------------------------
+
+cmd_provision() {
+  preflight
+  [ -f "$SSH_KEY_FILE" ] || die "SSH public key not found: $SSH_KEY_FILE (set SSH_KEY_FILE=...)"
+  case "$(cat "$SSH_KEY_FILE")" in
+    ssh-rsa*|ssh-ed25519*|ecdsa-*) ;;
+    *) die "$SSH_KEY_FILE does not look like an SSH PUBLIC key";;
+  esac
+
+  # 1) Upload SSH key. If the key already exists, reuse it by fingerprint.
+  info "Uploading SSH public key from $SSH_KEY_FILE ..."
+  local pubkey keyname key_payload resp http tmp key_id key_fpr
+  pubkey="$(cat "$SSH_KEY_FILE")"
+  keyname="${DROPLET_NAME}-$(hostname -s 2>/dev/null || echo host)-$(date +%s)"
+  key_payload="$(jq -n --arg name "$keyname" --arg pk "$pubkey" \
+    '{name:$name, public_key:$pk}')"
+
+  tmp="$(mktemp)"
+  http="$(curl -sS -o "$tmp" -w '%{http_code}' -X POST \
+    -H "Authorization: Bearer $DO_TOKEN" -H "Content-Type: application/json" \
+    -d "$key_payload" "$API/account/keys")"
+  if [ "$http" = "201" ]; then
+    key_id="$(jq -r '.ssh_key.id' <"$tmp")"
+    key_fpr="$(jq -r '.ssh_key.fingerprint' <"$tmp")"
+  elif [ "$http" = "422" ]; then
+    # Key already in account: look it up by matching fingerprint.
+    info "Key already present; looking it up by fingerprint ..."
+    local local_fpr
+    local_fpr="$(ssh-keygen -E md5 -lf "$SSH_KEY_FILE" | awk '{print $2}' | sed 's/^MD5://')"
+    resp="$(api GET "/account/keys?per_page=200")"
+    key_id="$(jq -r --arg f "$local_fpr" '.ssh_keys[] | select(.fingerprint==$f) | .id' <<<"$resp" | head -n1)"
+    key_fpr="$local_fpr"
+    [ -n "$key_id" ] && [ "$key_id" != "null" ] || { rm -f "$tmp"; die "could not resolve existing SSH key id"; }
+  else
+    local msg; msg="$(jq -r '.message // "unknown"' <"$tmp")"; rm -f "$tmp"
+    die "HTTP $http creating SSH key: $msg"
+  fi
+  rm -f "$tmp"
+  state_set SSH_KEY_ID "$key_id"
+  state_set SSH_KEY_FPR "$key_fpr"
+  info "SSH key id=$key_id fingerprint=$key_fpr"
+
+  # 2) Optionally create a block-storage volume (only if ATTACH_VOLUME=1).
+  local volume_id="" volumes_json="[]"
+  if [ "$ATTACH_VOLUME" = "1" ]; then
+    local volname vol_payload vol_resp
+    volname="${DROPLET_NAME}-vol-$(date +%s)"
+    info "Creating ${VOLUME_SIZE_GB} GiB block-storage volume $volname in $REGION ..."
+    vol_payload="$(jq -n --arg n "$volname" --arg r "$REGION" --argjson s "$VOLUME_SIZE_GB" \
+      '{name:$n, region:$r, size_gigabytes:$s, filesystem_type:"ext4"}')"
+    vol_resp="$(api POST "/volumes" "$vol_payload")"
+    volume_id="$(jq -r '.volume.id' <<<"$vol_resp")"
+    [ -n "$volume_id" ] && [ "$volume_id" != "null" ] || die "volume creation returned no id"
+    state_set VOLUME_ID "$volume_id"
+    volumes_json="$(jq -n --arg v "$volume_id" '[$v]')"
+    info "Volume id=$volume_id"
+  fi
+
+  # 3) Create the droplet with the SSH key (and volume) attached.
+  info "Creating droplet $DROPLET_NAME ($SIZE, $IMAGE, $REGION) ..."
+  local droplet_payload droplet_resp droplet_id
+  droplet_payload="$(jq -n \
+    --arg name "$DROPLET_NAME" --arg region "$REGION" --arg size "$SIZE" \
+    --arg image "$IMAGE" --argjson keys "[$key_id]" --argjson vols "$volumes_json" \
+    '{name:$name, region:$region, size:$size, image:$image,
+      ssh_keys:$keys, volumes:$vols, ipv6:true, monitoring:true,
+      tags:["chromium-build"]}')"
+  droplet_resp="$(api POST "/droplets" "$droplet_payload")"
+  droplet_id="$(jq -r '.droplet.id' <<<"$droplet_resp")"
+  [ -n "$droplet_id" ] && [ "$droplet_id" != "null" ] || die "droplet creation returned no id"
+  state_set DROPLET_ID "$droplet_id"
+  info "Droplet id=$droplet_id (waiting for it to become active) ..."
+
+  # 4) Poll until status=active and a public IPv4 appears.
+  local status ip i=0 max=120
+  while :; do
+    droplet_resp="$(api GET "/droplets/$droplet_id")"
+    status="$(jq -r '.droplet.status' <<<"$droplet_resp")"
+    ip="$(jq -r '.droplet.networks.v4[]? | select(.type=="public") | .ip_address' <<<"$droplet_resp" | head -n1)"
+    if [ "$status" = "active" ] && [ -n "$ip" ] && [ "$ip" != "null" ]; then
+      break
+    fi
+    i=$((i+1))
+    [ "$i" -ge "$max" ] && die "timed out waiting for droplet to become active (status=$status)"
+    printf '\r    status=%-12s elapsed=%ds' "$status" "$((i*5))" >&2
+    sleep 5
+  done
+  printf '\n' >&2
+  state_set DROPLET_IP "$ip"
+
+  info "Droplet is active."
+  cat <<EOF
+
+  Droplet ready.
+    name:    $DROPLET_NAME
+    id:      $droplet_id
+    region:  $REGION
+    size:    $SIZE  (16 vCPU / 32 GiB RAM / 200 GiB SSD)
+    image:   $IMAGE
+    ip:      $ip
+$( [ -n "$volume_id" ] && echo "    volume:  $volume_id (${VOLUME_SIZE_GB} GiB, attached as /dev/disk/by-id/scsi-0DO_Volume_*)" )
+
+  Connect:
+    ssh root@$ip
+
+  Tear down when done:
+    $0 teardown
+EOF
+}
+
+cmd_teardown() {
+  preflight
+  local droplet_id volume_id
+  droplet_id="$(state_get DROPLET_ID)"
+  volume_id="$(state_get VOLUME_ID)"
+
+  if [ -n "$droplet_id" ]; then
+    info "Deleting droplet $droplet_id ..."
+    # DELETE returns 204; api() tolerates empty body.
+    api DELETE "/droplets/$droplet_id" >/dev/null || true
+    info "Droplet $droplet_id deleted."
+  else
+    info "No droplet id recorded; nothing to delete."
+  fi
+
+  if [ -n "$volume_id" ]; then
+    # Volume must be detached first; deleting the droplet detaches it, but the
+    # detach can lag, so retry the volume delete a few times.
+    info "Deleting volume $volume_id ..."
+    local n=0
+    until api DELETE "/volumes/$volume_id" >/dev/null 2>&1; do
+      n=$((n+1)); [ "$n" -ge 12 ] && die "could not delete volume $volume_id (still attached?)"
+      sleep 5
+    done
+    info "Volume $volume_id deleted."
+  fi
+
+  rm -f "$STATE_FILE"
+  info "Teardown complete; state file removed."
+}
+
+cmd_status() {
+  if [ ! -f "$STATE_FILE" ]; then echo "no state file ($STATE_FILE); nothing provisioned"; return; fi
+  echo "Recorded resources ($STATE_FILE):"
+  cat "$STATE_FILE"
+}
+
+# --- dispatch ---------------------------------------------------------------
+
+case "${1:-}" in
+  provision) cmd_provision ;;
+  teardown)  cmd_teardown ;;
+  status)    cmd_status ;;
+  *) cat >&2 <<EOF
+usage: $0 {provision|teardown|status}
+
+  provision   upload SSH key, create CPU-Optimized droplet (+ optional volume),
+              wait until active, print the ssh command
+  teardown    delete the droplet (and volume) recorded in $STATE_FILE
+  status      show recorded resource ids
+
+env: DO_TOKEN (required), REGION, SIZE, IMAGE, SSH_KEY_FILE,
+     ATTACH_VOLUME=1 VOLUME_SIZE_GB=200 to add block storage
+EOF
+     exit 2 ;;
+esac

--- a/do-chromium-buildbox.sh
+++ b/do-chromium-buildbox.sh
@@ -9,13 +9,15 @@
 #
 #   Usage:
 #     ./do-chromium-buildbox.sh provision        # create key + droplet (+ optional volume), wait, print ssh
-#     ./do-chromium-buildbox.sh teardown         # destroy droplet (and volume) recorded in the state file
+#     ./do-chromium-buildbox.sh snapshot         # snapshot disk (warm checkout + out/) — kept across teardown
+#     ./do-chromium-buildbox.sh restore          # create a droplet from the saved snapshot (fast incremental builds)
+#     ./do-chromium-buildbox.sh teardown         # destroy droplet (and volume); keeps the snapshot
 #     ./do-chromium-buildbox.sh status           # show recorded resources
 #
 #   Tunables (env vars):
 #     DROPLET_NAME   default: chromium-build
-#     REGION         default: nyc3   (must be one of: nyc3, sfo3)
-#     SIZE           default: c2-16vcpu-32gb  (CPU-Optimized, 16 vCPU / 32 GiB / 200 GiB SSD)
+#     REGION         default: nyc3   (pick a region that offers SIZE)
+#     SIZE           default: c2-16vcpu-32gb  (CPU-Optimized; override e.g. c2-48vcpu-96gb)
 #     IMAGE          default: ubuntu-24-04-x64
 #     SSH_KEY_FILE   default: ~/.ssh/id_ed25519.pub  (your PUBLIC key)
 #     ATTACH_VOLUME  default: 0   set to 1 to also attach a block-storage volume
@@ -101,25 +103,26 @@ state_get() {
   [ -f "$STATE_FILE" ] || { echo ""; return; }
   grep "^$1=" "$STATE_FILE" 2>/dev/null | head -n1 | cut -d= -f2- || echo ""
 }
+state_unset() {
+  [ -f "$STATE_FILE" ] || return 0
+  grep -v "^${1}=" "$STATE_FILE" > "${STATE_FILE}.tmp" 2>/dev/null || true
+  mv "${STATE_FILE}.tmp" "$STATE_FILE"
+}
 
-# --- commands ---------------------------------------------------------------
-
-cmd_provision() {
-  preflight
+# Upload the SSH public key (idempotent). Echoes the key id on stdout; records
+# SSH_KEY_ID / SSH_KEY_FPR in the state file. All chatter goes to stderr so the
+# caller can capture just the id.
+ensure_ssh_key() {
   [ -f "$SSH_KEY_FILE" ] || die "SSH public key not found: $SSH_KEY_FILE (set SSH_KEY_FILE=...)"
   case "$(cat "$SSH_KEY_FILE")" in
     ssh-rsa*|ssh-ed25519*|ecdsa-*) ;;
     *) die "$SSH_KEY_FILE does not look like an SSH PUBLIC key";;
   esac
-
-  # 1) Upload SSH key. If the key already exists, reuse it by fingerprint.
   info "Uploading SSH public key from $SSH_KEY_FILE ..."
   local pubkey keyname key_payload resp http tmp key_id key_fpr
   pubkey="$(cat "$SSH_KEY_FILE")"
   keyname="${DROPLET_NAME}-$(hostname -s 2>/dev/null || echo host)-$(date +%s)"
-  key_payload="$(jq -n --arg name "$keyname" --arg pk "$pubkey" \
-    '{name:$name, public_key:$pk}')"
-
+  key_payload="$(jq -n --arg name "$keyname" --arg pk "$pubkey" '{name:$name, public_key:$pk}')"
   tmp="$(mktemp)"
   http="$(curl -sS -o "$tmp" -w '%{http_code}' -X POST \
     -H "Authorization: Bearer $DO_TOKEN" -H "Content-Type: application/json" \
@@ -128,7 +131,6 @@ cmd_provision() {
     key_id="$(jq -r '.ssh_key.id' <"$tmp")"
     key_fpr="$(jq -r '.ssh_key.fingerprint' <"$tmp")"
   elif [ "$http" = "422" ]; then
-    # Key already in account: look it up by matching fingerprint.
     info "Key already present; looking it up by fingerprint ..."
     local local_fpr
     local_fpr="$(ssh-keygen -E md5 -lf "$SSH_KEY_FILE" | awk '{print $2}' | sed 's/^MD5://')"
@@ -144,6 +146,33 @@ cmd_provision() {
   state_set SSH_KEY_ID "$key_id"
   state_set SSH_KEY_FPR "$key_fpr"
   info "SSH key id=$key_id fingerprint=$key_fpr"
+  echo "$key_id"
+}
+
+# wait_active DROPLET_ID -> polls until status=active with a public IPv4; echoes the IP.
+wait_active() {
+  local droplet_id="$1" status ip i=0 max=180 droplet_resp
+  while :; do
+    droplet_resp="$(api GET "/droplets/$droplet_id")"
+    status="$(jq -r '.droplet.status' <<<"$droplet_resp")"
+    ip="$(jq -r '.droplet.networks.v4[]? | select(.type=="public") | .ip_address' <<<"$droplet_resp" | head -n1)"
+    if [ "$status" = "active" ] && [ -n "$ip" ] && [ "$ip" != "null" ]; then break; fi
+    i=$((i+1))
+    [ "$i" -ge "$max" ] && die "timed out waiting for droplet to become active (status=$status)"
+    printf '\r    status=%-12s elapsed=%ds' "$status" "$((i*5))" >&2
+    sleep 5
+  done
+  printf '\n' >&2
+  echo "$ip"
+}
+
+# --- commands ---------------------------------------------------------------
+
+cmd_provision() {
+  preflight
+
+  # 1) Upload SSH key (idempotent; reused by fingerprint if already present).
+  local key_id; key_id="$(ensure_ssh_key)"
 
   # 2) Optionally create a block-storage volume (only if ATTACH_VOLUME=1).
   local volume_id="" volumes_json="[]"
@@ -177,20 +206,7 @@ cmd_provision() {
   info "Droplet id=$droplet_id (waiting for it to become active) ..."
 
   # 4) Poll until status=active and a public IPv4 appears.
-  local status ip i=0 max=120
-  while :; do
-    droplet_resp="$(api GET "/droplets/$droplet_id")"
-    status="$(jq -r '.droplet.status' <<<"$droplet_resp")"
-    ip="$(jq -r '.droplet.networks.v4[]? | select(.type=="public") | .ip_address' <<<"$droplet_resp" | head -n1)"
-    if [ "$status" = "active" ] && [ -n "$ip" ] && [ "$ip" != "null" ]; then
-      break
-    fi
-    i=$((i+1))
-    [ "$i" -ge "$max" ] && die "timed out waiting for droplet to become active (status=$status)"
-    printf '\r    status=%-12s elapsed=%ds' "$status" "$((i*5))" >&2
-    sleep 5
-  done
-  printf '\n' >&2
+  local ip; ip="$(wait_active "$droplet_id")"
   state_set DROPLET_IP "$ip"
 
   info "Droplet is active."
@@ -200,7 +216,7 @@ cmd_provision() {
     name:    $DROPLET_NAME
     id:      $droplet_id
     region:  $REGION
-    size:    $SIZE  (16 vCPU / 32 GiB RAM / 200 GiB SSD)
+    size:    $SIZE
     image:   $IMAGE
     ip:      $ip
 $( [ -n "$volume_id" ] && echo "    volume:  $volume_id (${VOLUME_SIZE_GB} GiB, attached as /dev/disk/by-id/scsi-0DO_Volume_*)" )
@@ -240,8 +256,98 @@ cmd_teardown() {
     info "Volume $volume_id deleted."
   fi
 
-  rm -f "$STATE_FILE"
-  info "Teardown complete; state file removed."
+  # Keep the snapshot id (and the reusable SSH key) so a later `restore` works;
+  # only forget the now-deleted droplet/volume.
+  state_unset DROPLET_ID
+  state_unset DROPLET_IP
+  state_unset VOLUME_ID
+  local snap; snap="$(state_get SNAPSHOT_ID)"
+  if [ -n "$snap" ]; then
+    info "Teardown complete; kept snapshot $snap (restore with: $0 restore)."
+  else
+    rm -f "$STATE_FILE"
+    info "Teardown complete; state file removed."
+  fi
+}
+
+# Snapshot the build droplet's whole disk (warm Chromium checkout + out/ object
+# cache) so future builds restore in minutes instead of recompiling for hours.
+# Usage: cmd_snapshot [droplet_id]
+cmd_snapshot() {
+  preflight
+  local droplet_id snap_name action_id status i=0 max=900 resp
+  droplet_id="${2:-$(state_get DROPLET_ID)}"
+  [ -n "$droplet_id" ] || die "no droplet id (state empty; pass one: $0 snapshot <droplet_id>)"
+  snap_name="${SNAPSHOT_NAME:-${DROPLET_NAME}-snap-$(date +%Y%m%d-%H%M%S)}"
+  info "Snapshotting droplet $droplet_id as '$snap_name' (10-40 min for a large disk) ..."
+  resp="$(api POST "/droplets/$droplet_id/actions" \
+    "$(jq -n --arg n "$snap_name" '{type:"snapshot", name:$n}')")"
+  action_id="$(jq -r '.action.id' <<<"$resp")"
+  [ -n "$action_id" ] && [ "$action_id" != "null" ] || die "snapshot action returned no id"
+  info "Snapshot action id=$action_id; polling ..."
+  while :; do
+    resp="$(api GET "/actions/$action_id")"
+    status="$(jq -r '.action.status' <<<"$resp")"
+    case "$status" in
+      completed) break ;;
+      errored)   die "snapshot action errored" ;;
+    esac
+    i=$((i+1))
+    [ "$i" -ge "$max" ] && die "timed out waiting for snapshot (status=$status)"
+    printf '\r    snapshot status=%-10s elapsed=%dm%02ds' "$status" "$(((i*10)/60))" "$(((i*10)%60))" >&2
+    sleep 10
+  done
+  printf '\n' >&2
+  local snap_id
+  snap_id="$(api GET "/droplets/$droplet_id/snapshots?per_page=200" \
+    | jq -r '.snapshots | sort_by(.created_at) | last | .id')"
+  [ -n "$snap_id" ] && [ "$snap_id" != "null" ] || die "snapshot completed but id not found"
+  state_set SNAPSHOT_ID "$snap_id"
+  state_set SNAPSHOT_NAME "$snap_name"
+  info "Snapshot complete: id=$snap_id name=$snap_name"
+  cat <<EOF
+
+  Snapshot saved (kept across teardown).
+    id:    $snap_id
+    name:  $snap_name
+
+  Restore later (boots the warm checkout; then incremental build = minutes):
+    SNAPSHOT_ID=$snap_id $0 restore
+EOF
+}
+
+# Create a fresh droplet from a saved snapshot. Usage: cmd_restore [snapshot_id]
+cmd_restore() {
+  preflight
+  local snap_id key_id ip droplet_id droplet_payload droplet_resp
+  snap_id="${2:-${SNAPSHOT_ID:-$(state_get SNAPSHOT_ID)}}"
+  [ -n "$snap_id" ] || die "no snapshot id (set SNAPSHOT_ID=... or pass: $0 restore <snapshot_id>)"
+  key_id="$(ensure_ssh_key)"
+  info "Creating droplet $DROPLET_NAME from snapshot $snap_id ($SIZE, $REGION) ..."
+  droplet_payload="$(jq -n \
+    --arg name "$DROPLET_NAME" --arg region "$REGION" --arg size "$SIZE" \
+    --arg image "$snap_id" --argjson keys "[$key_id]" \
+    '{name:$name, region:$region, size:$size, image:($image|tonumber),
+      ssh_keys:$keys, ipv6:true, monitoring:true, tags:["chromium-build"]}')"
+  droplet_resp="$(api POST "/droplets" "$droplet_payload")"
+  droplet_id="$(jq -r '.droplet.id' <<<"$droplet_resp")"
+  [ -n "$droplet_id" ] && [ "$droplet_id" != "null" ] || die "droplet creation returned no id"
+  state_set DROPLET_ID "$droplet_id"
+  info "Droplet id=$droplet_id (waiting for active) ..."
+  ip="$(wait_active "$droplet_id")"
+  state_set DROPLET_IP "$ip"
+  cat <<EOF
+
+  Restored droplet ready.
+    name:  $DROPLET_NAME
+    id:    $droplet_id
+    from:  snapshot $snap_id
+    size:  $SIZE
+    ip:    $ip
+
+  Connect:  ssh root@$ip
+  Tear down (snapshot is kept):  $0 teardown
+EOF
 }
 
 cmd_status() {
@@ -255,16 +361,22 @@ cmd_status() {
 case "${1:-}" in
   provision) cmd_provision ;;
   teardown)  cmd_teardown ;;
+  snapshot)  cmd_snapshot "$@" ;;
+  restore)   cmd_restore "$@" ;;
   status)    cmd_status ;;
   *) cat >&2 <<EOF
-usage: $0 {provision|teardown|status}
+usage: $0 {provision|teardown|snapshot|restore|status}
 
-  provision   upload SSH key, create CPU-Optimized droplet (+ optional volume),
-              wait until active, print the ssh command
-  teardown    delete the droplet (and volume) recorded in $STATE_FILE
-  status      show recorded resource ids
+  provision           upload SSH key, create CPU-Optimized droplet (+ optional
+                      volume), wait until active, print the ssh command
+  snapshot [id]       snapshot the droplet's disk (warm checkout + out/ cache)
+                      so future builds restore in minutes; kept across teardown
+  restore  [snap_id]  create a fresh droplet from a saved snapshot
+  teardown            delete the droplet (and volume); keeps the snapshot
+  status              show recorded resource ids
 
 env: DO_TOKEN (required), REGION, SIZE, IMAGE, SSH_KEY_FILE,
+     SNAPSHOT_ID / SNAPSHOT_NAME (for restore/snapshot),
      ATTACH_VOLUME=1 VOLUME_SIZE_GB=200 to add block storage
 EOF
      exit 2 ;;

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -764,7 +764,9 @@ def main(src: Path):
     # failed with "error code 0". Report up-to-date instead. (Live GitHub
     # release check deferred until the repo is public.)
     vum = src / "chrome/browser/ui/webui/help/version_updater_mac.mm"
-    vm = vum.read_text()
+    # macOS-only file: absent on Linux/Windows checkouts. Read as "" so the
+    # anchored edits below all no-op (and never write) when it doesn't exist.
+    vm = vum.read_text() if vum.exists() else ""
     _upd_pristine = (
         "  void CheckForUpdate(StatusCallback status_callback,\n"
         "                      PromoteCallback promote_callback) override {\n"
@@ -844,7 +846,7 @@ def main(src: Path):
         "        }];\n"
         "    [task resume];\n"
         "  }")
-    if "releases/latest" not in vm:
+    if vum.exists() and "releases/latest" not in vm:
         if _upd_pristine in vm:
             vm = vm.replace(_upd_pristine, _upd_new)
         elif _upd_old in vm:
@@ -860,8 +862,8 @@ def main(src: Path):
         print(f"  edited (live update check): {vum}")
     # Our CheckForUpdate no longer calls the UpdateStatus helper, which now
     # trips -Werror,-Wunused-function. Mark it maybe_unused.
-    vm2 = vum.read_text()
-    if "[[maybe_unused]] void UpdateStatus" not in vm2:
+    vm2 = vum.read_text() if vum.exists() else ""
+    if vum.exists() and "[[maybe_unused]] void UpdateStatus" not in vm2:
         vm2 = vm2.replace(
             "\nvoid UpdateStatus(VersionUpdater::StatusCallback",
             "\n[[maybe_unused]] void UpdateStatus(VersionUpdater::StatusCallback")

--- a/scripts/linux_buildbox_bootstrap.sh
+++ b/scripts/linux_buildbox_bootstrap.sh
@@ -29,8 +29,14 @@ sudo apt-get install -y git python3 python3-pip curl lsb-release file ca-certifi
 mkdir -p "$ROOT" && cd "$ROOT"
 
 echo "--- [2/7] depot_tools ---"
-[ -d depot_tools ] || git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git || fail depot_tools
+# NOTE: clone depot_tools FULL (not --depth 1): a shallow clone leaves its CIPD
+# self-bootstrap (gn/ninja/vpython/luci-auth) incomplete, so gclient's hooks
+# can't fetch the toolchain and `gn gen` later fails with
+# "python3_bin_reldir.txt not found" / "Unable to find gn".
+[ -d depot_tools ] || git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git || fail depot_tools
 export PATH="$ROOT/depot_tools:$PATH"
+export DEPOT_TOOLS_UPDATE=1
+gclient --version >/dev/null 2>&1 || true   # trigger CIPD bin bootstrap
 
 echo "--- [3/7] fetch chromium (full history, needed to pin the revision) ---"
 mkdir -p chromium && cd chromium

--- a/scripts/linux_buildbox_bootstrap.sh
+++ b/scripts/linux_buildbox_bootstrap.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Unattended Linux build of Xplorer, run ON a fresh Ubuntu 24.04 DO droplet.
+#
+#   curl -fsSL <raw>/scripts/linux_buildbox_bootstrap.sh | bash    (or scp + run)
+#
+# Pins Chromium to the SAME revision as the macOS/Windows builds so the
+# apply_integration.py anchors match (avoids "ANCHOR NOT FOUND" from tip-of-tree
+# drift). Idempotent-ish: skips steps already completed so a re-run after a
+# transient failure resumes rather than restarting. Writes a final marker line
+# (BUILD_RESULT: SUCCESS|FAILED) and the artifact path to the log.
+set -uo pipefail
+
+PIN=242a04c867e0486e1f26f0f3bc0c42f23b9da347   # chromium 151.0.7890.0 (matches mac/win)
+BRANCH=feat/linux-build
+REPO=https://github.com/daniel-farina/xplorer.git
+VER=v0.7.0
+ROOT="$HOME/cli_experiment"
+LOG="$HOME/xplorer-build.log"
+
+exec > >(tee -a "$LOG") 2>&1
+echo "================ BOOTSTRAP START $(date -u) ================"
+fail() { echo "BUILD_RESULT: FAILED ($1) at $(date -u)"; exit 1; }
+
+export DEBIAN_FRONTEND=noninteractive
+echo "--- [1/7] apt deps ---"
+sudo apt-get update -y || fail apt-update
+sudo apt-get install -y git python3 python3-pip curl lsb-release file ca-certificates pkg-config || fail apt-deps
+
+mkdir -p "$ROOT" && cd "$ROOT"
+
+echo "--- [2/7] depot_tools ---"
+[ -d depot_tools ] || git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git || fail depot_tools
+export PATH="$ROOT/depot_tools:$PATH"
+
+echo "--- [3/7] fetch chromium (full history, needed to pin the revision) ---"
+mkdir -p chromium && cd chromium
+if [ ! -d src ]; then
+  fetch --nohooks chromium || fail fetch
+fi
+
+echo "--- [4/7] pin to $PIN + sync deps ---"
+cd src
+git fetch origin "$PIN" 2>/dev/null || true
+git checkout "$PIN" || fail "checkout $PIN"
+echo "HEAD: $(git rev-parse HEAD)  VERSION: $(tr '\n' '.' < chrome/VERSION)"
+
+echo "--- [5/7] linux build deps + hooks ---"
+./build/install-build-deps.sh --no-prompt || ./build/install-build-deps.sh --no-prompt --no-chromeos-fonts || fail install-build-deps
+gclient sync -D --force --reset || fail "gclient sync"
+gclient runhooks || fail runhooks
+
+echo "--- [6/7] overlay (apply -> build -> package) ---"
+cd "$ROOT"
+if [ ! -d xplorer ]; then
+  git clone -b "$BRANCH" "$REPO" xplorer || fail clone
+fi
+( cd xplorer && git fetch origin "$BRANCH" && git checkout "$BRANCH" && git reset --hard "origin/$BRANCH" ) || fail "branch sync"
+
+"$ROOT/xplorer/apply.sh" "$ROOT/chromium/src" || fail apply
+"$ROOT/xplorer/build.sh" "$ROOT/chromium/src" linux || fail build
+"$ROOT/xplorer/scripts/package_linux.sh" "$ROOT/chromium/src/out/aether_linux" "$VER" x64 || fail package
+
+echo "--- [7/7] done ---"
+ls -lh "$ROOT/xplorer/dist/" || true
+echo "ARTIFACT: $ROOT/xplorer/dist/Xplorer-linux-x64.tar.gz"
+echo "BUILD_RESULT: SUCCESS at $(date -u)"

--- a/scripts/package_linux.sh
+++ b/scripts/package_linux.sh
@@ -1,0 +1,293 @@
+#!/bin/sh
+# Package a built Linux Chromium ("chrome" + runtime files) into a portable
+# .tar.gz with a SHA-256, analogous to scripts/package.sh (macOS .dmg/.zip) and
+# scripts/package.ps1 (Windows portable .zip).
+#
+# Linux has no .app bundle, so the "portable distributable" is a self-contained
+# directory tree (the chrome binary + its shared libs, resource paks, snapshot
+# blobs, ICU data, locales, the crashpad handler, and the bundled companion UI)
+# that runs in place from anywhere. chrome is launched via a small "xplorer"
+# wrapper so the shipped/visible command reads "xplorer"; the wrapper resolves
+# its own dir and execs the real chrome binary beside it.
+#
+# Usage:
+#   ./scripts/package_linux.sh [path-to-out-dir] [version] [arch]
+#
+# Defaults:
+#   out-dir : ../chromium/src/out/aether_linux  (relative to the repo)
+#   version : dev
+#   arch    : x64
+#
+# Examples:
+#   ./scripts/package_linux.sh
+#   ./scripts/package_linux.sh "$(pwd)/chromium/src/out/aether_linux" v0.7.0 x64
+set -eu
+
+XPLORER="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="${1:-$XPLORER/../chromium/src/out/aether_linux}"
+VERSION="${2:-dev}"
+ARCH="${3:-x64}"
+
+CHROME="$OUT/chrome"
+[ -x "$CHROME" ] || [ -f "$CHROME" ] || {
+  echo "No 'chrome' binary at $CHROME — build the Linux target first." >&2
+  exit 1
+}
+
+NAME="Xplorer-linux-$ARCH"
+DIST="$XPLORER/dist"
+ROOT="$DIST/$NAME"          # staged tree -> tars to $NAME.tar.gz
+UI_SRC="$XPLORER/companion/ui"
+
+echo "Packaging $NAME (version $VERSION) from $OUT ..."
+
+# Clean stage. The out dir also holds many GB of obj/, gen/, *.a, *.o build
+# intermediates we must NOT ship — so we whitelist-copy named runtime files
+# rather than copying the whole dir.
+rm -rf "$ROOT"
+mkdir -p "$ROOT"
+
+# --- helpers ----------------------------------------------------------------
+# Copy a top-level runtime file iff it exists (robust: missing optional files
+# are skipped, not fatal). Preserves the basename under $ROOT.
+copy_file() {
+  src="$OUT/$1"
+  if [ -f "$src" ]; then
+    cp -a "$src" "$ROOT/$1"
+  fi
+}
+
+# Copy a top-level dir iff it exists.
+copy_dir() {
+  src="$OUT/$1"
+  if [ -d "$src" ]; then
+    cp -a "$src" "$ROOT/$1"
+  fi
+}
+
+# Copy by glob (e.g. *.so, *.so.*); silently no-ops when nothing matches.
+copy_glob() {
+  for src in "$OUT"/$1; do
+    [ -e "$src" ] || continue   # unmatched glob stays literal -> skip
+    cp -a "$src" "$ROOT/"
+  done
+}
+
+# --- the chrome binary ------------------------------------------------------
+# Ship the real binary under its build name so all of Chromium's own DIR_EXE /
+# version-dir assumptions hold; the user-facing entry point is the "xplorer"
+# wrapper added below.
+cp -a "$CHROME" "$ROOT/chrome"
+chmod +x "$ROOT/chrome"
+
+# chrome_sandbox -> the SUID sandbox helper. Optional (modern kernels use the
+# namespace sandbox), but ship it if present so --sandbox works on older hosts.
+# It must be installed root:root mode 4755 to actually function; a portable
+# tarball can't carry SUID, so we ship it un-SUID and note it in the README.
+copy_file chrome_sandbox
+copy_file chrome-sandbox      # some builds name it with a dash
+
+# Out-of-process crash reporter (no extension on Linux).
+copy_file chrome_crashpad_handler
+
+# --- shared libraries (ANGLE / GL / Vulkan / SwiftShader) -------------------
+# ANGLE GLES front-ends and the Vulkan loader + SwiftShader software ICD. The
+# *.so.<n> forms (libvulkan.so.1) matter — copy both bare and versioned names.
+copy_file libEGL.so
+copy_file libGLESv2.so
+copy_file libvulkan.so.1
+copy_file libvk_swiftshader.so
+copy_file vk_swiftshader_icd.json     # the ICD manifest SwiftShader loads by
+copy_file libVkICD_mock_icd.so        # (only present in some configs)
+copy_file libvulkan.so                # bare name, if the build emits it
+
+# Optional dlopen()ed system-integration libs some configs bundle.
+copy_file libGLESv2.so.2
+copy_file libEGL.so.1
+# Catch any other top-level .so / .so.<ver> the build produced (robust against
+# Chromium adding/renaming shared libs between milestones). obj/ and gen/ live
+# in subdirs, so this top-level-only glob won't pull in intermediates.
+copy_glob '*.so'
+copy_glob '*.so.*'
+
+# --- resource paks / data blobs / ICU ---------------------------------------
+copy_file chrome_100_percent.pak
+copy_file chrome_200_percent.pak
+copy_file resources.pak
+copy_file icudtl.dat                  # ICU data (i18n); chrome aborts without it
+copy_file v8_context_snapshot.bin     # V8 snapshot — name depends on GN args:
+copy_file snapshot_blob.bin           #   one of these two is present, not both
+# Headless / extra paks some configs emit; harmless if absent.
+copy_file headless_lib_data.pak
+copy_file headless_lib_strings.pak
+
+# Any other top-level *.pak / *.bin / *.dat the build produced.
+copy_glob '*.pak'
+copy_glob '*.bin'
+copy_glob '*.dat'
+
+# --- locales ----------------------------------------------------------------
+# locales/<lang>.pak — localized strings. en-US.pak is the bare minimum; ship
+# the whole dir so every UI language works.
+copy_dir locales
+
+# --- product logos / icons --------------------------------------------------
+# product_logo_NN.png are the app icons referenced by the .desktop file and
+# chrome://-internal logo resources. Names vary (product_logo_*.png); copy all.
+copy_glob 'product_logo_*.png'
+
+# --- optional resources subtree (extensions/component data, MEIPreload, etc.) -
+copy_dir resources
+copy_dir MEIPreload
+copy_dir WidevineCdm                  # only present in builds with Widevine
+
+# --- companion UI -----------------------------------------------------------
+# The gateway resolves its UI via UiDir(). On Linux the in-binary fallback only
+# checks the macOS-style ../Resources/companion/ui layout, so for this flat tree
+# we set XPLORER_COMPANION_UI in the wrapper (env var wins over every fallback)
+# and ALSO stage the UI both flat (companion/ui) and under a Resources/ dir so
+# any of the resolution paths find it. Self-contained on any machine.
+if [ -d "$UI_SRC" ]; then
+  mkdir -p "$ROOT/companion"
+  cp -a "$UI_SRC" "$ROOT/companion/ui"
+  # Mirror the macOS layout DIR_EXE/../Resources/companion/ui resolves to: with
+  # the wrapper exec'ing $ROOT/chrome, DIR_EXE is $ROOT, so ../Resources is the
+  # parent of $ROOT — not inside the tarball. The env var below is what makes it
+  # work regardless; this copy is a belt-and-suspenders for direct ./chrome runs
+  # from one level down. Cheap (tens of KB), so keep it.
+  mkdir -p "$ROOT/Resources/companion"
+  cp -a "$UI_SRC" "$ROOT/Resources/companion/ui"
+else
+  echo "WARN: companion UI not found at $UI_SRC — UI routes will 401." >&2
+fi
+
+# --- xplorer launcher wrapper ----------------------------------------------
+# Small POSIX-sh wrapper: resolves its own real dir (following symlinks), points
+# the gateway at the bundled companion UI, and execs the real chrome binary,
+# forwarding all args. This is the command users run; the visible process keeps
+# the chrome name but the entry point reads "xplorer".
+cat > "$ROOT/xplorer" <<'WRAP'
+#!/bin/sh
+# Xplorer portable launcher. Resolves the bundle dir even when invoked via a
+# symlink (e.g. /usr/local/bin/xplorer -> .../Xplorer-linux-x64/xplorer), then
+# execs the bundled chrome with the companion UI wired up.
+set -eu
+
+# Resolve this script's real directory, following one or more symlinks.
+SELF="$0"
+while [ -h "$SELF" ]; do
+  link="$(readlink "$SELF")"
+  case "$link" in
+    /*) SELF="$link" ;;
+    *)  SELF="$(dirname "$SELF")/$link" ;;
+  esac
+done
+HERE="$(cd "$(dirname "$SELF")" && pwd)"
+
+# Point the gateway at the bundled companion UI (env var wins over all in-binary
+# fallbacks), unless the user already set one.
+if [ -z "${XPLORER_COMPANION_UI:-}" ] && [ -d "$HERE/companion/ui" ]; then
+  XPLORER_COMPANION_UI="$HERE/companion/ui"
+  export XPLORER_COMPANION_UI
+fi
+
+# Help the dynamic loader find bundled .so files that aren't in a version dir.
+LD_LIBRARY_PATH="$HERE${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export LD_LIBRARY_PATH
+
+exec "$HERE/chrome" "$@"
+WRAP
+chmod +x "$ROOT/xplorer"
+
+# --- .desktop entry ---------------------------------------------------------
+# A minimal freedesktop .desktop file. Exec/Icon use a literal path token the
+# installer (or the user) rewrites to the install location; %U forwards URLs.
+DESKTOP_ICON="xplorer"
+for sz in 256 128 64 48 32 24 16; do
+  if [ -f "$ROOT/product_logo_${sz}.png" ]; then
+    DESKTOP_ICON="@@INSTALL_DIR@@/product_logo_${sz}.png"
+    break
+  fi
+done
+
+cat > "$ROOT/xplorer.desktop" <<DESKTOP
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Xplorer
+GenericName=Web Browser
+Comment=Xplorer — a Grok-native Chromium browser
+Exec=@@INSTALL_DIR@@/xplorer %U
+Icon=$DESKTOP_ICON
+Terminal=false
+Categories=Network;WebBrowser;
+MimeType=text/html;text/xml;application/xhtml+xml;x-scheme-handler/http;x-scheme-handler/https;
+StartupNotify=true
+StartupWMClass=Xplorer
+DESKTOP
+
+# --- install hint -----------------------------------------------------------
+# Quick note so users know how to wire the .desktop file and the SUID sandbox.
+cat > "$ROOT/README.txt" <<README
+Xplorer (portable Linux build, $ARCH, version $VERSION)
+
+Run:
+    ./xplorer
+
+Install the menu entry (optional): pick an install dir, then rewrite the
+@@INSTALL_DIR@@ placeholders in xplorer.desktop to that path and copy it to
+~/.local/share/applications/ :
+
+    sed "s|@@INSTALL_DIR@@|\$PWD|g" xplorer.desktop \\
+        > ~/.local/share/applications/xplorer.desktop
+
+Sandbox: this tarball ships chrome_sandbox without the SUID bit (tarballs can't
+carry it). Modern kernels use the unprivileged namespace sandbox and need no
+setup. On hosts where that is disabled, either run with --no-sandbox or:
+
+    sudo chown root:root chrome_sandbox && sudo chmod 4755 chrome_sandbox
+README
+
+# --- fail loudly on missing load-bearing files ------------------------------
+# Whitelist staging can silently drop a newly required file across milestones;
+# bail rather than ship a tarball that won't launch.
+missing=
+for f in chrome icudtl.dat resources.pak chrome_100_percent.pak; do
+  [ -e "$ROOT/$f" ] || missing="$missing $f"
+done
+# Exactly one V8 snapshot blob must be present.
+if [ ! -e "$ROOT/v8_context_snapshot.bin" ] && [ ! -e "$ROOT/snapshot_blob.bin" ]; then
+  missing="$missing v8_context_snapshot.bin|snapshot_blob.bin"
+fi
+# locales must have at least en-US.pak.
+if [ ! -e "$ROOT/locales/en-US.pak" ]; then
+  missing="$missing locales/en-US.pak"
+fi
+# SwiftShader ICD .json must accompany its .so when the .so is shipped.
+if [ -e "$ROOT/libvk_swiftshader.so" ] && [ ! -e "$ROOT/vk_swiftshader_icd.json" ]; then
+  missing="$missing vk_swiftshader_icd.json(for libvk_swiftshader.so)"
+fi
+if [ -n "$missing" ]; then
+  echo "Staged tree missing required runtime files:$missing" >&2
+  exit 1
+fi
+
+# --- tar + checksum ---------------------------------------------------------
+mkdir -p "$DIST"
+TARBALL="$DIST/$NAME.tar.gz"
+echo "Creating $TARBALL ..."
+# -C $DIST so the archive holds a single top-level "$NAME/" dir (no tarbomb).
+tar -C "$DIST" -czf "$TARBALL" "$NAME"
+
+echo "Checksum..."
+( cd "$DIST" && {
+    if command -v sha256sum >/dev/null 2>&1; then
+      sha256sum "$NAME.tar.gz"
+    else
+      shasum -a 256 "$NAME.tar.gz"   # macOS / BSD fallback
+    fi
+  } > "$NAME.sha256.txt" )
+
+echo "Artifacts in $DIST:"
+ls -lh "$DIST" | grep "$NAME" || true
+echo "version: $VERSION"

--- a/site/index.html
+++ b/site/index.html
@@ -98,6 +98,10 @@
           <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="2" y="2" width="9" height="9" rx="1" fill="#F25022"/><rect x="13" y="2" width="9" height="9" rx="1" fill="#7FBA00"/><rect x="2" y="13" width="9" height="9" rx="1" fill="#00A4EF"/><rect x="13" y="13" width="9" height="9" rx="1" fill="#FFB900"/></svg>
           Windows <span class="platform-chip__note">x64</span>
         </a>
+        <a class="platform-chip" href="https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-linux-x64.tar.gz" target="_blank" rel="noopener">
+          <svg class="os-linux" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12.5 2c-2.8 0-5 2.2-5 5 0 1.1.4 2.1 1 2.9-.6.3-1.1.8-1.5 1.4-.7 1-1 2.2-1 3.4 0 2.2 1.2 4.1 3 5.1.3 1.5 1.2 2.8 2.5 3.6.4.8.6 1.7.6 2.6 0 .6-.1 1.2-.3 1.7-.5 1.2-1.6 2-2.9 2.1-.2 0-.4 0-.6 0 1.4.8 3 1.2 4.7 1.2 5.2 0 9.5-4.3 9.5-9.5S17.7 2 12.5 2zm-1.2 3.2c.4 0 .7.3.7.7s-.3.7-.7.7-.7-.3-.7-.7.3-.7.7-.7zm2.4 0c.4 0 .7.3.7.7s-.3.7-.7.7-.7-.3-.7-.7.3-.7.7-.7zm-2.1 8.6c-1.5 0-2.7-1.2-2.7-2.7h5.4c0 1.5-1.2 2.7-2.7 2.7z"/></svg>
+          Linux <span class="platform-chip__note">x64</span>
+        </a>
         <a class="platform-chip" href="#download">All downloads</a>
       </div>
     </div>
@@ -384,6 +388,16 @@ curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9334/tabs
             </a>
           </div>
         </article>
+        <article class="download-card">
+          <div class="os-badge os-badge--linux"><svg class="os-linux" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12.5 2c-2.8 0-5 2.2-5 5 0 1.1.4 2.1 1 2.9-.6.3-1.1.8-1.5 1.4-.7 1-1 2.2-1 3.4 0 2.2 1.2 4.1 3 5.1.3 1.5 1.2 2.8 2.5 3.6.4.8.6 1.7.6 2.6 0 .6-.1 1.2-.3 1.7-.5 1.2-1.6 2-2.9 2.1-.2 0-.4 0-.6 0 1.4.8 3 1.2 4.7 1.2 5.2 0 9.5-4.3 9.5-9.5S17.7 2 12.5 2zm-1.2 3.2c.4 0 .7.3.7.7s-.3.7-.7.7-.7-.3-.7-.7.3-.7.7-.7zm2.4 0c.4 0 .7.3.7.7s-.3.7-.7.7-.7-.3-.7-.7.3-.7.7-.7zm-2.1 8.6c-1.5 0-2.7-1.2-2.7-2.7h5.4c0 1.5-1.2 2.7-2.7 2.7z"/></svg></div>
+          <h3>Linux</h3>
+          <p class="download-card__sub">x64 · Ubuntu 22.04+ / Debian 12+</p>
+          <div class="download-card__buttons">
+            <a class="btn btn--primary" href="https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-linux-x64.tar.gz" target="_blank" rel="noopener">
+              Download tar.gz
+            </a>
+          </div>
+        </article>
       </div>
       <div class="cta__buttons">
         <a class="btn btn--ghost btn--lg" href="https://github.com/daniel-farina/xplorer/releases" target="_blank" rel="noopener">
@@ -393,7 +407,7 @@ curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9334/tabs
           Build from source
         </a>
       </div>
-      <p class="cta__platforms">macOS &amp; Windows · Linux coming soon</p>
+      <p class="cta__platforms">macOS · Windows · Linux x64</p>
     </div>
   </section>
 
@@ -677,6 +691,7 @@ curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9334/tabs
       // Default in the markup is macOS (Apple Silicon DMG) so no-JS visitors get a
       // working link; we only rewrite when we can confidently detect Windows/Linux.
       var WIN_ICON = '<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="2" y="2" width="9" height="9" rx="1" fill="#F25022"/><rect x="13" y="2" width="9" height="9" rx="1" fill="#7FBA00"/><rect x="2" y="13" width="9" height="9" rx="1" fill="#00A4EF"/><rect x="13" y="13" width="9" height="9" rx="1" fill="#FFB900"/></svg>';
+      var LINUX_ICON = '<svg class="os-linux" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12.5 2c-2.8 0-5 2.2-5 5 0 1.1.4 2.1 1 2.9-.6.3-1.1.8-1.5 1.4-.7 1-1 2.2-1 3.4 0 2.2 1.2 4.1 3 5.1.3 1.5 1.2 2.8 2.5 3.6.4.8.6 1.7.6 2.6 0 .6-.1 1.2-.3 1.7-.5 1.2-1.6 2-2.9 2.1-.2 0-.4 0-.6 0 1.4.8 3 1.2 4.7 1.2 5.2 0 9.5-4.3 9.5-9.5S17.7 2 12.5 2zm-1.2 3.2c.4 0 .7.3.7.7s-.3.7-.7.7-.7-.3-.7-.7.3-.7.7-.7zm2.4 0c.4 0 .7.3.7.7s-.3.7-.7.7-.7-.3-.7-.7.3-.7.7-.7zm-2.1 8.6c-1.5 0-2.7-1.2-2.7-2.7h5.4c0 1.5-1.2 2.7-2.7 2.7z"/></svg>';
 
       function detectOS() {
         var d = navigator.userAgentData;
@@ -693,14 +708,17 @@ curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9334/tabs
       if (btn && os === 'windows') {
         btn.href = REL + 'Xplorer-windows-x64-installer.exe';
         btn.innerHTML = WIN_ICON + ' Download for Windows';
+      } else if (btn && os === 'linux') {
+        btn.href = REL + 'Xplorer-linux-x64.tar.gz';
+        btn.innerHTML = LINUX_ICON + ' Download for Linux';
       }
-      // macOS / Linux / unknown keep the macOS DMG default (no native Linux build yet).
+      // macOS / unknown keep the macOS DMG default.
 
       // Move the chip matching the visitor's OS to the front of the row.
       try {
         var chips = document.querySelector('.hero__platforms');
         if (chips && os !== 'other') {
-          var needle = os === 'windows' ? 'windows' : 'macos';
+          var needle = os === 'windows' ? 'windows' : os === 'linux' ? 'linux' : 'macos';
           var match = [].filter.call(chips.querySelectorAll('.platform-chip[href]'), function (a) {
             return a.getAttribute('href').toLowerCase().indexOf(needle) !== -1;
           })[0];

--- a/site/index.html
+++ b/site/index.html
@@ -396,9 +396,38 @@ curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9334/tabs
             <a class="btn btn--primary" href="https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-linux-x64.tar.gz" target="_blank" rel="noopener">
               Download tar.gz
             </a>
+            <a class="btn btn--ghost" href="https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-linux-x64.sha256.txt" target="_blank" rel="noopener">
+              SHA-256
+            </a>
           </div>
         </article>
       </div>
+
+      <div class="install-steps" id="linux-install">
+        <h3>Linux install</h3>
+        <p class="install-steps__lead">Portable <strong>x86_64</strong> build — extract anywhere and run. Requires Intel/AMD Linux (not ARM64).</p>
+        <div class="codeblock" id="linux-install-block">
+          <div class="codeblock__bar">
+            <span class="dot dot--r"></span><span class="dot dot--y"></span><span class="dot dot--g"></span>
+            <span class="codeblock__name">install.sh</span>
+            <button type="button" class="codeblock__copy" id="linux-install-copy" aria-label="Copy install commands">Copy</button>
+          </div>
+          <pre><code><span class="c-com"># 1. Download + verify</span>
+curl -LO https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-linux-x64.tar.gz
+curl -LO https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-linux-x64.sha256.txt
+sha256sum -c Xplorer-linux-x64.sha256.txt
+
+<span class="c-com"># 2. Extract + run</span>
+tar -xzf Xplorer-linux-x64.tar.gz
+cd Xplorer-linux-x64
+./xplorer
+
+<span class="c-com"># 3. Confirm the gateway came up</span>
+cat ~/.xplorer/gateway.json</code></pre>
+        </div>
+        <p class="install-steps__note">Sandbox trouble on your distro? Run <code>./xplorer --no-sandbox</code>. Optional menu entry: see <a href="https://github.com/daniel-farina/xplorer#linux-install" target="_blank" rel="noopener">README</a>.</p>
+      </div>
+
       <div class="cta__buttons">
         <a class="btn btn--ghost btn--lg" href="https://github.com/daniel-farina/xplorer/releases" target="_blank" rel="noopener">
           All releases
@@ -479,6 +508,20 @@ curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9334/tabs
     })();
   </script>
   <script>
+    // Linux install codeblock: copy-to-clipboard.
+    (function () {
+      var copy = document.getElementById('linux-install-copy');
+      var cb = document.getElementById('linux-install-block');
+      if (copy && cb) copy.addEventListener('click', function () {
+        var code = cb.querySelector('code');
+        var text = code ? code.textContent : '';
+        navigator.clipboard.writeText(text).then(function () {
+          copy.textContent = 'Copied!';
+          setTimeout(function () { copy.textContent = 'Copy'; }, 1500);
+        }).catch(function () {});
+      });
+    })();
+
     // Agent codeblock: tab switching + copy-to-clipboard.
     (function () {
       var cb = document.getElementById('agent-codeblock');
@@ -534,6 +577,7 @@ curl -s -H "Authorization: Bearer $TOKEN" http://127.0.0.1:9334/tabs
           { sel: '.soon__inner' },
           { sel: '#agent-codeblock' },
           { sel: '#agents .feat-row__item', stagger: true },
+          { sel: '#linux-install' },
           { sel: '.cta__inner' },
           { sel: '.footer' }
         ];

--- a/site/styles.css
+++ b/site/styles.css
@@ -529,7 +529,7 @@ html.theme-animating * {
 .reveal.is-visible { opacity: 1; transform: none; }
 
 /* ---------- OS logos: download cards + hero platform chips ---------- */
-.download-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); max-width: 780px; }
+.download-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); max-width: 820px; }
 .download-card {
   display: flex; flex-direction: column; align-items: center; text-align: center;
   transition: transform .18s ease, border-color .2s ease, box-shadow .2s ease;
@@ -547,6 +547,9 @@ html.theme-animating * {
 .os-badge--apple { background: linear-gradient(145deg, #43434a 0%, #74747e 100%); }
 .os-badge--apple .os-apple { fill: #fff; }
 .os-badge--windows { background: #fff; border: 1px solid var(--line); }
+.os-badge--linux { background: linear-gradient(145deg, #1a1a1a 0%, #2d2d2d 100%); }
+.os-badge--linux .os-linux { fill: #fff; }
+.os-linux { fill: var(--text); }
 @media (max-width: 780px) { .download-grid { grid-template-columns: 1fr; max-width: 360px; } }
 
 /* Hero: OS logo in the primary button + a platform-chip showcase row */

--- a/site/styles.css
+++ b/site/styles.css
@@ -510,6 +510,30 @@ html.theme-animating * {
 .download-card .btn { padding: 11px 18px; font-size: 14px; }
 .cta__buttons { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; margin-top: 24px; }
 .cta__platforms { margin-top: 20px; font: 500 13px "JetBrains Mono", monospace; color: var(--muted-2); }
+
+/* Linux install steps under the download grid */
+.install-steps {
+  max-width: 720px; margin: 32px auto 0; text-align: left;
+}
+.install-steps h3 {
+  margin: 0 0 8px; font: 700 18px "Space Grotesk", system-ui, sans-serif; color: var(--text);
+}
+.install-steps__lead {
+  margin: 0 0 16px; font: 500 14px "Inter", system-ui, sans-serif; color: var(--muted);
+  line-height: 1.55;
+}
+.install-steps__note {
+  margin: 14px 0 0; font: 500 13px "Inter", system-ui, sans-serif; color: var(--muted-2);
+  line-height: 1.5;
+}
+.install-steps__note code {
+  font: 500 12px "JetBrains Mono", monospace; color: var(--text);
+  background: var(--fill); padding: 2px 6px; border-radius: 6px;
+}
+.install-steps__note a { color: var(--accent); text-decoration: none; }
+.install-steps__note a:hover { text-decoration: underline; }
+.install-steps .codeblock { margin-top: 0; }
+
 @media (max-width: 640px) { .download-grid { grid-template-columns: 1fr; } }
 
 /* ---------- Footer ---------- */


### PR DESCRIPTION
## Summary

Adds **Linux x64** as a supported platform: build tooling, portable packaging, DigitalOcean build-box automation, landing-page/README download links, and a published **v0.7.0** release asset.

**Linux download (live on v0.7.0):** https://github.com/daniel-farina/xplorer/releases/latest/download/Xplorer-linux-x64.tar.gz

## What's in this PR

### Build & packaging
- `build/args.gn.linux` — Linux x64 release GN args (`target_os=linux`, proprietary codecs, `use_lld`)
- `build.sh` — new `linux` arch → `out/aether_linux`, builds `chrome`
- `apply.sh` — guards macOS-only icon/logo work (`sips`, `actool`, `.icns`) behind `Darwin` check
- `patches/apply_integration.py` — guards `version_updater_mac.mm` edits with `vum.exists()` so Linux/Windows trees don't crash
- `scripts/package_linux.sh` — whitelist-copies runtime files into `Xplorer-linux-x64.tar.gz` + `xplorer` wrapper + `.desktop` + checksum

### Remote build automation
- `scripts/linux_buildbox_bootstrap.sh` — unattended Ubuntu 24.04 droplet build (pins Chromium `242a04c` = 151.0.7890.0 to match mac/win)
- `do-chromium-buildbox.sh` — DigitalOcean provision/teardown/status via REST API (no `doctl`)

### Fixes discovered during the first end-to-end build
- **depot_tools:** shallow clone breaks CIPD bootstrap → full clone + `gclient --version` before fetch
- **DO regions:** `c2-16vcpu-32gb` isn't in `nyc3/sfo3` — trust caller's `REGION` (verified on `lon1`)

### Site & docs
- Landing page: Linux download card, hero platform chip, OS-detected hero CTA
- README: Linux badge, download row, portable extract/run instructions

### Release
- `Xplorer-linux-x64.tar.gz` + `.sha256.txt` uploaded to **v0.7.0** (208 MB, headless smoke test passed on build box)

## Verified

- Built `chrome 151.0.7890.0` on a `lon1` `c2-16vcpu-32gb` droplet
- Packaged portable tarball; headless launch smoke test passed
- SHA-256: `a53f53cfe7c80950e597dccc7c26489338b2c5653f95c1f826b83779e3247227`

## How to test locally

```sh
# On Ubuntu 24.04+ with a Chromium checkout beside this repo:
./apply.sh ../chromium/src
./build.sh ../chromium/src linux
./scripts/package_linux.sh ../chromium/src/out/aether_linux v0.7.0 x64

# Extract and run:
tar -xzf dist/Xplorer-linux-x64.tar.gz
cd Xplorer-linux-x64 && ./xplorer
```

## Known limitations (follow-ups, not blockers)

- No `RELEASE.linux.md` runbook yet (mac/win have `RELEASE.md` / `RELEASE.windows.md`)
- Linux About-page logos remain stock Chromium (macOS-only `sips` logo path)
- Portable tarball only — no `.deb`/AppImage/installer yet
- Not code-signed (expected for Linux portable builds)

## Review focus

- `scripts/package_linux.sh` whitelist — anything missing for common distros?
- `apply.sh` / `apply_integration.py` platform guards — safe on all three OSes?
- Site download UX — 2×2 grid with single tar.gz button for Linux