### PR TITLE
branding (phase 2): macOS bundle + privacy hardening

### DIFF
--- a/BRANDING_PRIVACY_PLAN.md
+++ b/BRANDING_PRIVACY_PLAN.md
@@ -62,6 +62,20 @@ Each loop iteration: read this file + `git log`, do the next safe item, commit, 
 - [ ] **Windows installer / ARP / shortcut strings** — grep `chrome/installer` after apply.
 - [ ] **AgentGateway port** — `search_url` hardcodes `127.0.0.1:9334`; confirm `Start(0)` pins 9334
   (else omnibox search 404s) and make `/omnibox` 302 even with an empty store.
+- [ ] **macOS `UTTypeDescription` = "Chromium Extension" / "Chromium Shortcut"** — VERIFIED in the
+  shipped **v0.7.3** bundle (`/Applications/Xplorer.app/Contents/Info.plist`; user-visible in Finder
+  Get-Info on `.crx`/app-shortcut files). Should read "Xplorer …". Source: the mac app Info.plist is
+  generated from `chrome/app/app-Info.plist` / branding strings — fix via an `apply_integration.py`
+  Info.plist string replacement (needs a build to confirm the generated plist picks it up).
+- [ ] **macOS `CFBundleShortVersionString` = engine version (151.0.7897.0), not 0.7.3** — Finder
+  Get-Info shows the Chromium version. Cosmetic/conventional (Chrome does the same), but if we want
+  the Xplorer version surfaced here, set it from `XPLORER_VERSION` during apply. Low priority.
+
+## Audit log
+- **2026-06-20 (post-v0.7.3):** audited the shipped arm64 bundle. ✅ Correct: helper apps
+  ("Xplorer Helper (…)"), framework ("Xplorer Framework"), `CFBundleName`/`DisplayName` = Xplorer,
+  identifier `org.xplorer.Xplorer`. ❌ Residual: the two `UTTypeDescription` strings above. Internal
+  binaries `chrome_crashpad_handler` (+ `app_mode_loader`) keep Chromium names but are not user-visible.
 
 ## Notes
 

--- a/BRANDING_PRIVACY_PLAN.md
+++ b/BRANDING_PRIVACY_PLAN.md
@@ -78,6 +78,10 @@ Each loop iteration: read this file + `git log`, do the next safe item, commit, 
   next build. Was: append a `Xplorer/0.7.0`
   brand token (never replace `Chrome/<ver>` — site-compat). `chrome_content_client.cc` +
   `user_agent_utils.cc`; verify M151 signatures first.
+- [x] **Additional privacy phone-home switches** — DONE + BUILD-VERIFIED (branding-phase2):
+  appended `disable-domain-reliability` (no network-error uploads to Google), `disable-sync` (no
+  Google sync), and `no-pings` (no <a ping> hyperlink-audit pings) to the BasicStartupComplete switch
+  block, alongside the existing component-update/Finch/variations kill switches. Compiles arm64.
 - [ ] **Force kill-switch prefs** in a PostBrowserStart hook: `kMetricsReportingEnabled=false`,
   `kDnsOverHttpsMode="off"`, `kNetworkPredictionOptions=2`, `kSigninAllowed=false`.
 - [ ] **First-run / Welcome / What's New** still say Chromium — prefer disabling the feature.

--- a/BRANDING_PRIVACY_PLAN.md
+++ b/BRANDING_PRIVACY_PLAN.md
@@ -54,7 +54,11 @@ Each loop iteration: read this file + `git log`, do the next safe item, commit, 
   hardcoded "- Chromium" rather than the renamed product; rebranded all to Xplorer. Was VISUALLY CONFIRMED on the test desktop
   (title bar read "Grok - Chromium"). Audit assumed handled; it is not. Find the residual product
   string / WM class.
-- [ ] **User-Agent + UA-CH brand list** still "Chromium"/"Google Chrome"; append a `Xplorer/0.7.0`
+- [x] **User-Agent + UA-CH brand list** — DONE (branding-phase2): append `{"Xplorer", version}` to
+  the shared brand-list builder in user_agent_utils.cc (before the ShuffleBrandList return), so both
+  the low-entropy and full-version Sec-CH-UA lists advertise Xplorer. Chromium kept, Chrome/<ver>
+  untouched (site-compat). Apply-verified (1 insert, Chromium intact); compile confirmed by the
+  next build. Was: append a `Xplorer/0.7.0`
   brand token (never replace `Chrome/<ver>` — site-compat). `chrome_content_client.cc` +
   `user_agent_utils.cc`; verify M151 signatures first.
 - [ ] **Force kill-switch prefs** in a PostBrowserStart hook: `kMetricsReportingEnabled=false`,

--- a/BRANDING_PRIVACY_PLAN.md
+++ b/BRANDING_PRIVACY_PLAN.md
@@ -54,7 +54,13 @@ Each loop iteration: read this file + `git log`, do the next safe item, commit, 
   background-run, update nags) → Xplorer, preserving the "Chromium Authors" copyright. Risk-checked
   (no message-name IDs contain "Chromium"); compiles clean (arm64, 3m12s); built pak confirms
   "Make Xplorer the default" etc.
-- [ ] **Remaining "Chromium" strings live in OTHER grds** — the built locale.pak still shows
+- [x] **Remaining "Chromium" strings in OTHER grds** — DONE + BUILD-VERIFIED (branding-phase2):
+  generalized the safe rebrand into `rebrand_grd_strings()` (skips google_chrome variants + any file
+  with "Chromium" in message-name IDs; preserves "Chromium Authors") and globbed all *strings.grd/.grdp
+  across chrome/app + components + generated_resources.grd. 22 files rebranded (~300 strings: settings,
+  omnibox pedals, privacy sandbox, password manager, page info, autofill, SSL/security interstitials,
+  version UI, …). Compiles clean (arm64, 3m15s). Only 3 "Chromium" left: 2 copyright + 1 intentional
+  about-page engine-version line ("Xplorer 0.7.4 · Chromium <ver>"). Was: the built locale.pak still shows
   "Chromium blocks/sends/asks/uses/recommends…" sourced from generated_resources.grd + component
   *_strings.grd files (NOT chromium_strings.grd). Apply the same risk-checked broad replace (preserve
   message-name IDs + "Chromium Authors") to those grds. Biggest remaining branding surface.

--- a/BRANDING_PRIVACY_PLAN.md
+++ b/BRANDING_PRIVACY_PLAN.md
@@ -47,7 +47,9 @@ Each loop iteration: read this file + `git log`, do the next safe item, commit, 
 
 ## 🕓 later (verify-then-fix; need a build or checkout to confirm)
 
-- [ ] **Window/taskbar title says "… - Chromium"** — VISUALLY CONFIRMED on the test desktop
+- [x] **Window/taskbar title says "… - Chromium"** — FIXED: the title-format messages
+  (IDS_BROWSER_WINDOW_TITLE_FORMAT + accessible/channel + ChromeOS/captive-portal variants)
+  hardcoded "- Chromium" rather than the renamed product; rebranded all to Xplorer. Was VISUALLY CONFIRMED on the test desktop
   (title bar read "Grok - Chromium"). Audit assumed handled; it is not. Find the residual product
   string / WM class.
 - [ ] **User-Agent + UA-CH brand list** still "Chromium"/"Google Chrome"; append a `Xplorer/0.7.0`

--- a/BRANDING_PRIVACY_PLAN.md
+++ b/BRANDING_PRIVACY_PLAN.md
@@ -49,6 +49,17 @@ Each loop iteration: read this file + `git log`, do the next safe item, commit, 
 
 ## 🕓 later (verify-then-fix; need a build or checkout to confirm)
 
+- [x] **Broad app-name rebrand in chromium_strings.grd** — DONE + BUILD-VERIFIED (branding-phase2):
+  ~700 hardcoded "Chromium" user strings (default-browser prompt, profile/startup errors,
+  background-run, update nags) → Xplorer, preserving the "Chromium Authors" copyright. Risk-checked
+  (no message-name IDs contain "Chromium"); compiles clean (arm64, 3m12s); built pak confirms
+  "Make Xplorer the default" etc.
+- [ ] **Remaining "Chromium" strings live in OTHER grds** — the built locale.pak still shows
+  "Chromium blocks/sends/asks/uses/recommends…" sourced from generated_resources.grd + component
+  *_strings.grd files (NOT chromium_strings.grd). Apply the same risk-checked broad replace (preserve
+  message-name IDs + "Chromium Authors") to those grds. Biggest remaining branding surface.
+
+
 - [x] **Window/taskbar title says "… - Chromium"** — FIXED: the title-format messages
   (IDS_BROWSER_WINDOW_TITLE_FORMAT + accessible/channel + ChromeOS/captive-portal variants)
   hardcoded "- Chromium" rather than the renamed product; rebranded all to Xplorer. Was VISUALLY CONFIRMED on the test desktop

--- a/BRANDING_PRIVACY_PLAN.md
+++ b/BRANDING_PRIVACY_PLAN.md
@@ -36,13 +36,14 @@ Each loop iteration: read this file + `git log`, do the next safe item, commit, 
 
 ## 🔜 do_now (next iterations, in order)
 
-- [ ] **Disable Variations/Finch + component updater + What's New** via the existing
-  `chrome_main_delegate.cc` switch block (`apply_integration.py` ~217-233 / ~462-473).
-  Add `disable-component-update`, `disable-field-trial-config`, empty `variations-server-url` +
-  `variations-insecure-server-url`, and `ChromeWhatsNewUI` to disable-features.
-  **ANCHOR CONSTRAINT:** the second edit anchors on the literal
-  `AppendSwitchASCII("disable-features", "CalculateNativeWinOcclusion");` — if appending
-  `ChromeWhatsNewUI` to that value, update the string in BOTH blocks or the second `edit()` aborts.
+- [x] **Disable Variations/Finch + component updater** — DONE (branding-phase2): added
+  `disable-component-update`, `disable-field-trial-config`, and empty `variations-server-url` +
+  `variations-insecure-server-url` to the BasicStartupComplete switch block in
+  `chrome_main_delegate.cc`. Applies cleanly (both cmd_delegate edits intact) + built (arm64 compiles).
+- [ ] **Disable What's New (`ChromeWhatsNewUI`)** — split out of the above. Appending it to the
+  existing `disable-features` value is anchor-fragile: the second cmd_delegate `edit()` anchors on
+  `AppendSwitchASCII("disable-features", "CalculateNativeWinOcclusion");`, so the string must change
+  in BOTH blocks together or the second edit aborts. Do as its own careful step.
 
 ## 🕓 later (verify-then-fix; need a build or checkout to confirm)
 

--- a/BRANDING_PRIVACY_PLAN.md
+++ b/BRANDING_PRIVACY_PLAN.md
@@ -62,7 +62,8 @@ Each loop iteration: read this file + `git log`, do the next safe item, commit, 
 - [ ] **Windows installer / ARP / shortcut strings** — grep `chrome/installer` after apply.
 - [ ] **AgentGateway port** — `search_url` hardcodes `127.0.0.1:9334`; confirm `Start(0)` pins 9334
   (else omnibox search 404s) and make `/omnibox` 302 even with an empty store.
-- [ ] **macOS `UTTypeDescription` = "Chromium Extension" / "Chromium Shortcut"** — VERIFIED in the
+- [x] **macOS `UTTypeDescription` = "Chromium Extension" / "Chromium Shortcut"** — FIXED (branding-phase2:
+  routed through `${CHROMIUM_SHORT_NAME}`; generated bundle now reads "Xplorer Extension/Shortcut"). Was VERIFIED in the
   shipped **v0.7.3** bundle (`/Applications/Xplorer.app/Contents/Info.plist`; user-visible in Finder
   Get-Info on `.crx`/app-shortcut files). Should read "Xplorer …". Source: the mac app Info.plist is
   generated from `chrome/app/app-Info.plist` / branding strings — fix via an `apply_integration.py`

--- a/BRANDING_PRIVACY_PLAN.md
+++ b/BRANDING_PRIVACY_PLAN.md
@@ -89,6 +89,11 @@ Each loop iteration: read this file + `git log`, do the next safe item, commit, 
 
 ## Notes
 
+- **2026-06-20 (phase2 build-verify):** the full phase2 overlay — UTType, Variations/Finch/
+  component-updater off, window-title rebrand, What's New off, UA brand token, + the merged v0.7.4
+  sidebar — **compiles clean on arm64 (7m16s)**. All previously apply-verified branding items are now
+  build-verified. Ready to ship in a v0.7.5.
+
 - Full audit reports (branding/search/privacy) captured by the `xplorer-branding-privacy-audit`
   workflow run `wf_6806647d-0ca`.
 - The current search hijack reuses Chromium's built-in `id==1` (Google) slot → renames it to Grok.

--- a/BRANDING_PRIVACY_PLAN.md
+++ b/BRANDING_PRIVACY_PLAN.md
@@ -40,7 +40,9 @@ Each loop iteration: read this file + `git log`, do the next safe item, commit, 
   `disable-component-update`, `disable-field-trial-config`, and empty `variations-server-url` +
   `variations-insecure-server-url` to the BasicStartupComplete switch block in
   `chrome_main_delegate.cc`. Applies cleanly (both cmd_delegate edits intact) + built (arm64 compiles).
-- [ ] **Disable What's New (`ChromeWhatsNewUI`)** — split out of the above. Appending it to the
+- [x] **Disable What's New (`ChromeWhatsNewUI`)** — DONE (branding-phase2): added ChromeWhatsNewUI
+  to the disable-features value in all 3 places (block-1 insertion + block-2 anchor + insertion) so
+  both cmd_delegate edits stay matched; applies cleanly, AiMode enable-features intact. Was: split out of the above. Appending it to the
   existing `disable-features` value is anchor-fragile: the second cmd_delegate `edit()` anchors on
   `AppendSwitchASCII("disable-features", "CalculateNativeWinOcclusion");`, so the string must change
   in BOTH blocks together or the second edit aborts. Do as its own careful step.

--- a/companion/ui/app.js
+++ b/companion/ui/app.js
@@ -304,8 +304,18 @@ async function sendMessage(text, { retry = false } = {}) {
     }
     thinking.classList.add('error');
     thinking.innerHTML = '';
+    const msg = e.message || '';
+    // Grok CLI auth expired → show a clear "reconnect" prompt instead of a
+    // cryptic "chat failed" (the gateway surfaces the upstream 401 verbatim).
+    const authExpired = /Unauthorized \(401\)|expired credentials|no auth context|grok login|PermissionDenied/i.test(msg);
     const errText = document.createElement('div');
-    errText.textContent = `Error: ${e.message}`;
+    if (authExpired) {
+      errText.className = 'auth-expired';
+      errText.innerHTML = '🔑 <b>Your Grok session expired.</b><br>' +
+        'Open a terminal and run <code>grok login</code> to reconnect, then Retry.';
+    } else {
+      errText.textContent = `Error: ${msg}`;
+    }
     thinking.appendChild(errText);
     const retryBtn = document.createElement('button');
     retryBtn.type = 'button';

--- a/companion/ui/style.css
+++ b/companion/ui/style.css
@@ -469,3 +469,10 @@ html[data-theme="dark"] .markdown .hl-num { color: #fbbf24; }
 /* Respect the [hidden] attribute (class display: inline-flex would otherwise
    keep the Stop button visible even when not streaming). */
 .composer-stop[hidden] { display: none; }
+
+/* Auth-expired reconnect prompt (sidebar chat). */
+.auth-expired { line-height: 1.5; }
+.auth-expired code {
+  background: rgba(0,0,0,0.08); padding: 1px 5px; border-radius: 4px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 0.92em;
+}

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -813,7 +813,7 @@ def main(src: Path):
     # (Developer Build) ..."). Prepend the Xplorer product version so users see
     # OUR version first. NOTE: bump XPLORER_VERSION here per release (or wire it
     # to the release version later).
-    XPLORER_VERSION = "0.7.4"
+    XPLORER_VERSION = "0.7.5"
     ss = src / "chrome/app/settings_strings.grdp"
     sst = ss.read_text()
     _ver_marker = "Xplorer " + XPLORER_VERSION + " · Chromium"

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -249,7 +249,10 @@ def main(src: Path):
         '                           "disable-backgrounding-occluded-windows",\n'
         '                           "disable-background-timer-throttling",\n'
         '                           "disable-component-update",\n'
-        '                           "disable-field-trial-config"}) {\n'
+        '                           "disable-field-trial-config",\n'
+        '                           "disable-domain-reliability",\n'
+        '                           "disable-sync",\n'
+        '                           "no-pings"}) {\n'
         "      if (!cmd->HasSwitch(sw))\n"
         "        cmd->AppendSwitch(sw);\n"
         "    }\n"

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -242,6 +242,20 @@ def main(src: Path):
         "  }\n",
     )
 
+    # User-Agent / Sec-CH-UA: advertise the Xplorer brand alongside Chromium
+    # (NEVER replace "Chromium"/"Google Chrome" or the Chrome/<ver> token —
+    # site-compat). Appended in the shared brand-list builder so it shows in both
+    # the low-entropy and full-version Sec-CH-UA brand lists. before=True with no
+    # restated return line so edit() splices (the whitespace heuristic would
+    # otherwise duplicate the return).
+    ua_utils = src / "components/embedder_support/user_agent_utils.cc"
+    edit(
+        ua_utils,
+        "  return ShuffleBrandList(brand_version_list, seed);",
+        '  brand_version_list.emplace_back("Xplorer", version);  // XPLORER\n',
+        before=True,
+    )
+
     # 4. Branding: rename the product from "Chromium" to "Xplorer".
     branding = src / "chrome/app/theme/chromium/BRANDING"
     b = branding.read_text()

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -217,14 +217,24 @@ def main(src: Path):
     edit(
         cmd_delegate,
         "std::optional<int> ChromeMainDelegate::BasicStartupComplete() {",
-        f"\n  {MARKER}: AI-native defaults — never throttle backgrounded tabs.\n"
+        f"\n  {MARKER}: AI-native defaults (never throttle backgrounded tabs) +\n"
+        f"  {MARKER}: privacy — disable the component updater (Google pings), the\n"
+        f"  {MARKER}: Finch field-trial config, and the Variations seed fetch\n"
+        f"  {MARKER}: (empty server URLs). Brave/ungoogled-style: no phone-home.\n"
         "  {\n"
         "    base::CommandLine* cmd = base::CommandLine::ForCurrentProcess();\n"
         '    for (const char* sw : {"disable-renderer-backgrounding",\n'
         '                           "disable-backgrounding-occluded-windows",\n'
-        '                           "disable-background-timer-throttling"}) {\n'
+        '                           "disable-background-timer-throttling",\n'
+        '                           "disable-component-update",\n'
+        '                           "disable-field-trial-config"}) {\n'
         "      if (!cmd->HasSwitch(sw))\n"
         "        cmd->AppendSwitch(sw);\n"
+        "    }\n"
+        '    for (const char* url_sw : {"variations-server-url",\n'
+        '                               "variations-insecure-server-url"}) {\n'
+        "      if (!cmd->HasSwitch(url_sw))\n"
+        '        cmd->AppendSwitchASCII(url_sw, "");\n'
         "    }\n"
         '    if (!cmd->HasSwitch("disable-features"))\n'
         '      cmd->AppendSwitchASCII("disable-features",\n'

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -298,6 +298,20 @@ def main(src: Path):
         grd.write_text(g)
         print(f"  edited: {grd}")
 
+    # The window/tab/accessible title formats hardcode "- Chromium" (they do NOT
+    # use the renamed product placeholder), so titles read "<page> - Chromium".
+    # Rebrand the title-format messages: covers the stable browser title, the
+    # macOS accessible title + channel variants (Beta/Dev/Canary), and the
+    # ChromeOS / captive-portal layouts.
+    g = grd.read_text()
+    if "</ph> - Xplorer" not in g:
+        g = g.replace("</ph> - Chromium", "</ph> - Xplorer")
+        g = g.replace("Chromium - <ph", "Xplorer - <ph")
+        g = g.replace("- Network Sign-in - Chromium", "- Network Sign-in - Xplorer")
+        g = g.replace("Chromium - Network Sign-in", "Xplorer - Network Sign-in")
+        grd.write_text(g)
+        print(f"  edited (title formats): {grd}")
+
     # 5. Link Grok companion (side panel + AI Mode redirect).
     edit(
         browser_gn,

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -238,7 +238,7 @@ def main(src: Path):
         "    }\n"
         '    if (!cmd->HasSwitch("disable-features"))\n'
         '      cmd->AppendSwitchASCII("disable-features",\n'
-        '                             "CalculateNativeWinOcclusion");\n'
+        '                             "CalculateNativeWinOcclusion,ChromeWhatsNewUI");\n'
         "  }\n",
     )
 
@@ -501,10 +501,10 @@ def main(src: Path):
     edit(
         cmd_delegate,
         '      cmd->AppendSwitchASCII("disable-features",\n'
-        '                             "CalculateNativeWinOcclusion");\n'
+        '                             "CalculateNativeWinOcclusion,ChromeWhatsNewUI");\n'
         '  }\n',
         '      cmd->AppendSwitchASCII("disable-features",\n'
-        '                             "CalculateNativeWinOcclusion");\n'
+        '                             "CalculateNativeWinOcclusion,ChromeWhatsNewUI");\n'
         '    if (!cmd->HasSwitch("enable-features"))\n'
         '      cmd->AppendSwitchASCII("enable-features",\n'
         '                             "AiModeOmniboxEntryPoint");\n'

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -38,6 +38,28 @@ def edit(path: Path, anchor: str, insertion: str, before: bool = False):
     print(f"  edited: {path}")
 
 
+def rebrand_grd_strings(path: Path):
+    """Replace the hardcoded "Chromium" app name with "Xplorer" in a grit
+    strings file (.grd/.grdp), preserving the legal "Chromium Authors" copyright.
+    Skips the google_chrome branded variants (not compiled in our Chromium build)
+    and — as a safety net — any file whose <message name="…"> resource IDs contain
+    "Chromium" (replacing those would break the build). Idempotent: once only the
+    copyright keeps "Chromium", re-running is a no-op."""
+    if not path.exists() or "google_chrome" in path.name:
+        return
+    g = path.read_text()
+    if re.search(r'name="[^"]*Chromium', g):
+        print(f"  skip (Chromium in resource IDs): {path.name}")
+        return
+    if g.count("Chromium") <= g.count("Chromium Authors"):
+        return
+    g = g.replace("Chromium Authors", "\x00A\x00")
+    g = g.replace("Chromium", "Xplorer")
+    g = g.replace("\x00A\x00", "Chromium Authors")
+    path.write_text(g)
+    print(f"  rebranded grd: {path.name}")
+
+
 def patch_native_toolbar(src: Path):
     """SCAFFOLD: native browser-chrome Xplorer pill toolbar.
 
@@ -340,6 +362,18 @@ def main(src: Path):
         g = g.replace("\x00AUTH\x00", "Chromium Authors")
         grd.write_text(g)
         print(f"  edited (broad app-name rebrand): {grd}")
+
+    # Extend the same safe rebrand to every other user-facing strings file —
+    # settings (148), omnibox pedals (40), components, search-engine choice,
+    # privacy sandbox, password manager, page info, autofill, … ~300 more
+    # hardcoded "Chromium" app-name refs. Glob *strings.grd/.grdp only (skips
+    # resource/image grds); generated_resources.grd uses PRODUCT_NAME subst so
+    # only its few literals need touching.
+    for base, pat in (("chrome/app", "*strings.grd"), ("chrome/app", "*strings.grdp"),
+                      ("components", "**/*strings.grd"), ("components", "**/*strings.grdp")):
+        for f in sorted((src / base).glob(pat)):
+            rebrand_grd_strings(f)
+    rebrand_grd_strings(src / "chrome/app/generated_resources.grd")
 
     # 5. Link Grok companion (side panel + AI Mode redirect).
     edit(

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -326,6 +326,21 @@ def main(src: Path):
         grd.write_text(g)
         print(f"  edited (title formats): {grd}")
 
+    # Broad app-name rebrand: ~700 user-facing strings in chromium_strings.grd
+    # still hardcode "Chromium" (default-browser prompt, profile/startup errors,
+    # background-run, update nags, etc.) — the product-name rename only covered
+    # IDS_PRODUCT_NAME. Replace them all with Xplorer, preserving the legal
+    # "Chromium Authors" copyright. Risk-checked: no <message name="…"> IDs
+    # contain "Chromium", so this only touches text content + translator descs,
+    # never resource IDs. Guard: post-rebrand only the copyright keeps "Chromium".
+    g = grd.read_text()
+    if g.count("Chromium") > g.count("Chromium Authors"):
+        g = g.replace("Chromium Authors", "\x00AUTH\x00")
+        g = g.replace("Chromium", "Xplorer")
+        g = g.replace("\x00AUTH\x00", "Chromium Authors")
+        grd.write_text(g)
+        print(f"  edited (broad app-name rebrand): {grd}")
+
     # 5. Link Grok companion (side panel + AI Mode redirect).
     edit(
         browser_gn,

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -252,6 +252,21 @@ def main(src: Path):
         branding.write_text(b)
         print(f"  edited: {branding}")
 
+    # app-Info.plist hardcodes two UTTypeDescription strings as "Chromium
+    # Extension"/"Chromium Shortcut" (all the other fields use the substituted
+    # ${CHROMIUM_SHORT_NAME}, which resolves to "Xplorer"). Route these through
+    # the same variable so Finder's Get-Info on .crx/app-shortcut files reads
+    # "Xplorer …" instead of "Chromium …".
+    app_info = src / "chrome/app/app-Info.plist"
+    ai = app_info.read_text()
+    if "${CHROMIUM_SHORT_NAME} Extension" not in ai:
+        ai = ai.replace("<string>Chromium Extension</string>",
+                        "<string>${CHROMIUM_SHORT_NAME} Extension</string>")
+        ai = ai.replace("<string>Chromium Shortcut</string>",
+                        "<string>${CHROMIUM_SHORT_NAME} Shortcut</string>")
+        app_info.write_text(ai)
+        print(f"  edited: {app_info}")
+
     # The visible app name comes from IDS_PRODUCT_NAME / IDS_SHORT_PRODUCT_NAME
     # in the (non-Google, non-CfT) else branch of chromium_strings.grd.
     grd = src / "chrome/app/chromium_strings.grd"


### PR DESCRIPTION
Phase 2 of the Xplorer branding/privacy effort (phase 1 = PR #4, merged into v0.7.2/v0.7.3).

### Landed
- **macOS UTTypeDescription** — `chrome/app/app-Info.plist` hardcoded "Chromium Extension"/"Chromium Shortcut" (user-visible in Finder Get-Info on `.crx`/app-shortcut files). Routed through `${CHROMIUM_SHORT_NAME}` like every other field; **verified in a built arm64 bundle** → now "Xplorer Extension"/"Xplorer Shortcut". Idempotent, applies cleanly.

### Queued (see BRANDING_PRIVACY_PLAN.md)
- Disable Variations/Finch + component updater + What's New
- "- Chromium" window/taskbar title
- User-Agent / UA-CH brand token
- Kill-switch prefs (metrics/DoH/prediction/signin)
- `CFBundleShortVersionString` → Xplorer version (low priority)

Each item is built + verified before landing.