### PR TITLE
branding+privacy: Xplorer rebrand, Grok default search, Brave-style Google-data hardening (WIP)

### DIFF
--- a/BRANDING_PRIVACY_PLAN.md
+++ b/BRANDING_PRIVACY_PLAN.md
@@ -23,17 +23,19 @@ Each loop iteration: read this file + `git log`, do the next safe item, commit, 
 - [x] **Blank Google key env vars** in `build.sh` before `gn gen` (belt-and-suspenders so a dev's
   exported real key can't be compiled in).
 
+## ✅ Done (cont.)
+
+- [x] **Hardened the prepopulated_engines.json default-search hijack** (`apply_integration.py`).
+  Replaced the literal `.replace()` (silent no-op on drift) with a whitespace-tolerant `re.subn`
+  + `n==1` **fail-loud assert**, and the hardcoded `kCurrentDataVersion 206→207` (a no-op on M151,
+  which ships 207) with a **dynamic read-then-+1 bump**. Verified the exact pristine name/keyword
+  format + version against the **local Mac checkout** (same pinned rev 242a04c8 — no snapshot needed)
+  and unit-tested the transform (Grok set, 207→208, other engines untouched, idempotent, valid JSON).
+- [x] **Grok engine favicon** — was still Google's `googleg_alldp.ico`; now `https://grok.com/favicon.ico`,
+  scoped `count=1` to the Grok block.
+
 ## 🔜 do_now (next iterations, in order)
 
-- [ ] **Harden the prepopulated_engines.json default-search hijack** (`apply_integration.py` ~621-631).
-  HIGH IMPACT — current code uses literal `.replace()` for name/keyword and a hardcoded
-  `kCurrentDataVersion 206→207`; on M151 both can silently no-op → ships **Google** as default.
-  Fix: `re.subn` + `n==1` assert (fail loud), read-then-bump version to `current+1`.
-  **GATE: verify the exact name/keyword JSON format + current kCurrentDataVersion against the real
-  `third_party/search_engines_data/.../prepopulated_engines.json`** (available on the build snapshot)
-  before landing the assert — an unverified assert would break `apply.sh`.
-- [ ] **Set the Grok engine favicon** (same JSON block) — currently still Google's favicon. Scope a
-  `count=1` regex to the Grok object → `https://grok.com/favicon.ico`.
 - [ ] **Disable Variations/Finch + component updater + What's New** via the existing
   `chrome_main_delegate.cc` switch block (`apply_integration.py` ~217-233 / ~462-473).
   Add `disable-component-update`, `disable-field-trial-config`, empty `variations-server-url` +

--- a/BRANDING_PRIVACY_PLAN.md
+++ b/BRANDING_PRIVACY_PLAN.md
@@ -1,0 +1,69 @@
+# Xplorer Branding + Privacy Plan (`branding` branch)
+
+Living roadmap for the hourly branding/privacy loop. Goals:
+1. **Branding** — all Chromium/Google Chrome → Xplorer.
+2. **Search** — default search engine = Grok, not Google.
+3. **Privacy** — Brave/ungoogled-style: no data sent to Google.
+
+Source of truth is the overlay: `patches/apply_integration.py` (anchor-based `edit()`),
+`src/chrome/**` (verbatim file copies), and `build/args.gn*` (GN flags, copied as-is by `build.sh`).
+
+Each loop iteration: read this file + `git log`, do the next safe item, commit, tick it off.
+**Never push to master.** Keep edits idempotent so `apply.sh` re-applies cleanly.
+
+---
+
+## ✅ Done
+
+- [x] **Privacy GN args** in all four `build/args.gn*` (purely additive, verified net-new):
+  `use_official_google_api_keys=false`, empty `google_api_key`/`client_id`/`client_secret`,
+  `enable_reporting=false` (UMA/UKM/crash upload), `safe_browsing_mode=0` (no /v4 lookups+pings),
+  `enable_hangout_services_extension=false`, `enable_mdns=false`, `enable_rlz=false`.
+  *(NOT touching `enable_widevine` — keep DRM; NOT `is_official_build`.)*
+- [x] **Blank Google key env vars** in `build.sh` before `gn gen` (belt-and-suspenders so a dev's
+  exported real key can't be compiled in).
+
+## 🔜 do_now (next iterations, in order)
+
+- [ ] **Harden the prepopulated_engines.json default-search hijack** (`apply_integration.py` ~621-631).
+  HIGH IMPACT — current code uses literal `.replace()` for name/keyword and a hardcoded
+  `kCurrentDataVersion 206→207`; on M151 both can silently no-op → ships **Google** as default.
+  Fix: `re.subn` + `n==1` assert (fail loud), read-then-bump version to `current+1`.
+  **GATE: verify the exact name/keyword JSON format + current kCurrentDataVersion against the real
+  `third_party/search_engines_data/.../prepopulated_engines.json`** (available on the build snapshot)
+  before landing the assert — an unverified assert would break `apply.sh`.
+- [ ] **Set the Grok engine favicon** (same JSON block) — currently still Google's favicon. Scope a
+  `count=1` regex to the Grok object → `https://grok.com/favicon.ico`.
+- [ ] **Disable Variations/Finch + component updater + What's New** via the existing
+  `chrome_main_delegate.cc` switch block (`apply_integration.py` ~217-233 / ~462-473).
+  Add `disable-component-update`, `disable-field-trial-config`, empty `variations-server-url` +
+  `variations-insecure-server-url`, and `ChromeWhatsNewUI` to disable-features.
+  **ANCHOR CONSTRAINT:** the second edit anchors on the literal
+  `AppendSwitchASCII("disable-features", "CalculateNativeWinOcclusion");` — if appending
+  `ChromeWhatsNewUI` to that value, update the string in BOTH blocks or the second `edit()` aborts.
+
+## 🕓 later (verify-then-fix; need a build or checkout to confirm)
+
+- [ ] **Window/taskbar title says "… - Chromium"** — VISUALLY CONFIRMED on the test desktop
+  (title bar read "Grok - Chromium"). Audit assumed handled; it is not. Find the residual product
+  string / WM class.
+- [ ] **User-Agent + UA-CH brand list** still "Chromium"/"Google Chrome"; append a `Xplorer/0.7.0`
+  brand token (never replace `Chrome/<ver>` — site-compat). `chrome_content_client.cc` +
+  `user_agent_utils.cc`; verify M151 signatures first.
+- [ ] **Force kill-switch prefs** in a PostBrowserStart hook: `kMetricsReportingEnabled=false`,
+  `kDnsOverHttpsMode="off"`, `kNetworkPredictionOptions=2`, `kSigninAllowed=false`.
+- [ ] **First-run / Welcome / What's New** still say Chromium — prefer disabling the feature.
+- [ ] **macOS helper bundles / Info.plist / crashpad product** — verify against a build; likely
+  already covered by product-name + bundle-id edits.
+- [ ] **Linux product_logo PNGs + About-page logo** — `apply.sh` skips logo regen on non-Darwin;
+  ship pre-rendered Xplorer PNGs.
+- [ ] **Windows installer / ARP / shortcut strings** — grep `chrome/installer` after apply.
+- [ ] **AgentGateway port** — `search_url` hardcodes `127.0.0.1:9334`; confirm `Start(0)` pins 9334
+  (else omnibox search 404s) and make `/omnibox` 302 even with an empty store.
+
+## Notes
+
+- Full audit reports (branding/search/privacy) captured by the `xplorer-branding-privacy-audit`
+  workflow run `wf_6806647d-0ca`.
+- The current search hijack reuses Chromium's built-in `id==1` (Google) slot → renames it to Grok.
+  Side effect: Google is no longer separately selectable. Acceptable unless product wants it back.

--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,13 @@ esac
 cd "$SRC"
 mkdir -p "out/$OUT_DIR"
 cp "$XPLORER/build/$ARGS_FILE" "out/$OUT_DIR/args.gn"
+# Xplorer privacy: never bake a developer's real Google key into the build.
+# Pairs with the empty google_* GN args in build/args.gn*. google_api_keys.cc
+# reads these env vars at gn-gen/compile time, so an exported key would
+# otherwise be compiled in. Empty = ungoogled (sign-in/sync already inert).
+export GOOGLE_API_KEY=""
+export GOOGLE_DEFAULT_CLIENT_ID=""
+export GOOGLE_DEFAULT_CLIENT_SECRET=""
 gn gen "out/$OUT_DIR"
 autoninja -C "out/$OUT_DIR" chrome
 if [ "$ARCH" = "linux" ]; then

--- a/build/args.gn
+++ b/build/args.gn
@@ -23,3 +23,15 @@ target_os = "mac"
 
 # Faster linking on Apple Silicon.
 use_lld = true
+
+# === Xplorer privacy hardening (Brave/ungoogled-style) — see BRANDING_PRIVACY_PLAN.md ===
+# Compile out Google data channels. Net-new args (none previously set here).
+use_official_google_api_keys = false
+google_api_key = ""
+google_default_client_id = ""
+google_default_client_secret = ""
+enable_reporting = false            # drops UMA/UKM + crash-upload code paths
+safe_browsing_mode = 0              # compiles out Safe Browsing /v4 lookups + pings
+enable_hangout_services_extension = false
+enable_mdns = false                 # disables Cast/mDNS device discovery
+enable_rlz = false                  # no RLZ ping (also the unbranded default)

--- a/build/args.gn.linux
+++ b/build/args.gn.linux
@@ -21,3 +21,15 @@ use_lld = true
 
 # Use Chromium's bundled Debian sysroot (default true) for a reproducible build
 # independent of the host distro's -dev packages. Do NOT set is_official_build.
+
+# === Xplorer privacy hardening (Brave/ungoogled-style) — see BRANDING_PRIVACY_PLAN.md ===
+# Compile out Google data channels. Net-new args (none previously set here).
+use_official_google_api_keys = false
+google_api_key = ""
+google_default_client_id = ""
+google_default_client_secret = ""
+enable_reporting = false            # drops UMA/UKM + crash-upload code paths
+safe_browsing_mode = 0              # compiles out Safe Browsing /v4 lookups + pings
+enable_hangout_services_extension = false
+enable_mdns = false                 # disables Cast/mDNS device discovery
+enable_rlz = false                  # no RLZ ping (also the unbranded default)

--- a/build/args.gn.win
+++ b/build/args.gn.win
@@ -28,3 +28,15 @@ target_os = "win"
 #   * is_official_build is deliberately NOT set, to mirror the lighter mac
 #     release config (is_debug=false). Add it only for a fully PGO-optimized
 #     shippable build.
+
+# === Xplorer privacy hardening (Brave/ungoogled-style) — see BRANDING_PRIVACY_PLAN.md ===
+# Compile out Google data channels. Net-new args (none previously set here).
+use_official_google_api_keys = false
+google_api_key = ""
+google_default_client_id = ""
+google_default_client_secret = ""
+enable_reporting = false            # drops UMA/UKM + crash-upload code paths
+safe_browsing_mode = 0              # compiles out Safe Browsing /v4 lookups + pings
+enable_hangout_services_extension = false
+enable_mdns = false                 # disables Cast/mDNS device discovery
+enable_rlz = false                  # no RLZ ping (also the unbranded default)

--- a/build/args.gn.x64
+++ b/build/args.gn.x64
@@ -20,3 +20,15 @@ target_cpu = "x64"
 target_os = "mac"
 
 use_lld = true
+
+# === Xplorer privacy hardening (Brave/ungoogled-style) — see BRANDING_PRIVACY_PLAN.md ===
+# Compile out Google data channels. Net-new args (none previously set here).
+use_official_google_api_keys = false
+google_api_key = ""
+google_default_client_id = ""
+google_default_client_secret = ""
+enable_reporting = false            # drops UMA/UKM + crash-upload code paths
+safe_browsing_mode = 0              # compiles out Safe Browsing /v4 lookups + pings
+enable_hangout_services_extension = false
+enable_mdns = false                 # disables Cast/mDNS device discovery
+enable_rlz = false                  # no RLZ ping (also the unbranded default)

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -619,16 +619,34 @@ def main(src: Path):
                     "prepopulated_engines.json")
     pp = prepop.read_text()
     if "127.0.0.1:9334/omnibox" not in pp:
-        pp = pp.replace(
-            '"name": "Google",\n      "keyword": "google.com",',
-            '"name": "Grok",\n      "keyword": "grok.com",')
+        # name + keyword: whitespace-tolerant regex with a hard assert. The old
+        # literal .replace() silently no-ops on any format drift (unlike edit()),
+        # which would ship Google as the default search engine. Fail LOUD here so
+        # an upstream format change is caught at patch time, not in the binary.
+        pp, n = re.subn(
+            r'"name":\s*"Google",\s*"keyword":\s*"google\.com",',
+            '"name": "Grok",\n      "keyword": "grok.com",', pp)
+        if n != 1:
+            sys.exit("prepopulated_engines.json: Google name/keyword anchor "
+                     f"matched {n}x (expected 1) — upstream format moved")
         pp = re.sub(
             r'"search_url": "\{google:baseURL\}search\?q=\{searchTerms\}[^"]*"',
             '"search_url": "http://127.0.0.1:9334/omnibox?q={searchTerms}"', pp)
         pp = re.sub(r'"suggest_url": "\{google:baseSuggestURL\}[^"]*"',
                     '"suggest_url": ""', pp)
-        pp = pp.replace('"kCurrentDataVersion": 206',
-                        '"kCurrentDataVersion": 207')
+        # The engine favicon was left pointing at Google; repoint it at Grok,
+        # scoped to the now-"Grok" block (count=1) so no other engine is touched.
+        pp = re.sub(
+            r'("name": "Grok",[\s\S]{0,400}?"favicon_url": )"[^"]*"',
+            r'\1"https://grok.com/favicon.ico"', pp, count=1)
+        # Bump kCurrentDataVersion to current+1 so existing profiles re-merge.
+        # (The old hardcoded "206"->"207" was a silent no-op on M151, which
+        # already ships 207 — read the live value and increment it instead.)
+        m = re.search(r'"kCurrentDataVersion":\s*(\d+)', pp)
+        if not m:
+            sys.exit("prepopulated_engines.json: kCurrentDataVersion not found")
+        pp = re.sub(r'"kCurrentDataVersion":\s*\d+',
+                    f'"kCurrentDataVersion": {int(m.group(1)) + 1}', pp, count=1)
         prepop.write_text(pp)
         print(f"  edited: {prepop}")
 


### PR DESCRIPTION
Ongoing effort (driven by an hourly self-improvement loop) to:

1. **Branding** — replace all residual Chromium / Google Chrome branding with Xplorer.
2. **Search** — make Grok the default search engine instead of Google.
3. **Privacy** — Brave / ungoogled-style hardening so no data is sent to Google.

All changes live in the overlay (`patches/apply_integration.py`, `src/chrome/**`, `build/args.gn*`).
The roadmap + per-iteration progress is tracked in **`BRANDING_PRIVACY_PLAN.md`**.

### Landed so far
- **Privacy GN args** in all four `build/args.gn*`: `use_official_google_api_keys=false`, empty
  `google_api_key`/`client_id`/`client_secret`, `enable_reporting=false`, `safe_browsing_mode=0`,
  `enable_hangout_services_extension=false`, `enable_mdns=false`, `enable_rlz=false`
  (kept `enable_widevine` for DRM; no `is_official_build`).
- **`build.sh`** blanks `GOOGLE_API_KEY`/`CLIENT_ID`/`SECRET` before `gn gen` (no dev key compiled in).

### Next (see plan)
- Harden the `prepopulated_engines.json` Grok-default hijack (fix a real silent-failure path).
- Disable Variations/Finch + component updater + What's New.
- Fix the "… - Chromium" window title; UA / UA-CH brand token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)