### PR TITLE
feat(privacy): borrow ungoogled-chromium degoogling patches (no domain-sub/pruning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ launch flags, no setup dance.
 - [Project layout](#project-layout)
 - [Contributing](#contributing)
 - [Star history](#star-history)
+- [Acknowledgements](#acknowledgements)
 - [License](#license)
 
 ---
@@ -371,6 +372,17 @@ If Xplorer is useful to you, please **[give it a ⭐ on GitHub](https://github.c
     </picture>
   </a>
 </p>
+
+---
+
+## Acknowledgements
+
+Xplorer's privacy hardening borrows degoogling patches from the
+[ungoogled-chromium](https://github.com/ungoogled-software/ungoogled-chromium) project (and
+the upstream patch sets it builds on) to strip Google phone‑home and telemetry from the
+Chromium base. Those patches are BSD‑3‑Clause licensed; see
+[`docs/UNGOOGLED.md`](docs/UNGOOGLED.md) for what we use and what we intentionally leave out.
+With thanks to the maintainers.
 
 ---
 

--- a/VERSIONS
+++ b/VERSIONS
@@ -1,0 +1,10 @@
+# Upstream version pins for the Xplorer overlay. Keep this in sync when bumping Chromium
+# or refreshing the vendored ungoogled patches. Grep-friendly; not parsed by the build.
+
+chromium  = 151.0.7897.0       # git cd1d42cba19c64f3386d5dfa1475d620b6efb6a4
+ungoogled = 149.0.7827.155-1   # git 2a53b77d33b055a4a41139007fb60b6ec1960a48 — source of patches/ungoogled/
+
+# NOTE: ungoogled-chromium has NO 150 or 151 release yet (it trails Chromium stable), so our
+# Chromium pin is ~2 milestones AHEAD of ungoogled. The vendored degoogling patches were
+# selected/validated against 151 by hand. When ungoogled ships a >=150 tag, refresh from it.
+# See docs/UNGOOGLED.md ("Keeping it updated").

--- a/apply.ps1
+++ b/apply.ps1
@@ -69,4 +69,9 @@ $env:PYTHONUTF8 = "1"
 & $python (Join-Path $Xplorer "patches\apply_integration.py") $Src
 if ($LASTEXITCODE -ne 0) { throw "apply_integration.py failed (exit $LASTEXITCODE)" }
 
+# Degoogling pass: vendored ungoogled-chromium series, applied LAST so Grok + branding
+# edits stay authoritative. Best-effort/idempotent — drifted patches are logged, not fatal.
+Write-Host "Applying ungoogled degoogling patches..."
+& powershell -ExecutionPolicy Bypass -File (Join-Path $Xplorer "scripts\apply_ungoogled.ps1") -Src $Src
+
 Write-Host "Done. Next: .\build.ps1"

--- a/apply.sh
+++ b/apply.sh
@@ -88,4 +88,11 @@ fi  # end macOS-only product-logo block
 echo "Applying integration edits..."
 python3 "$XPLORER/patches/apply_integration.py" "$SRC"
 
+# Degoogling pass: apply the vendored ungoogled-chromium series LAST, so the Grok +
+# branding edits above stay authoritative. Best-effort and idempotent — a patch that has
+# drifted against the current Chromium pin is logged and skipped, never fatal.
+# See patches/ungoogled/series and docs/UNGOOGLED.md.
+echo "Applying ungoogled degoogling patches..."
+sh "$XPLORER/scripts/apply_ungoogled.sh" "$SRC"
+
 echo "Done. Next: ./build.sh"

--- a/build/args.gn
+++ b/build/args.gn
@@ -34,3 +34,16 @@ google_api_key = ""
 google_default_client_id = ""
 google_default_client_secret = ""
 enable_rlz = false                  # no RLZ ping (also the unbranded default)
+
+# === ungoogled-chromium degoogling flags (vendored 149.0.7827.155-1) — see docs/UNGOOGLED.md ===
+# Build-safe subset of ungoogled's flags.gn: removes Google-connected services / phone-home
+# without requiring source patches. NOTE: safe_browsing_mode=0 is intentionally NOT set — it
+# needs the safe-browsing stub patches (patches/ungoogled/quarantine.series), which do not yet
+# apply to this Chromium pin; setting it alone would break the link.
+enable_reporting = false                  # no NEL / Reporting-API upload pipeline
+enable_remoting = false                   # no Chrome Remote Desktop (Google-account-tied)
+enable_mdns = false                       # no multicast-DNS local discovery
+enable_service_discovery = false          # no privet/Cast local service discovery (pairs with enable_mdns)
+enable_hangout_services_extension = false # no built-in Google Meet/Hangouts helper extension
+disable_fieldtrial_testing_config = true  # behave like stable: no baked-in Google experiment config
+exclude_unwind_tables = true              # smaller binary, less stack metadata (symbol_level=0 already)

--- a/build/args.gn.linux
+++ b/build/args.gn.linux
@@ -32,3 +32,16 @@ google_api_key = ""
 google_default_client_id = ""
 google_default_client_secret = ""
 enable_rlz = false                  # no RLZ ping (also the unbranded default)
+
+# === ungoogled-chromium degoogling flags (vendored 149.0.7827.155-1) — see docs/UNGOOGLED.md ===
+# Build-safe subset of ungoogled's flags.gn: removes Google-connected services / phone-home
+# without requiring source patches. NOTE: safe_browsing_mode=0 is intentionally NOT set — it
+# needs the safe-browsing stub patches (patches/ungoogled/quarantine.series), which do not yet
+# apply to this Chromium pin; setting it alone would break the link.
+enable_reporting = false                  # no NEL / Reporting-API upload pipeline
+enable_remoting = false                   # no Chrome Remote Desktop (Google-account-tied)
+enable_mdns = false                       # no multicast-DNS local discovery
+enable_service_discovery = false          # no privet/Cast local service discovery (pairs with enable_mdns)
+enable_hangout_services_extension = false # no built-in Google Meet/Hangouts helper extension
+disable_fieldtrial_testing_config = true  # behave like stable: no baked-in Google experiment config
+exclude_unwind_tables = true              # smaller binary, less stack metadata (symbol_level=0 already)

--- a/build/args.gn.win
+++ b/build/args.gn.win
@@ -39,3 +39,16 @@ google_api_key = ""
 google_default_client_id = ""
 google_default_client_secret = ""
 enable_rlz = false                  # no RLZ ping (also the unbranded default)
+
+# === ungoogled-chromium degoogling flags (vendored 149.0.7827.155-1) — see docs/UNGOOGLED.md ===
+# Build-safe subset of ungoogled's flags.gn: removes Google-connected services / phone-home
+# without requiring source patches. NOTE: safe_browsing_mode=0 is intentionally NOT set — it
+# needs the safe-browsing stub patches (patches/ungoogled/quarantine.series), which do not yet
+# apply to this Chromium pin; setting it alone would break the link.
+enable_reporting = false                  # no NEL / Reporting-API upload pipeline
+enable_remoting = false                   # no Chrome Remote Desktop (Google-account-tied)
+enable_mdns = false                       # no multicast-DNS local discovery
+enable_service_discovery = false          # no privet/Cast local service discovery (pairs with enable_mdns)
+enable_hangout_services_extension = false # no built-in Google Meet/Hangouts helper extension
+disable_fieldtrial_testing_config = true  # behave like stable: no baked-in Google experiment config
+exclude_unwind_tables = true              # smaller binary, less stack metadata (symbol_level=0 already)

--- a/build/args.gn.x64
+++ b/build/args.gn.x64
@@ -31,3 +31,16 @@ google_api_key = ""
 google_default_client_id = ""
 google_default_client_secret = ""
 enable_rlz = false                  # no RLZ ping (also the unbranded default)
+
+# === ungoogled-chromium degoogling flags (vendored 149.0.7827.155-1) — see docs/UNGOOGLED.md ===
+# Build-safe subset of ungoogled's flags.gn: removes Google-connected services / phone-home
+# without requiring source patches. NOTE: safe_browsing_mode=0 is intentionally NOT set — it
+# needs the safe-browsing stub patches (patches/ungoogled/quarantine.series), which do not yet
+# apply to this Chromium pin; setting it alone would break the link.
+enable_reporting = false                  # no NEL / Reporting-API upload pipeline
+enable_remoting = false                   # no Chrome Remote Desktop (Google-account-tied)
+enable_mdns = false                       # no multicast-DNS local discovery
+enable_service_discovery = false          # no privet/Cast local service discovery (pairs with enable_mdns)
+enable_hangout_services_extension = false # no built-in Google Meet/Hangouts helper extension
+disable_fieldtrial_testing_config = true  # behave like stable: no baked-in Google experiment config
+exclude_unwind_tables = true              # smaller binary, less stack metadata (symbol_level=0 already)

--- a/docs/UNGOOGLED.md
+++ b/docs/UNGOOGLED.md
@@ -1,0 +1,184 @@
+# Degoogling — ungoogled-chromium integration
+
+Xplorer borrows the **degoogling patches** from
+[ungoogled-chromium](https://github.com/ungoogled-software/ungoogled-chromium) to strip the
+remaining Google phone-home / telemetry / tracking channels out of the Chromium base, while
+keeping Xplorer's own integration (Grok in every tab, the Agent Gateway, branding) fully
+intact. This document explains exactly what was taken, what was deliberately left out, why,
+and how to keep it current.
+
+> **Scope decision:** we take the **patch series only**. We do **not** apply ungoogled's
+> *domain substitution* (rewriting every Google domain to the `qjz9zk` placeholder) or its
+> *binary pruning*. Those break legitimate Google sign-in / Chrome Web Store / Translate and
+> carry a large per-bump maintenance cost, for little additional benefit to a browser that is
+> meant to stay usable. Grok runs over `grok.com` / `x.com` (not Google domains) and is
+> unaffected by anything here.
+
+## The version-skew situation (read this first)
+
+ungoogled-chromium patches target an **exact** Chromium version. Their newest release is
+**149.0.7827.155-1**; they have shipped **no 150 and no 151**. Xplorer pins
+**Chromium 151.0.7897.0** — roughly **two milestones ahead** of ungoogled.
+
+Consequence: their 149-targeted patches cannot be expected to apply to 151 verbatim. We
+therefore treat their 149 series as the **source of truth for content**, and select only the
+patches that still apply to our 151 tree (verified with `git apply --check`). Patches that
+have drifted are kept in-repo but **quarantined** (not applied) until they can be re-anchored
+or until ungoogled ships a ≥150 tag we can refresh from.
+
+The pins are recorded in [`/VERSIONS`](../VERSIONS).
+
+## How it's wired
+
+```
+apply.sh / apply.ps1
+  ├─ copy src/chrome, icons …
+  ├─ patches/apply_integration.py        # Xplorer's Grok + branding edits (authoritative)
+  └─ scripts/apply_ungoogled.sh          # ← degoogling pass, runs LAST
+```
+
+- The degoogling pass runs **after** `apply_integration.py` on purpose: Xplorer's Grok and
+  branding edits land first and unconditionally; the ungoogled patches are best-effort on top.
+- `scripts/apply_ungoogled.sh` (and the `.ps1` mirror) is **idempotent** (skips
+  already-applied patches) and **non-fatal** (a patch that has drifted against the current pin
+  is logged and skipped — it never breaks the overlay, since these patches only *remove*
+  Google channels; a missing one degrades privacy coverage, it doesn't break Xplorer).
+- Patches are **vendored verbatim** under `patches/ungoogled/`, preserving their upstream
+  sub-paths (`core/…`, `extra/…`) as provenance, so they diff cleanly against future
+  ungoogled refreshes. Source: ungoogled-chromium 149.0.7827.155-1
+  (`2a53b77d33b055a4a41139007fb60b6ec1960a48`).
+
+### Verify (read-only — never builds, never writes the tree)
+
+```sh
+scripts/check_ungoogled_patches.sh            # checks the ACTIVE series against ../chromium/src
+scripts/check_ungoogled_patches.sh --all      # also reports the quarantine set
+scripts/check_ungoogled_patches.sh /path/to/chromium/src --all
+```
+
+It runs `git apply --check` per patch and reports `APPLIES` / `FAILS`. Run it whenever you
+bump the Chromium pin or refresh the vendored patches; it exits non-zero if any **active**
+patch fails (suitable as a CI / pre-bump gate).
+
+## What's applied — active series (24 patches)
+
+All verified to apply cleanly to Chromium 151.0.7897.0 (after Xplorer's overlay). Source:
+[`patches/ungoogled/series`](../patches/ungoogled/series). Three change behavior (not just
+telemetry) and are marked **[B]**.
+
+| Patch | Effect |
+|-------|--------|
+| `inox/0003-disable-autofill-download-manager` | No autofill crowdsourcing upload to Google |
+| `inox/0015-disable-update-pings` | Empty updater Update/Ping URLs |
+| `inox/0021-disable-rlz` | Compile out RLZ search-attribution tracking |
+| `iridium/safe_browsing-disable-incident-reporting` | No Safe Browsing incident-report upload |
+| `iridium/safe_browsing-disable-reporting-of-safebrowsing-over` | No client-side phishing verdict upload |
+| `ungoogled/disable-crash-reporter` | No crash-dump upload to Google |
+| `ungoogled/disable-fonts-googleapis-references` | Drop `fonts.googleapis.com` references |
+| `ungoogled/disable-gaia` **[B]** | No browser-level Google sign-in / sync |
+| `ungoogled/disable-gcm` | Disable Google Cloud Messaging (push) |
+| `ungoogled/disable-network-time-tracker` | No `time.google` network-time ping |
+| `ungoogled/disable-untraceable-urls` | Blank the RLZ financial-ping endpoint |
+| `ungoogled/disable-webrtc-log-uploader` | No WebRTC log upload to Google |
+| `ungoogled/doh-changes` **[B]** | Neutral DoH defaults (no Google auto-DoH) |
+| `ungoogled/disable-mei-preload` | Drop Google Media-Engagement preload data |
+| `ungoogled/remove-f1-shortcut` | F1 no longer opens `support.google.com` |
+| `ungoogled/disable-domain-reliability` | No Google Domain Reliability uploads |
+| `ungoogled/disable-profile-avatar-downloading` | No profile-avatar fetch from Google |
+| `bromite/disable-fetching-field-trials` | Never fetch variations / field-trials from Google |
+| `inox/0019-disable-battery-status-service` | Remove Battery Status API (fingerprinting surface) |
+| `debian/google-api-warning` | Suppress the "Google API keys are missing" nag |
+| `inox/0013-disable-missing-key-warning` | Companion missing-API-key warning suppression |
+| `ungoogled/default-webrtc-ip-handling-policy` **[B]** | Default WebRTC IP policy that avoids local-IP leak |
+| `ungoogled/disable-dial-repeating-discovery` | Stop repeating DIAL / Cast discovery |
+| `ungoogled/disable-intranet-redirect-detector` | Stop random-hostname captive-portal DNS probes |
+
+**Behavioral notes for review** — `disable-gaia` removes the browser's own *sign-in to
+Chrome / sync to Google* (it does **not** affect "Sign in with Google" on websites);
+`doh-changes` adjusts Secure-DNS defaults; `default-webrtc-ip-handling-policy` changes the
+default WebRTC IP-handling mode. If any of these isn't wanted, delete its line from
+`patches/ungoogled/series` (the file is the single source of what gets applied).
+
+## What's added — GN flags
+
+Build-safe degoogling switches from ungoogled's `flags.gn`, appended to all four
+`build/args.gn*` files:
+
+`enable_reporting=false`, `enable_remoting=false`, `enable_mdns=false`,
+`enable_service_discovery=false`, `enable_hangout_services_extension=false`,
+`disable_fieldtrial_testing_config=true`, `exclude_unwind_tables=true`.
+
+Five ungoogled flags (`use_official_google_api_keys=false`, the three empty
+`google_*` keys, `enable_rlz=false`) were **already** set by Xplorer.
+
+> **Held back: `safe_browsing_mode=0`.** This is the single biggest degoogling flag, but
+> setting it strips the Safe Browsing subsystem and requires ungoogled's
+> `*-fix-building-without-safebrowsing` companion patches — which currently **fail** on 151
+> (they're quarantined). Enabling the flag without them would break the link. Runtime Safe
+> Browsing *reporting* is already removed by the two iridium patches in the active series, so
+> we keep the privacy win without the build risk. Graduate the flag once those patches are
+> re-anchored.
+
+## What's quarantined (vendored, NOT applied — 10 patches)
+
+See [`patches/ungoogled/quarantine.series`](../patches/ungoogled/quarantine.series). Reasons:
+
+- **Drift (fail on 151, need a re-anchor):** `disable-privacy-sandbox`,
+  `toggle-translation-via-switch`, `remove-unused-preferences-fields`,
+  `disable-google-host-detection` (also touches suggest plumbing near the Grok omnibox —
+  reconcile carefully), `disable-fedcm-by-default`, `inox/0006-modify-default-prefs`.
+- **Coupled to the held-back flag:** both `*-fix-building-without-safebrowsing` (only needed
+  with `safe_browsing_mode=0`).
+- **Capability tradeoffs:** `disable-default-extensions`, `extensions-manifestv2`, and
+  `disable-webstore-urls` (this last one *applies cleanly* but removes Chrome Web Store
+  access, which conflicts with Xplorer's "every extension runs" positioning — opt in only if
+  you want full Web Store removal).
+
+## What's deliberately excluded (not vendored)
+
+- **Domain substitution** (`qjz9zk`) and **binary pruning** — out of scope (see top).
+- **`replace-google-search-engine-with-nosearch`** and other **search / new-tab / branding**
+  patches — they rewrite the same `prepopulated_engines.json` "google" block and NTP/branding
+  that `patches/apply_integration.py` already rewrites to make **Grok** the default. They are
+  mutually exclusive with Xplorer's integration; Xplorer already achieves "no Google search"
+  via its own Grok edit.
+- ungoogled's **chrome://flags UX toggles** (fingerprinting/referrer/etc. flag patches) — they
+  depend on ungoogled's flag-header infrastructure and are UX, not core degoogling. Candidates
+  for a later pass.
+
+## Keeping it updated
+
+ungoogled's own maintenance model (for reference): patches are a GNU **quilt** series pinned
+to an exact Chromium version via `chromium_version.txt` + `revision.txt`; on a Chromium bump a
+maintainer runs `quilt push -a --refresh` to rebase the whole series, fixes breakages one
+patch at a time, and validates with `devutils/validate_patches.py` (no-fuzz apply against a
+clean tree). Releases are tagged `{chromium_version}-{revision}`; an hourly Action watches
+Google's version history and files a tracking issue when stable moves. Updating is volunteer /
+best-effort, so they trail Chromium stable by days-to-weeks (today: a full ~2 milestones).
+
+**Xplorer's process** (lightweight analog — `scripts/check_ungoogled_patches.sh` is our
+`validate_patches.py`):
+
+1. **On every Chromium pin bump:** re-run `scripts/check_ungoogled_patches.sh --all`. Any
+   active patch that newly `FAILS` moves to `quarantine.series` (coverage degrades *visibly*
+   in review, never silently). Put the `applies N / quarantined M` line in the PR.
+2. **Reconcile high-value drift by hand** when needed before ungoogled catches up: re-anchor
+   the patch against `../chromium/src`, keep the reconciled copy under `patches/ungoogled/`
+   with a `reconciled-from ugc 149, pending upstream` note, and re-run the check.
+3. **Graduate on an ungoogled ≥150/151 tag:** when ungoogled ships a tag at/after our
+   milestone, diff their refreshed `core/ungoogled-chromium/` series against our vendored copy,
+   replace our hand-reconciled patches with their official ones, re-run the check, clear the
+   matching quarantine entries, and bump `ungoogled =` in `/VERSIONS`.
+4. **Watch upstream:** periodically check
+   <https://github.com/ungoogled-software/ungoogled-chromium/tags> for a tag whose
+   `chromium_version` ≥ our pin's milestone (mirrors ungoogled's own `new_version_check`).
+
+## Credit & license
+
+The patches under `patches/ungoogled/` are from
+[ungoogled-chromium](https://github.com/ungoogled-software/ungoogled-chromium), which is
+distributed under the **BSD-3-Clause** license — the same family as Chromium's. The upstream
+license text is vendored alongside the patches at
+[`patches/ungoogled/LICENSE.ungoogled`](../patches/ungoogled/LICENSE.ungoogled). With thanks
+to the ungoogled-chromium project and the upstream patch sets it draws on (Inox, Bromite,
+Iridium, Debian).

--- a/patches/ungoogled/LICENSE.ungoogled
+++ b/patches/ungoogled/LICENSE.ungoogled
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2015-2026, The ungoogled-chromium Authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/patches/ungoogled/core/bromite/disable-fetching-field-trials.patch
+++ b/patches/ungoogled/core/bromite/disable-fetching-field-trials.patch
@@ -1,0 +1,76 @@
+# NOTE: Modified to remove usage of compiler #if macros
+From: csagan5 <32685696+csagan5@users.noreply.github.com>
+Date: Sun, 8 Jul 2018 18:16:34 +0200
+Subject: Disable fetching of all field trials
+
+---
+ .../browser/flags/ChromeFeatureList.java      | 19 ++++---------------
+ .../variations/service/variations_service.cc  | 12 +-----------
+ 2 files changed, 5 insertions(+), 26 deletions(-)
+
+--- a/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
++++ b/chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/ChromeFeatureList.java
+@@ -61,7 +61,7 @@ public abstract class ChromeFeatureList
+      * |kFeaturesExposedToJava| in chrome/browser/flags/android/chrome_feature_list.cc
+      */
+     public static String getFieldTrialParamByFeature(String featureName, String paramName) {
+-        return ChromeFeatureMap.getInstance().getFieldTrialParamByFeature(featureName, paramName);
++        return "";
+     }
+ 
+     /**
+@@ -73,8 +73,7 @@ public abstract class ChromeFeatureList
+      */
+     public static boolean getFieldTrialParamByFeatureAsBoolean(
+             String featureName, String paramName, boolean defaultValue) {
+-        return ChromeFeatureMap.getInstance()
+-                .getFieldTrialParamByFeatureAsBoolean(featureName, paramName, defaultValue);
++        return defaultValue;
+     }
+ 
+     /**
+@@ -86,8 +85,7 @@ public abstract class ChromeFeatureList
+      */
+     public static int getFieldTrialParamByFeatureAsInt(
+             String featureName, String paramName, int defaultValue) {
+-        return ChromeFeatureMap.getInstance()
+-                .getFieldTrialParamByFeatureAsInt(featureName, paramName, defaultValue);
++        return defaultValue;
+     }
+ 
+     /**
+@@ -99,8 +97,7 @@ public abstract class ChromeFeatureList
+      */
+     public static double getFieldTrialParamByFeatureAsDouble(
+             String featureName, String paramName, double defaultValue) {
+-        return ChromeFeatureMap.getInstance()
+-                .getFieldTrialParamByFeatureAsDouble(featureName, paramName, defaultValue);
++        return defaultValue;
+     }
+ 
+     /**
+--- a/components/variations/service/variations_service.cc
++++ b/components/variations/service/variations_service.cc
+@@ -225,22 +225,7 @@ bool GetInstanceManipulations(const net:
+ // Variations seed fetching is only enabled in official Chrome builds, if a URL
+ // is specified on the command line, and for testing.
+ bool IsFetchingEnabled() {
+-#if BUILDFLAG(GOOGLE_CHROME_BRANDING)
+-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+-          switches::kDisableVariationsSeedFetch)) {
+     return false;
+-  }
+-#else
+-  if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
+-          switches::kVariationsServerURL) &&
+-      !g_should_fetch_for_testing) {
+-    DVLOG(1)
+-        << "Not performing repeated fetching in unofficial build without --"
+-        << switches::kVariationsServerURL << " specified.";
+-    return false;
+-  }
+-#endif  // BUILDFLAG(GOOGLE_CHROME_BRANDING)
+-  return true;
+ }
+ 
+ // Returns the already downloaded first run seed, and clear the seed from the

--- a/patches/ungoogled/core/inox-patchset/0001-fix-building-without-safebrowsing.patch
+++ b/patches/ungoogled/core/inox-patchset/0001-fix-building-without-safebrowsing.patch
@@ -1,0 +1,199 @@
+--- a/chrome/browser/chrome_content_browser_client_navigation_throttles.cc
++++ b/chrome/browser/chrome_content_browser_client_navigation_throttles.cc
+@@ -433,10 +433,6 @@ void CreateAndAddChromeThrottlesForNavig
+           Profile::FromBrowserContext(context)),
+       SafeSearchFactory::GetForBrowserContext(context)));
+ 
+-  // Before setting up SSL error detection, configure SSLErrorHandler to invoke
+-  // the relevant extension API whenever an SSL interstitial is shown.
+-  SSLErrorHandler::SetClientCallbackOnInterstitialsShown(
+-      base::BindRepeating(&MaybeTriggerSecurityInterstitialShownEvent));
+   registry.AddThrottle(std::make_unique<SSLErrorNavigationThrottle>(
+       registry, base::BindOnce(&HandleSSLErrorWrapper),
+       base::BindOnce(&IsInWebApp),
+--- a/chrome/browser/component_updater/file_type_policies_component_installer.cc
++++ b/chrome/browser/component_updater/file_type_policies_component_installer.cc
+@@ -36,21 +36,6 @@ const uint8_t kFileTypePoliciesPublicKey
+ const char kFileTypePoliciesManifestName[] = "File Type Policies";
+ 
+ void LoadFileTypesFromDisk(const base::FilePath& pb_path) {
+-  if (pb_path.empty()) {
+-    return;
+-  }
+-
+-  VLOG(1) << "Reading Download File Types from file: " << pb_path.value();
+-  std::string binary_pb;
+-  if (!base::ReadFileToString(pb_path, &binary_pb)) {
+-    // The file won't exist on new installations, so this is not always an
+-    // error.
+-    VLOG(1) << "Failed reading from " << pb_path.value();
+-    return;
+-  }
+-
+-  safe_browsing::FileTypePolicies::GetInstance()->PopulateFromDynamicUpdate(
+-      binary_pb);
+ }
+ 
+ }  // namespace
+--- a/chrome/browser/download/download_item_model.cc
++++ b/chrome/browser/download/download_item_model.cc
+@@ -129,7 +129,7 @@ class DownloadItemModelData : public bas
+ 
+   // Danger level of the file determined based on the file type and whether
+   // there was a user action associated with the download.
+-  DownloadFileType::DangerLevel danger_level_ = DownloadFileType::NOT_DANGEROUS;
++  safe_browsing::DownloadFileType::DangerLevel danger_level_ = safe_browsing::DownloadFileType::NOT_DANGEROUS;
+ 
+   // Whether the download is currently being revived.
+   bool is_being_revived_ = false;
+@@ -468,13 +468,13 @@ void DownloadItemModel::SetShouldPreferO
+   data->should_prefer_opening_in_browser_ = preference;
+ }
+ 
+-DownloadFileType::DangerLevel DownloadItemModel::GetDangerLevel() const {
++safe_browsing::DownloadFileType::DangerLevel DownloadItemModel::GetDangerLevel() const {
+   const DownloadItemModelData* data = DownloadItemModelData::Get(download_);
+-  return data ? data->danger_level_ : DownloadFileType::NOT_DANGEROUS;
++  return data ? data->danger_level_ : safe_browsing::DownloadFileType::NOT_DANGEROUS;
+ }
+ 
+ void DownloadItemModel::SetDangerLevel(
+-    DownloadFileType::DangerLevel danger_level) {
++    safe_browsing::DownloadFileType::DangerLevel danger_level) {
+   DownloadItemModelData* data = DownloadItemModelData::GetOrCreate(download_);
+   data->danger_level_ = danger_level;
+ }
+--- a/chrome/browser/extensions/api/webstore_private/webstore_private_api.cc
++++ b/chrome/browser/extensions/api/webstore_private/webstore_private_api.cc
+@@ -849,18 +849,6 @@ void WebstorePrivateBeginInstallWithMani
+ 
+ void WebstorePrivateBeginInstallWithManifest3Function::
+     ReportFrictionAcceptedEvent() {
+-  if (!profile_) {
+-    return;
+-  }
+-  auto* metrics_collector =
+-      safe_browsing::SafeBrowsingMetricsCollectorFactory::GetForProfile(
+-          profile_);
+-  // `metrics_collector` can be null in incognito.
+-  if (metrics_collector) {
+-    metrics_collector->AddSafeBrowsingEventToPref(
+-        safe_browsing::SafeBrowsingMetricsCollector::EventType::
+-            EXTENSION_ALLOWLIST_INSTALL_BYPASS);
+-  }
+ }
+ 
+ void WebstorePrivateBeginInstallWithManifest3Function::OnInstallPromptDone(
+--- a/chrome/browser/safe_browsing/BUILD.gn
++++ b/chrome/browser/safe_browsing/BUILD.gn
+@@ -7,6 +7,7 @@ import("//components/safe_browsing/build
+ import("//extensions/buildflags/buildflags.gni")
+ 
+ static_library("safe_browsing") {
++  if (false) {
+   public = [
+     "chrome_controller_client.h",
+     "metrics/bundled_settings_metrics_provider.h",
+@@ -104,6 +105,7 @@ static_library("safe_browsing") {
+     "//services/metrics/public/cpp:ukm_builders",
+     "//services/preferences/public/cpp",
+   ]
++  }
+ 
+   if (enable_extensions) {
+     deps += [ "//chrome/browser/ui/web_applications" ]
+@@ -678,6 +680,7 @@ static_library("advanced_protection") {
+ }
+ 
+ source_set("metrics_collector") {
++  if (false) {
+   sources = [
+     "safe_browsing_metrics_collector_factory.cc",
+     "safe_browsing_metrics_collector_factory.h",
+@@ -697,6 +700,7 @@ source_set("metrics_collector") {
+     "//components/safe_browsing/core/common:safe_browsing_prefs",
+     "//content/public/browser",
+   ]
++  }
+ }
+ 
+ source_set("unit_tests") {
+--- a/chrome/browser/ui/webui/downloads/downloads_dom_handler.cc
++++ b/chrome/browser/ui/webui/downloads/downloads_dom_handler.cc
+@@ -25,7 +25,6 @@
+ #include "base/values.h"
+ #include "build/branding_buildflags.h"
+ #include "chrome/browser/browser_process.h"
+-#include "chrome/browser/download/download_danger_prompt.h"
+ #include "chrome/browser/download/download_history.h"
+ #include "chrome/browser/download/download_item_model.h"
+ #include "chrome/browser/download/download_item_warning_data.h"
+@@ -565,12 +564,6 @@ void DownloadsDOMHandler::RemoveDownload
+   IdSet ids;
+ 
+   for (download::DownloadItem* download : to_remove) {
+-    if (download->IsDangerous() || download->IsInsecure()) {
+-      // Don't allow users to revive dangerous downloads; just nuke 'em.
+-      download->Remove();
+-      continue;
+-    }
+-
+     DownloadItemModel item_model(download);
+     if (!item_model.ShouldShowInUi() ||
+         download->GetState() == download::DownloadItem::IN_PROGRESS) {
+--- a/chrome/browser/ui/webui/downloads/downloads_dom_handler.h
++++ b/chrome/browser/ui/webui/downloads/downloads_dom_handler.h
+@@ -13,7 +13,6 @@
+ #include "base/memory/raw_ptr.h"
+ #include "base/memory/weak_ptr.h"
+ #include "base/time/time.h"
+-#include "chrome/browser/download/download_danger_prompt.h"
+ #include "chrome/browser/download/download_warning_desktop_hats_utils.h"
+ #include "chrome/browser/ui/webui/downloads/downloads.mojom-forward.h"
+ #include "chrome/browser/ui/webui/downloads/downloads_list_tracker.h"
+--- a/chrome/renderer/chrome_content_renderer_client.cc
++++ b/chrome/renderer/chrome_content_renderer_client.cc
+@@ -110,7 +110,6 @@
+ #include "components/pdf/common/pdf_util.h"
+ #include "components/permissions/features.h"
+ #include "components/safe_browsing/buildflags.h"
+-#include "components/safe_browsing/content/renderer/threat_dom_details.h"
+ #include "components/sampling_profiler/process_type.h"
+ #include "components/sampling_profiler/thread_profiler.h"
+ #include "components/security_interstitials/content/renderer/security_interstitial_page_controller_delegate_impl.h"
+--- a/extensions/browser/blocklist_state_fetcher.cc
++++ b/extensions/browser/blocklist_state_fetcher.cc
+@@ -69,8 +69,7 @@ void BlocklistStateFetcher::SendRequest(
+   std::string request_str;
+   request.SerializeToString(&request_str);
+ 
+-  GURL request_url = GURL(safe_browsing::GetReportUrl(
+-      *safe_browsing_config_, "clientreport/crx-list-info"));
++  GURL request_url = GURL();
+   net::NetworkTrafficAnnotationTag traffic_annotation =
+       net::DefineNetworkTrafficAnnotation("extension_blacklist", R"(
+         semantics {
+@@ -134,12 +133,6 @@ void BlocklistStateFetcher::SendRequest(
+                      base::Unretained(this), fetcher));
+ }
+ 
+-void BlocklistStateFetcher::SetSafeBrowsingConfig(
+-    const safe_browsing::V4ProtocolConfig& config) {
+-  safe_browsing_config_ =
+-      std::make_unique<safe_browsing::V4ProtocolConfig>(config);
+-}
+-
+ void BlocklistStateFetcher::OnURLLoaderComplete(
+     network::SimpleURLLoader* url_loader,
+     std::optional<std::string> response_body) {
+--- a/extensions/browser/blocklist_state_fetcher.h
++++ b/extensions/browser/blocklist_state_fetcher.h
+@@ -41,8 +41,6 @@ class BlocklistStateFetcher {
+ 
+   virtual void Request(const std::string& id, RequestCallback callback);
+ 
+-  void SetSafeBrowsingConfig(const safe_browsing::V4ProtocolConfig& config);
+-
+  protected:
+   void OnURLLoaderComplete(network::SimpleURLLoader* url_loader,
+                            std::optional<std::string> response_body);

--- a/patches/ungoogled/core/inox-patchset/0003-disable-autofill-download-manager.patch
+++ b/patches/ungoogled/core/inox-patchset/0003-disable-autofill-download-manager.patch
@@ -1,0 +1,97 @@
+--- a/components/autofill/core/browser/crowdsourcing/autofill_crowdsourcing_manager.cc
++++ b/components/autofill/core/browser/crowdsourcing/autofill_crowdsourcing_manager.cc
+@@ -916,94 +916,6 @@ std::tuple<GURL, std::string> AutofillCr
+ }
+ 
+ bool AutofillCrowdsourcingManager::StartRequest(FormRequestData request_data) {
+-  // kRequestUploads take no IsolationInfo because Password Manager uploads when
+-  // RenderFrameHostImpl::DidCommitNavigation() is called, in which case
+-  // AutofillDriver::IsolationInfo() may crash because there is no committing
+-  // NavigationRequest. Not setting an IsolationInfo is safe because no
+-  // information about the response is passed to the renderer, or is otherwise
+-  // visible to a page. See crbug/1176635#c22.
+-#if BUILDFLAG(IS_IOS)
+-  DCHECK(!request_data.isolation_info);
+-#else
+-  DCHECK(
+-      (request_data.request_type == CrowdsourcingRequestType::kRequestUpload) ==
+-      !request_data.isolation_info);
+-#endif
+-  // Get the URL and method to use for this request.
+-  auto [request_url, method] = GetRequestURLAndMethod(request_data);
+-
+-  // Track the URL length for GET queries because the URL length can be in the
+-  // thousands when rich metadata is enabled.
+-  if (request_data.request_type == CrowdsourcingRequestType::kRequestQuery &&
+-      method == "GET") {
+-    base::UmaHistogramCounts100000(kUmaGetUrlLength,
+-                                   request_url.spec().length());
+-  }
+-
+-  auto resource_request = std::make_unique<network::ResourceRequest>();
+-  resource_request->url = request_url;
+-  resource_request->credentials_mode = network::mojom::CredentialsMode::kOmit;
+-  resource_request->method = method;
+-
+-  if (request_data.isolation_info) {
+-    resource_request->trusted_params =
+-        network::ResourceRequest::TrustedParams();
+-    resource_request->trusted_params->isolation_info =
+-        *request_data.isolation_info;
+-  }
+-
+-  // Add Chrome experiment state to the request headers.
+-  variations::AppendVariationsHeaderUnknownSignedIn(
+-      request_url,
+-      client_->IsOffTheRecord() ? variations::InIncognito::kYes
+-                                : variations::InIncognito::kNo,
+-      resource_request.get());
+-
+-  // Set headers specific to the API.
+-  // Encode response serialized proto in base64 for safety.
+-  resource_request->headers.SetHeader(kGoogEncodeResponseIfExecutable,
+-                                      "base64");
+-
+-  // Add API key to the request if a key exists, and the endpoint is trusted by
+-  // Google.
+-  if (!api_key_.empty() && request_url.SchemeIs(url::kHttpsScheme) &&
+-      google_util::IsGoogleAssociatedDomainUrl(request_url)) {
+-    google_apis::AddAPIKeyToRequest(*resource_request, api_key_);
+-  }
+-
+-  auto simple_loader = network::SimpleURLLoader::Create(
+-      std::move(resource_request),
+-      GetNetworkTrafficAnnotation(request_data.request_type));
+-
+-  // This allows reading the error message within the API response when status
+-  // is not 200 (e.g., 400). Otherwise, URL loader will not give any content in
+-  // the response when there is a failure, which makes debugging hard.
+-  simple_loader->SetAllowHttpErrorResults(true);
+-
+-  if (method == "POST") {
+-    static constexpr char content_type[] = "application/x-protobuf";
+-    std::optional<std::string> payload =
+-        GetAPIBodyPayload(request_data.payload, request_data.request_type);
+-    if (!payload) {
+-      return false;
+-    }
+-    // Attach payload data and add data format header.
+-    simple_loader->AttachStringForUpload(std::move(payload).value(),
+-                                         content_type);
+-  }
+-
+-  // Transfer ownership of the loader into url_loaders_. Temporarily hang
+-  // onto the raw pointer to use it as a key and to kick off the request;
+-  // transferring ownership (std::move) invalidates the `simple_loader`
+-  // variable.
+-  auto* raw_simple_loader = simple_loader.get();
+-  url_loaders_.push_back(std::move(simple_loader));
+-  raw_simple_loader->SetTimeoutDuration(kFetchTimeout);
+-  raw_simple_loader->DownloadToStringOfUnboundedSizeUntilCrashAndDie(
+-      client_->GetURLLoaderFactory().get(),
+-      base::BindOnce(&AutofillCrowdsourcingManager::OnSimpleLoaderComplete,
+-                     base::Unretained(this), std::move(--url_loaders_.end()),
+-                     std::move(request_data), base::TimeTicks::Now()));
+   return true;
+ }
+ 

--- a/patches/ungoogled/core/inox-patchset/0005-disable-default-extensions.patch
+++ b/patches/ungoogled/core/inox-patchset/0005-disable-default-extensions.patch
@@ -1,0 +1,85 @@
+--- a/chrome/browser/extensions/component_extensions_allowlist/allowlist.cc
++++ b/chrome/browser/extensions/component_extensions_allowlist/allowlist.cc
+@@ -34,7 +34,6 @@ namespace extensions {
+ bool IsComponentExtensionAllowlisted(const std::string& extension_id) {
+   constexpr auto kAllowed = base::MakeFixedFlatSet<std::string_view>({
+       extension_misc::kGlicExtensionId,
+-      extension_misc::kInAppPaymentsSupportAppId,
+       extension_misc::kPdfExtensionId,
+ #if BUILDFLAG(IS_CHROMEOS)
+       extension_misc::kAssessmentAssistantExtensionId,
+--- a/chrome/browser/extensions/component_loader.cc
++++ b/chrome/browser/extensions/component_loader.cc
+@@ -432,11 +432,6 @@ void ComponentLoader::AddWebStoreApp() {
+     return;
+   }
+ #endif
+-
+-  AddWithNameAndDescription(
+-      IDR_WEBSTORE_MANIFEST, base::FilePath(FILE_PATH_LITERAL("web_store")),
+-      l10n_util::GetStringUTF8(IDS_WEBSTORE_NAME_STORE),
+-      l10n_util::GetStringUTF8(IDS_WEBSTORE_APP_DESCRIPTION));
+ }
+ 
+ #if BUILDFLAG(IS_CHROMEOS)
+--- a/chrome/browser/extensions/external_component_loader.cc
++++ b/chrome/browser/extensions/external_component_loader.cc
+@@ -41,9 +41,6 @@ ExternalComponentLoader::~ExternalCompon
+ void ExternalComponentLoader::StartLoading() {
+   auto prefs = base::DictValue();
+   // Skip in-app payments app on Android. crbug.com/409396604
+-#if BUILDFLAG(GOOGLE_CHROME_BRANDING) && !BUILDFLAG(IS_ANDROID)
+-  AddExternalExtension(extension_misc::kInAppPaymentsSupportAppId, prefs);
+-#endif  // BUILDFLAG(GOOGLE_CHROME_BRANDING) && !BUILDFLAG(IS_ANDROID)
+ 
+ #if BUILDFLAG(IS_CHROMEOS)
+   {
+--- a/extensions/browser/webstore_installer.cc
++++ b/extensions/browser/webstore_installer.cc
+@@ -483,21 +483,6 @@ void WebstoreInstaller::DownloadNextPend
+ 
+ void WebstoreInstaller::DownloadCrx(const ExtensionId& extension_id,
+                                     InstallSource source) {
+-  download_url_ = GetWebstoreInstallURL(extension_id, source);
+-  MaybeAppendAuthUserParameter(approval_->authuser, download_url_);
+-
+-  base::FilePath user_data_dir =
+-      ExtensionsBrowserClient::Get()->GetUserDataDir();
+-  base::FilePath download_path = user_data_dir.Append(kWebstoreDownloadFolder);
+-
+-  base::FilePath download_directory(g_download_directory_for_tests
+-                                        ? *g_download_directory_for_tests
+-                                        : download_path);
+-
+-  GetExtensionFileTaskRunner()->PostTaskAndReplyWithResult(
+-      FROM_HERE,
+-      base::BindOnce(&GetDownloadFilePath, download_directory, extension_id),
+-      base::BindOnce(&WebstoreInstaller::StartDownload, this, extension_id));
+ }
+ 
+ // http://crbug.com/40957413
+@@ -655,24 +640,6 @@ void WebstoreInstaller::UpdateDownloadPr
+ void WebstoreInstaller::StartCrxInstaller(const DownloadItem& download) {
+   DCHECK_CURRENTLY_ON(BrowserThread::UI);
+   DCHECK(!crx_installer_.get());
+-
+-  const InstallApproval* approval = GetAssociatedApproval(download);
+-  DCHECK(approval);
+-
+-  crx_installer_ =
+-      ExtensionsBrowserClient::Get()->CreateCrxInstallerFromDownloadItem(
+-          browser_context_, download);
+-
+-  crx_installer_->set_expected_id(approval->extension_id);
+-  crx_installer_->set_is_gallery_install(true);
+-  crx_installer_->set_allow_silent_install(true);
+-  crx_installer_->AddInstallerCallback(base::BindOnce(
+-      &WebstoreInstaller::OnInstallerDone, weak_ptr_factory_.GetWeakPtr()));
+-  if (approval->withhold_permissions) {
+-    crx_installer_->set_withhold_permissions();
+-  }
+-
+-  crx_installer_->InstallCrx(download.GetFullPath());
+ }
+ 
+ void WebstoreInstaller::ReportFailure(const std::string& error,

--- a/patches/ungoogled/core/inox-patchset/0015-disable-update-pings.patch
+++ b/patches/ungoogled/core/inox-patchset/0015-disable-update-pings.patch
@@ -1,0 +1,11 @@
+--- a/chrome/updater/configurator.cc
++++ b/chrome/updater/configurator.cc
+@@ -136,7 +136,7 @@ base::TimeDelta Configurator::UpdateDela
+ 
+ std::vector<GURL> Configurator::UpdateUrl() const {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+-  return external_constants_->UpdateURL();
++  return std::vector<GURL>();
+ }
+ 
+ std::vector<GURL> Configurator::PingUrl() const {

--- a/patches/ungoogled/core/inox-patchset/0021-disable-rlz.patch
+++ b/patches/ungoogled/core/inox-patchset/0021-disable-rlz.patch
@@ -1,0 +1,30 @@
+# Disable rlz
+
+--- a/BUILD.gn
++++ b/BUILD.gn
+@@ -455,14 +455,6 @@ group("gn_all") {
+       ]
+     }
+ 
+-    if (is_chromeos || is_mac || is_win) {
+-      deps += [
+-        "//rlz:rlz_id",
+-        "//rlz:rlz_lib",
+-        "//rlz:rlz_unittests",
+-      ]
+-    }
+-
+     if (is_linux || is_chromeos) {
+       # The following are definitely linux-only.
+       deps += [
+--- a/rlz/buildflags/buildflags.gni
++++ b/rlz/buildflags/buildflags.gni
+@@ -6,7 +6,7 @@ import("//build/config/chrome_build.gni"
+ 
+ # Whether we are using the rlz library or not.  Platforms like Android send
+ # rlz codes for searches but do not use the library.
+-enable_rlz_support = is_win || is_apple || is_chromeos
++enable_rlz_support = false
+ 
+ declare_args() {
+   enable_rlz = is_chrome_branded && enable_rlz_support

--- a/patches/ungoogled/core/iridium-browser/safe_browsing-disable-incident-reporting.patch
+++ b/patches/ungoogled/core/iridium-browser/safe_browsing-disable-incident-reporting.patch
@@ -1,0 +1,83 @@
+From 4dfa8ed0814040317cb82d8545502186daa0a204 Mon Sep 17 00:00:00 2001
+From: Jan Engelhardt <jengelh@inai.de>
+Date: Tue, 7 Jul 2015 17:02:09 +0200
+Subject: [PATCH 62/76] safe_browsing: disable incident reporting
+
+Disables the safebrowsing incident reporting where you could upload
+information about a blocked URL to Google (also added a trk prefix to
+the URL so we get notified if this happens again in the future).
+---
+ .../incident_reporting/incident_report_uploader_impl.cc        | 2 +-
+ .../incident_reporting/incident_reporting_service.cc           | 3 +++
+ chrome/browser/safe_browsing/safe_browsing_blocking_page.cc    | 3 +--
+ chrome/browser/safe_browsing/safe_browsing_service.cc          | 2 +-
+ .../security_interstitials/core/safe_browsing_loud_error_ui.cc | 1 +
+ 5 files changed, 7 insertions(+), 4 deletions(-)
+
+--- a/chrome/browser/safe_browsing/chrome_safe_browsing_blocking_page_factory.cc
++++ b/chrome/browser/safe_browsing/chrome_safe_browsing_blocking_page_factory.cc
+@@ -63,8 +63,7 @@ ChromeSafeBrowsingBlockingPageFactory::C
+       Profile::FromBrowserContext(web_contents->GetBrowserContext());
+   // Create appropriate display options for this blocking page.
+   PrefService* prefs = profile->GetPrefs();
+-  bool is_extended_reporting_opt_in_allowed =
+-      IsExtendedReportingOptInAllowed(*prefs);
++  bool is_extended_reporting_opt_in_allowed = false;
+   bool is_proceed_anyway_disabled = IsSafeBrowsingProceedAnywayDisabled(*prefs);
+ 
+   // Determine if any prefs need to be updated prior to showing the security
+--- a/chrome/browser/safe_browsing/incident_reporting/incident_report_uploader_impl.cc
++++ b/chrome/browser/safe_browsing/incident_reporting/incident_report_uploader_impl.cc
+@@ -29,7 +29,7 @@ namespace safe_browsing {
+ namespace {
+ 
+ const char kSbIncidentReportUrl[] =
+-    "https://sb-ssl.google.com/safebrowsing/clientreport/incident";
++    "trk:268:https://sb-ssl.google.com/safebrowsing/clientreport/incident";
+ 
+ constexpr net::NetworkTrafficAnnotationTag
+     kSafeBrowsingIncidentTrafficAnnotation =
+--- a/chrome/browser/safe_browsing/incident_reporting/incident_reporting_service.cc
++++ b/chrome/browser/safe_browsing/incident_reporting/incident_reporting_service.cc
+@@ -302,11 +302,14 @@ IncidentReportingService::UploadContext:
+ 
+ // static
+ bool IncidentReportingService::IsEnabledForProfile(Profile* profile) {
++  return false;
++#if 0
+   if (profile->IsOffTheRecord())
+     return false;
+   if (!IsSafeBrowsingEnabled(*profile->GetPrefs()))
+     return false;
+   return IsExtendedReportingEnabled(*profile->GetPrefs());
++#endif
+ }
+ 
+ IncidentReportingService::IncidentReportingService(
+--- a/chrome/browser/safe_browsing/safe_browsing_service.cc
++++ b/chrome/browser/safe_browsing/safe_browsing_service.cc
+@@ -519,7 +519,7 @@ SafeBrowsingUIManager* SafeBrowsingServi
+ }
+ 
+ void SafeBrowsingServiceImpl::RegisterAllDelayedAnalysis() {
+-#if BUILDFLAG(FULL_SAFE_BROWSING)
++#if 0
+   RegisterBinaryIntegrityAnalysis();
+ #endif
+ }
+--- a/components/security_interstitials/core/safe_browsing_loud_error_ui.cc
++++ b/components/security_interstitials/core/safe_browsing_loud_error_ui.cc
+@@ -27,11 +27,11 @@ namespace {
+ // For malware interstitial pages, we link the problematic URL to Google's
+ // diagnostic page.
+ const char kSbDiagnosticUrl[] =
+-    "https://transparencyreport.google.com/safe-browsing/search?url=%s";
++    "trk:227:https://transparencyreport.google.com/safe-browsing/search?url=%s";
+ 
+ // Constants for the V4 phishing string upgrades.
+ const char kReportPhishingErrorUrl[] =
+-    "https://safebrowsing.google.com/safebrowsing/report_error/?url=%s";
++    "trk:228:https://safebrowsing.google.com/safebrowsing/report_error/?url=%s";
+ 
+ void RecordExtendedReportingPrefChanged(bool report) {
+   UMA_HISTOGRAM_BOOLEAN("SafeBrowsing.Pref.Extended.SecurityInterstitial",

--- a/patches/ungoogled/core/iridium-browser/safe_browsing-disable-reporting-of-safebrowsing-over.patch
+++ b/patches/ungoogled/core/iridium-browser/safe_browsing-disable-reporting-of-safebrowsing-over.patch
@@ -1,0 +1,34 @@
+From c89ce946e5328ca8a7df923d421e904bb6bfe9b6 Mon Sep 17 00:00:00 2001
+From: Jan Engelhardt <jengelh@inai.de>
+Date: Tue, 7 Jul 2015 18:28:46 +0200
+Subject: [PATCH 63/76] safe_browsing: disable reporting of safebrowsing
+ override
+
+Disables reporting of the safebrowsing override, i.e. the report sent
+if a user decides to visit a page that was flagged as "insecure".
+This prevents trk:148 (phishing) and trk:149 (malware).
+---
+ components/safe_browsing/content/browser/client_side_detection_service.cc   | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+--- a/components/safe_browsing/content/browser/client_side_detection_service.cc
++++ b/components/safe_browsing/content/browser/client_side_detection_service.cc
+@@ -291,6 +291,10 @@ void ClientSideDetectionService::StartCl
+     return;
+   }
+ 
++#if 1
++  if (!callback.is_null())
++    std::move(callback).Run(GURL(request->url()), false, std::nullopt, std::nullopt);
++#else
+   std::string request_data;
+   request->SerializeToString(&request_data);
+ 
+@@ -370,6 +374,7 @@ void ClientSideDetectionService::StartCl
+           &WebUIContentInfoSingleton::AddToClientPhishingRequestsSent,
+           base::Unretained(WebUIContentInfoSingleton::GetInstance()),
+           std::move(request), access_token));
++#endif
+ }
+ 
+ void ClientSideDetectionService::HandlePhishingVerdict(

--- a/patches/ungoogled/core/ungoogled-chromium/disable-crash-reporter.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/disable-crash-reporter.patch
@@ -1,0 +1,49 @@
+# Disable some background communication with clients2.google.com
+
+--- a/components/crash/core/app/crash_reporter_client.cc
++++ b/components/crash/core/app/crash_reporter_client.cc
+@@ -146,7 +146,7 @@ void CrashReporterClient::GetSanitizatio
+ #endif
+ 
+ std::string CrashReporterClient::GetUploadUrl() {
+-#if BUILDFLAG(GOOGLE_CHROME_BRANDING) && defined(OFFICIAL_BUILD)
++#if 0
+   return kDefaultUploadURL;
+ #else
+   return std::string();
+--- a/components/crash/core/app/crashpad.cc
++++ b/components/crash/core/app/crashpad.cc
+@@ -73,6 +73,13 @@ bool InitializeCrashpadImpl(bool initial
+                             const std::vector<std::string>& initial_arguments,
+                             bool embedded_handler,
+                             const std::vector<base::FilePath>& attachments) {
++// Crashpad is needed on Linux because it's used as a WASM signal handler.
++// This is not the case on other platforms, and so it can remain entirely
++// disabled there.
++#if !BUILDFLAG(IS_LINUX)
++  return false;
++#endif
++
+   static bool initialized = false;
+   DCHECK(!initialized);
+   initialized = true;
+--- a/third_party/crashpad/crashpad/handler/handler_main.cc
++++ b/third_party/crashpad/crashpad/handler/handler_main.cc
+@@ -875,7 +875,7 @@ int HandlerMain(int argc,
+ #endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) ||
+         // BUILDFLAG(IS_ANDROID)
+       case kOptionURL: {
+-        options.url = optarg;
++        options.url = "";
+         break;
+       }
+ #if BUILDFLAG(IS_CHROMEOS)
+@@ -1016,7 +1016,7 @@ int HandlerMain(int argc,
+   }
+ 
+   ScopedStoppable upload_thread;
+-  if (!options.url.empty()) {
++  if ((false)) {
+     // TODO(scottmg): options.rate_limit should be removed when we have a
+     // configurable database setting to control upload limiting.
+     // See https://crashpad.chromium.org/bug/23.

--- a/patches/ungoogled/core/ungoogled-chromium/disable-domain-reliability.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/disable-domain-reliability.patch
@@ -1,0 +1,721 @@
+## Disable domain reliability component
+# Many of these changes are for thoroughness,
+# the most significant changes are in service_factory.cc and uploader.cc
+
+--- a/chrome/browser/domain_reliability/service_factory.cc
++++ b/chrome/browser/domain_reliability/service_factory.cc
+@@ -10,36 +10,10 @@
+ 
+ namespace domain_reliability {
+ 
+-namespace {
+-
+-// If Domain Reliability is enabled in the absence of a flag or field trial.
+-const bool kDefaultEnabled = true;
+-
+-// The name and value of the field trial to turn Domain Reliability on.
+-const char kFieldTrialName[] = "DomRel-Enable";
+-const char kFieldTrialValueEnable[] = "enable";
+-
+-}  // namespace
+-
+ const char kUploadReporterString[] = "chrome";
+ 
+ bool ShouldCreateService(const DomainReliabilityServiceDelegate* delegate) {
+-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+-  if (command_line->HasSwitch(switches::kDisableDomainReliability))
+-    return false;
+-  if (command_line->HasSwitch(switches::kEnableDomainReliability))
+-    return true;
+-  if (!delegate->IsDomainReliabilityAllowed()) {
+-    return false;
+-  }
+-  if (!delegate->IsMetricsAndCrashReportingEnabled()) {
+-    return false;
+-  }
+-  if (base::FieldTrialList::TrialExists(kFieldTrialName)) {
+-    std::string value = base::FieldTrialList::FindFullName(kFieldTrialName);
+-    return (value == kFieldTrialValueEnable);
+-  }
+-  return kDefaultEnabled;
++  return false;
+ }
+ 
+ }  // namespace domain_reliability
+--- a/chrome/browser/net/profile_network_context_service.cc
++++ b/chrome/browser/net/profile_network_context_service.cc
+@@ -184,8 +184,7 @@ class ChromeDomainReliabilityDelegate
+   ~ChromeDomainReliabilityDelegate() override = default;
+ 
+   bool IsDomainReliabilityAllowed() const override {
+-    return g_browser_process->local_state()->GetBoolean(
+-        domain_reliability::prefs::kDomainReliabilityAllowedByPolicy);
++    return false;
+   }
+ 
+   bool IsMetricsAndCrashReportingEnabled() const override {
+--- a/components/domain_reliability/BUILD.gn
++++ b/components/domain_reliability/BUILD.gn
+@@ -7,26 +7,6 @@ action("bake_in_configs") {
+   script = "bake_in_configs.py"
+ 
+   inputs = [
+-    "baked_in_configs/c_android_clients_google_com.json",
+-    "baked_in_configs/c_bigcache_googleapis_com.json",
+-    "baked_in_configs/c_doc-0-0-sj_sj_googleusercontent_com.json",
+-    "baked_in_configs/c_docs_google_com.json",
+-    "baked_in_configs/c_drive_google_com.json",
+-    "baked_in_configs/c_googlesyndication_com.json",
+-    "baked_in_configs/c_pack_google_com.json",
+-    "baked_in_configs/c_play_google_com.json",
+-    "baked_in_configs/c_youtube_com.json",
+-    "baked_in_configs/clients2_google_com.json",
+-    "baked_in_configs/docs_google_com.json",
+-    "baked_in_configs/gcp_gvt2_com.json",
+-    "baked_in_configs/gcp_gvt6_com.json",
+-    "baked_in_configs/google-analytics_com.json",
+-    "baked_in_configs/googlevideo_com.json",
+-    "baked_in_configs/gvt1_com.json",
+-    "baked_in_configs/gvt2_com.json",
+-    "baked_in_configs/gvt6_com.json",
+-    "baked_in_configs/ssl_gstatic_com.json",
+-    "baked_in_configs/www_google_com.json",
+   ]
+ 
+   output_file = "$target_gen_dir/baked_in_configs.cc"
+@@ -34,13 +14,21 @@ action("bake_in_configs") {
+ 
+   # The JSON file list is too long for the command line on Windows, so put
+   # them in a response file.
+-  response_file_contents = rebase_path(inputs, root_build_dir)
+-  args = [
+-    "--file-list",
+-    "{{response_file_name}}",
+-    "--output",
+-    rebase_path(output_file, root_build_dir),
+-  ]
++  if (host_os == "win") {
++      args = [
++        "--file-list",
++        "nul",
++        "--output",
++        rebase_path(output_file, root_build_dir),
++      ]
++  } else {
++        args = [
++        "--file-list",
++        "/dev/null",
++        "--output",
++        rebase_path(output_file, root_build_dir),
++      ]
++  }
+ }
+ 
+ component("domain_reliability") {
+--- a/components/domain_reliability/bake_in_configs.py
++++ b/components/domain_reliability/bake_in_configs.py
+@@ -490,7 +490,7 @@ def origin_is_whitelisted(origin):
+     domain = origin[8:-1]
+   else:
+     return False
+-  return any(domain == e or domain.endswith('.' + e)  for e in DOMAIN_WHITELIST)
++  return False
+ 
+ 
+ def quote_and_wrap_text(text, width=79, prefix='  "', suffix='"'):
+--- a/components/domain_reliability/google_configs.cc
++++ b/components/domain_reliability/google_configs.cc
+@@ -13,569 +13,8 @@
+ 
+ namespace domain_reliability {
+ 
+-namespace {
+-
+-struct GoogleConfigParams {
+-  bool include_subdomains;
+-
+-  // If true, prepend a collector URL within https://|hostname|/.
+-  bool include_origin_specific_collector;
+-
+-  // If true, also add a config for www.|hostname|.
+-  //
+-  // |include_subdomains| will be false in the extra config, but
+-  // |include_origin_specific_collector| will be respected, and will use the
+-  // www subdomain as the origin for the collector so it matches the config.
+-  bool duplicate_for_www;
+-};
+-
+-const auto kGoogleConfigs = base::MakeFixedFlatMap<std::string_view,
+-                                                   GoogleConfigParams>({
+-    // Origins with subdomains and same-origin collectors. Currently, all
+-    // origins with same-origin collectors also run collectors on their www
+-    // subdomain. (e.g., both foo.com and www.foo.com.)
+-    {"google.ac", {true, true, true}},
+-    {"google.ad", {true, true, true}},
+-    {"google.ae", {true, true, true}},
+-    {"google.af", {true, true, true}},
+-    {"google.ag", {true, true, true}},
+-    {"google.al", {true, true, true}},
+-    {"google.am", {true, true, true}},
+-    {"google.as", {true, true, true}},
+-    {"google.at", {true, true, true}},
+-    {"google.az", {true, true, true}},
+-    {"google.ba", {true, true, true}},
+-    {"google.be", {true, true, true}},
+-    {"google.bf", {true, true, true}},
+-    {"google.bg", {true, true, true}},
+-    {"google.bi", {true, true, true}},
+-    {"google.bj", {true, true, true}},
+-    {"google.bs", {true, true, true}},
+-    {"google.bt", {true, true, true}},
+-    {"google.by", {true, true, true}},
+-    {"google.ca", {true, true, true}},
+-    {"google.cc", {true, true, true}},
+-    {"google.cd", {true, true, true}},
+-    {"google.cf", {true, true, true}},
+-    {"google.cg", {true, true, true}},
+-    {"google.ch", {true, true, true}},
+-    {"google.ci", {true, true, true}},
+-    {"google.cl", {true, true, true}},
+-    {"google.cm", {true, true, true}},
+-    {"google.cn", {true, true, true}},
+-    {"google.co.ao", {true, true, true}},
+-    {"google.co.bw", {true, true, true}},
+-    {"google.co.ck", {true, true, true}},
+-    {"google.co.cr", {true, true, true}},
+-    {"google.co.hu", {true, true, true}},
+-    {"google.co.id", {true, true, true}},
+-    {"google.co.il", {true, true, true}},
+-    {"google.co.im", {true, true, true}},
+-    {"google.co.in", {true, true, true}},
+-    {"google.co.je", {true, true, true}},
+-    {"google.co.jp", {true, true, true}},
+-    {"google.co.ke", {true, true, true}},
+-    {"google.co.kr", {true, true, true}},
+-    {"google.co.ls", {true, true, true}},
+-    {"google.co.ma", {true, true, true}},
+-    {"google.co.mz", {true, true, true}},
+-    {"google.co.nz", {true, true, true}},
+-    {"google.co.th", {true, true, true}},
+-    {"google.co.tz", {true, true, true}},
+-    {"google.co.ug", {true, true, true}},
+-    {"google.co.uk", {true, true, true}},
+-    {"google.co.uz", {true, true, true}},
+-    {"google.co.ve", {true, true, true}},
+-    {"google.co.vi", {true, true, true}},
+-    {"google.co.za", {true, true, true}},
+-    {"google.co.zm", {true, true, true}},
+-    {"google.co.zw", {true, true, true}},
+-    {"google.com.af", {true, true, true}},
+-    {"google.com.ag", {true, true, true}},
+-    {"google.com.ai", {true, true, true}},
+-    {"google.com.ar", {true, true, true}},
+-    {"google.com.au", {true, true, true}},
+-    {"google.com.bd", {true, true, true}},
+-    {"google.com.bh", {true, true, true}},
+-    {"google.com.bn", {true, true, true}},
+-    {"google.com.bo", {true, true, true}},
+-    {"google.com.br", {true, true, true}},
+-    {"google.com.by", {true, true, true}},
+-    {"google.com.bz", {true, true, true}},
+-    {"google.com.cn", {true, true, true}},
+-    {"google.com.co", {true, true, true}},
+-    {"google.com.cu", {true, true, true}},
+-    {"google.com.cy", {true, true, true}},
+-    {"google.com.do", {true, true, true}},
+-    {"google.com.ec", {true, true, true}},
+-    {"google.com.eg", {true, true, true}},
+-    {"google.com.et", {true, true, true}},
+-    {"google.com.fj", {true, true, true}},
+-    {"google.com.ge", {true, true, true}},
+-    {"google.com.gh", {true, true, true}},
+-    {"google.com.gi", {true, true, true}},
+-    {"google.com.gr", {true, true, true}},
+-    {"google.com.gt", {true, true, true}},
+-    {"google.com.hk", {true, true, true}},
+-    {"google.com.iq", {true, true, true}},
+-    {"google.com.jm", {true, true, true}},
+-    {"google.com.jo", {true, true, true}},
+-    {"google.com.kh", {true, true, true}},
+-    {"google.com.kw", {true, true, true}},
+-    {"google.com.lb", {true, true, true}},
+-    {"google.com.ly", {true, true, true}},
+-    {"google.com.mm", {true, true, true}},
+-    {"google.com.mt", {true, true, true}},
+-    {"google.com.mx", {true, true, true}},
+-    {"google.com.my", {true, true, true}},
+-    {"google.com.na", {true, true, true}},
+-    {"google.com.nf", {true, true, true}},
+-    {"google.com.ng", {true, true, true}},
+-    {"google.com.ni", {true, true, true}},
+-    {"google.com.np", {true, true, true}},
+-    {"google.com.nr", {true, true, true}},
+-    {"google.com.om", {true, true, true}},
+-    {"google.com.pa", {true, true, true}},
+-    {"google.com.pe", {true, true, true}},
+-    {"google.com.pg", {true, true, true}},
+-    {"google.com.ph", {true, true, true}},
+-    {"google.com.pk", {true, true, true}},
+-    {"google.com.pl", {true, true, true}},
+-    {"google.com.pr", {true, true, true}},
+-    {"google.com.py", {true, true, true}},
+-    {"google.com.qa", {true, true, true}},
+-    {"google.com.ru", {true, true, true}},
+-    {"google.com.sa", {true, true, true}},
+-    {"google.com.sb", {true, true, true}},
+-    {"google.com.sg", {true, true, true}},
+-    {"google.com.sl", {true, true, true}},
+-    {"google.com.sv", {true, true, true}},
+-    {"google.com.tj", {true, true, true}},
+-    {"google.com.tn", {true, true, true}},
+-    {"google.com.tr", {true, true, true}},
+-    {"google.com.tw", {true, true, true}},
+-    {"google.com.ua", {true, true, true}},
+-    {"google.com.uy", {true, true, true}},
+-    {"google.com.vc", {true, true, true}},
+-    {"google.com.ve", {true, true, true}},
+-    {"google.com.vn", {true, true, true}},
+-    {"google.cv", {true, true, true}},
+-    {"google.cz", {true, true, true}},
+-    {"google.de", {true, true, true}},
+-    {"google.dj", {true, true, true}},
+-    {"google.dk", {true, true, true}},
+-    {"google.dm", {true, true, true}},
+-    {"google.dz", {true, true, true}},
+-    {"google.ee", {true, true, true}},
+-    {"google.es", {true, true, true}},
+-    {"google.fi", {true, true, true}},
+-    {"google.fm", {true, true, true}},
+-    {"google.fr", {true, true, true}},
+-    {"google.ga", {true, true, true}},
+-    {"google.ge", {true, true, true}},
+-    {"google.gg", {true, true, true}},
+-    {"google.gl", {true, true, true}},
+-    {"google.gm", {true, true, true}},
+-    {"google.gp", {true, true, true}},
+-    {"google.gr", {true, true, true}},
+-    {"google.gy", {true, true, true}},
+-    {"google.hk", {true, true, true}},
+-    {"google.hn", {true, true, true}},
+-    {"google.hr", {true, true, true}},
+-    {"google.ht", {true, true, true}},
+-    {"google.hu", {true, true, true}},
+-    {"google.ie", {true, true, true}},
+-    {"google.im", {true, true, true}},
+-    {"google.iq", {true, true, true}},
+-    {"google.ir", {true, true, true}},
+-    {"google.is", {true, true, true}},
+-    {"google.it", {true, true, true}},
+-    {"google.it.ao", {true, true, true}},
+-    {"google.je", {true, true, true}},
+-    {"google.jo", {true, true, true}},
+-    {"google.jp", {true, true, true}},
+-    {"google.kg", {true, true, true}},
+-    {"google.ki", {true, true, true}},
+-    {"google.kz", {true, true, true}},
+-    {"google.la", {true, true, true}},
+-    {"google.li", {true, true, true}},
+-    {"google.lk", {true, true, true}},
+-    {"google.lt", {true, true, true}},
+-    {"google.lu", {true, true, true}},
+-    {"google.lv", {true, true, true}},
+-    {"google.md", {true, true, true}},
+-    {"google.me", {true, true, true}},
+-    {"google.mg", {true, true, true}},
+-    {"google.mk", {true, true, true}},
+-    {"google.ml", {true, true, true}},
+-    {"google.mn", {true, true, true}},
+-    {"google.ms", {true, true, true}},
+-    {"google.mu", {true, true, true}},
+-    {"google.mv", {true, true, true}},
+-    {"google.mw", {true, true, true}},
+-    {"google.ne", {true, true, true}},
+-    {"google.ne.jp", {true, true, true}},
+-    {"google.ng", {true, true, true}},
+-    {"google.nl", {true, true, true}},
+-    {"google.no", {true, true, true}},
+-    {"google.nr", {true, true, true}},
+-    {"google.nu", {true, true, true}},
+-    {"google.off.ai", {true, true, true}},
+-    {"google.pk", {true, true, true}},
+-    {"google.pl", {true, true, true}},
+-    {"google.pn", {true, true, true}},
+-    {"google.ps", {true, true, true}},
+-    {"google.pt", {true, true, true}},
+-    {"google.ro", {true, true, true}},
+-    {"google.rs", {true, true, true}},
+-    {"google.ru", {true, true, true}},
+-    {"google.rw", {true, true, true}},
+-    {"google.sc", {true, true, true}},
+-    {"google.se", {true, true, true}},
+-    {"google.sh", {true, true, true}},
+-    {"google.si", {true, true, true}},
+-    {"google.sk", {true, true, true}},
+-    {"google.sm", {true, true, true}},
+-    {"google.sn", {true, true, true}},
+-    {"google.so", {true, true, true}},
+-    {"google.sr", {true, true, true}},
+-    {"google.st", {true, true, true}},
+-    {"google.td", {true, true, true}},
+-    {"google.tg", {true, true, true}},
+-    {"google.tk", {true, true, true}},
+-    {"google.tl", {true, true, true}},
+-    {"google.tm", {true, true, true}},
+-    {"google.tn", {true, true, true}},
+-    {"google.to", {true, true, true}},
+-    {"google.tt", {true, true, true}},
+-    {"google.us", {true, true, true}},
+-    {"google.uz", {true, true, true}},
+-    {"google.vg", {true, true, true}},
+-    {"google.vu", {true, true, true}},
+-    {"google.ws", {true, true, true}},
+-    {"l.google.com", {true, true, true}},
+-
+-    // google.com is a special case. We have a custom config for www.google.com,
+-    // so set duplicate_for_www = false.
+-    {"google.com", {true, true, false}},
+-
+-    // Origins with subdomains and without same-origin collectors.
+-    {"2mdn.net", {true, false, false}},
+-    {"adgoogle.net", {true, false, false}},
+-    {"admeld.com", {true, false, false}},
+-    {"admob.biz", {true, false, false}},
+-    {"admob.co.in", {true, false, false}},
+-    {"admob.co.kr", {true, false, false}},
+-    {"admob.co.nz", {true, false, false}},
+-    {"admob.co.uk", {true, false, false}},
+-    {"admob.co.za", {true, false, false}},
+-    {"admob.com", {true, false, false}},
+-    {"admob.com.br", {true, false, false}},
+-    {"admob.com.es", {true, false, false}},
+-    {"admob.com.fr", {true, false, false}},
+-    {"admob.com.mx", {true, false, false}},
+-    {"admob.com.pt", {true, false, false}},
+-    {"admob.de", {true, false, false}},
+-    {"admob.dk", {true, false, false}},
+-    {"admob.es", {true, false, false}},
+-    {"admob.fi", {true, false, false}},
+-    {"admob.fr", {true, false, false}},
+-    {"admob.gr", {true, false, false}},
+-    {"admob.hk", {true, false, false}},
+-    {"admob.ie", {true, false, false}},
+-    {"admob.in", {true, false, false}},
+-    {"admob.it", {true, false, false}},
+-    {"admob.jp", {true, false, false}},
+-    {"admob.kr", {true, false, false}},
+-    {"admob.mobi", {true, false, false}},
+-    {"admob.no", {true, false, false}},
+-    {"admob.ph", {true, false, false}},
+-    {"admob.pt", {true, false, false}},
+-    {"admob.sg", {true, false, false}},
+-    {"admob.tw", {true, false, false}},
+-    {"admob.us", {true, false, false}},
+-    {"admob.vn", {true, false, false}},
+-    {"adwhirl.com", {true, false, false}},
+-    {"ampproject.com", {true, false, false}},
+-    {"ampproject.net", {true, false, false}},
+-    {"ampproject.org", {true, false, false}},
+-    {"android.com", {true, false, false}},
+-    {"cdn.ampproject.org", {true, false, false}},
+-    {"chromecast.com", {true, false, false}},
+-    {"chromeexperiments.com", {true, false, false}},
+-    {"chromestatus.com", {true, false, false}},
+-    {"chromium.org", {true, false, false}},
+-    {"clients6.google.com", {true, false, false}},
+-    {"cloudendpointsapis.com", {true, false, false}},
+-    {"dartmotif.com", {true, false, false}},
+-    {"dartsearch.net", {true, false, false}},
+-    {"doubleclick.com", {true, false, false}},
+-    {"doubleclick.ne.jp", {true, false, false}},
+-    {"doubleclick.net", {true, false, false}},
+-    {"doubleclickusercontent.com", {true, false, false}},
+-    {"fls.doubleclick.net", {true, false, false}},
+-    {"g.co", {true, false, false}},
+-    {"g.doubleclick.net", {true, false, false}},
+-    {"ggpht.com", {true, false, false}},
+-    {"gmodules.com", {true, false, false}},
+-    {"goo.gl", {true, false, false}},
+-    {"google-syndication.com", {true, false, false}},
+-    {"google.cat", {true, false, false}},
+-    {"google.info", {true, false, false}},
+-    {"google.jobs", {true, false, false}},
+-    {"google.net", {true, false, false}},
+-    {"google.org", {true, false, false}},
+-    {"google.stackdriver.com", {true, false, false}},
+-    {"googleadservices.com", {true, false, false}},
+-    {"googleadsserving.cn", {true, false, false}},
+-    {"googlealumni.com", {true, false, false}},
+-    {"googleapis.cn", {true, false, false}},
+-    {"googleapis.com", {true, false, false}},
+-    {"googleapps.com", {true, false, false}},
+-    {"googlecbs.com", {true, false, false}},
+-    {"googlecode.com", {true, false, false}},
+-    {"googlecommerce.com", {true, false, false}},
+-    {"googledrive.com", {true, false, false}},
+-    {"googleenterprise.com", {true, false, false}},
+-    {"googlefiber.com", {true, false, false}},
+-    {"googlefiber.net", {true, false, false}},
+-    {"googlegoro.com", {true, false, false}},
+-    {"googlehosted.com", {true, false, false}},
+-    {"googlepayments.com", {true, false, false}},
+-    {"googlesource.com", {true, false, false}},
+-    {"googlesyndication.com", {true, false, false}},
+-    {"googletagmanager.com", {true, false, false}},
+-    {"googletagservices.com", {true, false, false}},
+-    {"googleusercontent.com", {true, false, false}},
+-    {"googlezip.net", {true, false, false}},
+-    {"gstatic.cn", {true, false, false}},
+-    {"gstatic.com", {true, false, false}},
+-    {"gvt3.com", {true, false, false}},
+-    {"gvt9.com", {true, false, false}},
+-    {"picasa.com", {true, false, false}},
+-    {"recaptcha.net", {true, false, false}},
+-    {"stackdriver.com", {true, false, false}},
+-    {"usercontent.google.com", {true, false, false}},
+-    {"waze.com", {true, false, false}},
+-    {"withgoogle.com", {true, false, false}},
+-    {"youtu.be", {true, false, false}},
+-    {"youtube-3rd-party.com", {true, false, false}},
+-    {"youtube-nocookie.com", {true, false, false}},
+-    {"youtube.ae", {true, false, false}},
+-    {"youtube.al", {true, false, false}},
+-    {"youtube.am", {true, false, false}},
+-    {"youtube.at", {true, false, false}},
+-    {"youtube.az", {true, false, false}},
+-    {"youtube.ba", {true, false, false}},
+-    {"youtube.be", {true, false, false}},
+-    {"youtube.bg", {true, false, false}},
+-    {"youtube.bh", {true, false, false}},
+-    {"youtube.bo", {true, false, false}},
+-    {"youtube.ca", {true, false, false}},
+-    {"youtube.cat", {true, false, false}},
+-    {"youtube.ch", {true, false, false}},
+-    {"youtube.cl", {true, false, false}},
+-    {"youtube.co", {true, false, false}},
+-    {"youtube.co.ae", {true, false, false}},
+-    {"youtube.co.at", {true, false, false}},
+-    {"youtube.co.hu", {true, false, false}},
+-    {"youtube.co.id", {true, false, false}},
+-    {"youtube.co.il", {true, false, false}},
+-    {"youtube.co.in", {true, false, false}},
+-    {"youtube.co.jp", {true, false, false}},
+-    {"youtube.co.ke", {true, false, false}},
+-    {"youtube.co.kr", {true, false, false}},
+-    {"youtube.co.ma", {true, false, false}},
+-    {"youtube.co.nz", {true, false, false}},
+-    {"youtube.co.th", {true, false, false}},
+-    {"youtube.co.ug", {true, false, false}},
+-    {"youtube.co.uk", {true, false, false}},
+-    {"youtube.co.ve", {true, false, false}},
+-    {"youtube.co.za", {true, false, false}},
+-    {"youtube.com", {true, false, false}},
+-    {"youtube.com.ar", {true, false, false}},
+-    {"youtube.com.au", {true, false, false}},
+-    {"youtube.com.az", {true, false, false}},
+-    {"youtube.com.bh", {true, false, false}},
+-    {"youtube.com.bo", {true, false, false}},
+-    {"youtube.com.br", {true, false, false}},
+-    {"youtube.com.by", {true, false, false}},
+-    {"youtube.com.co", {true, false, false}},
+-    {"youtube.com.do", {true, false, false}},
+-    {"youtube.com.ee", {true, false, false}},
+-    {"youtube.com.eg", {true, false, false}},
+-    {"youtube.com.es", {true, false, false}},
+-    {"youtube.com.gh", {true, false, false}},
+-    {"youtube.com.gr", {true, false, false}},
+-    {"youtube.com.gt", {true, false, false}},
+-    {"youtube.com.hk", {true, false, false}},
+-    {"youtube.com.hr", {true, false, false}},
+-    {"youtube.com.jm", {true, false, false}},
+-    {"youtube.com.jo", {true, false, false}},
+-    {"youtube.com.kw", {true, false, false}},
+-    {"youtube.com.lb", {true, false, false}},
+-    {"youtube.com.lv", {true, false, false}},
+-    {"youtube.com.mk", {true, false, false}},
+-    {"youtube.com.mt", {true, false, false}},
+-    {"youtube.com.mx", {true, false, false}},
+-    {"youtube.com.my", {true, false, false}},
+-    {"youtube.com.ng", {true, false, false}},
+-    {"youtube.com.om", {true, false, false}},
+-    {"youtube.com.pe", {true, false, false}},
+-    {"youtube.com.ph", {true, false, false}},
+-    {"youtube.com.pk", {true, false, false}},
+-    {"youtube.com.pt", {true, false, false}},
+-    {"youtube.com.qa", {true, false, false}},
+-    {"youtube.com.ro", {true, false, false}},
+-    {"youtube.com.sa", {true, false, false}},
+-    {"youtube.com.sg", {true, false, false}},
+-    {"youtube.com.tn", {true, false, false}},
+-    {"youtube.com.tr", {true, false, false}},
+-    {"youtube.com.tw", {true, false, false}},
+-    {"youtube.com.ua", {true, false, false}},
+-    {"youtube.com.uy", {true, false, false}},
+-    {"youtube.com.ve", {true, false, false}},
+-    {"youtube.cz", {true, false, false}},
+-    {"youtube.de", {true, false, false}},
+-    {"youtube.dk", {true, false, false}},
+-    {"youtube.ee", {true, false, false}},
+-    {"youtube.es", {true, false, false}},
+-    {"youtube.fi", {true, false, false}},
+-    {"youtube.fr", {true, false, false}},
+-    {"youtube.ge", {true, false, false}},
+-    {"youtube.gr", {true, false, false}},
+-    {"youtube.gt", {true, false, false}},
+-    {"youtube.hk", {true, false, false}},
+-    {"youtube.hr", {true, false, false}},
+-    {"youtube.hu", {true, false, false}},
+-    {"youtube.ie", {true, false, false}},
+-    {"youtube.in", {true, false, false}},
+-    {"youtube.is", {true, false, false}},
+-    {"youtube.it", {true, false, false}},
+-    {"youtube.jo", {true, false, false}},
+-    {"youtube.jp", {true, false, false}},
+-    {"youtube.kr", {true, false, false}},
+-    {"youtube.lk", {true, false, false}},
+-    {"youtube.lt", {true, false, false}},
+-    {"youtube.lv", {true, false, false}},
+-    {"youtube.ma", {true, false, false}},
+-    {"youtube.md", {true, false, false}},
+-    {"youtube.me", {true, false, false}},
+-    {"youtube.mk", {true, false, false}},
+-    {"youtube.mx", {true, false, false}},
+-    {"youtube.my", {true, false, false}},
+-    {"youtube.ng", {true, false, false}},
+-    {"youtube.nl", {true, false, false}},
+-    {"youtube.no", {true, false, false}},
+-    {"youtube.pe", {true, false, false}},
+-    {"youtube.ph", {true, false, false}},
+-    {"youtube.pk", {true, false, false}},
+-    {"youtube.pl", {true, false, false}},
+-    {"youtube.pr", {true, false, false}},
+-    {"youtube.pt", {true, false, false}},
+-    {"youtube.qa", {true, false, false}},
+-    {"youtube.ro", {true, false, false}},
+-    {"youtube.rs", {true, false, false}},
+-    {"youtube.ru", {true, false, false}},
+-    {"youtube.sa", {true, false, false}},
+-    {"youtube.se", {true, false, false}},
+-    {"youtube.sg", {true, false, false}},
+-    {"youtube.si", {true, false, false}},
+-    {"youtube.sk", {true, false, false}},
+-    {"youtube.sn", {true, false, false}},
+-    {"youtube.tn", {true, false, false}},
+-    {"youtube.ua", {true, false, false}},
+-    {"youtube.ug", {true, false, false}},
+-    {"youtube.uy", {true, false, false}},
+-    {"youtube.vn", {true, false, false}},
+-    {"youtubeeducation.com", {true, false, false}},
+-    {"youtubemobilesupport.com", {true, false, false}},
+-    {"ytimg.com", {true, false, false}},
+-
+-    // Origins without subdomains and with same-origin collectors.
+-    {"accounts.google.com", {false, true, false}},
+-    {"apis.google.com", {false, true, false}},
+-    {"app.google.stackdriver.com", {false, true, false}},
+-    {"b.mail.google.com", {false, true, false}},
+-    {"chatenabled.mail.google.com", {false, true, false}},
+-    {"ddm.google.com", {false, true, false}},
+-    {"gmail.com", {false, true, false}},
+-    {"gmail.google.com", {false, true, false}},
+-    {"mail-attachment.googleusercontent.com", {false, true, false}},
+-    {"mail.google.com", {false, true, false}},
+-    {"www.gmail.com", {false, true, false}},
+-
+-    // Origins without subdomains or same-origin collectors.
+-    {"ad.doubleclick.net", {false, false, false}},
+-    {"drive.google.com", {false, false, false}},
+-    {"redirector.googlevideo.com", {false, false, false}},
+-});
+-
+-const char* const kGoogleStandardCollectors[] = {
+-    "https://beacons.gcp.gvt2.com/domainreliability/upload",
+-    "https://beacons.gvt2.com/domainreliability/upload",
+-    "https://beacons2.gvt2.com/domainreliability/upload",
+-    "https://beacons3.gvt2.com/domainreliability/upload",
+-    "https://beacons4.gvt2.com/domainreliability/upload",
+-    "https://beacons5.gvt2.com/domainreliability/upload",
+-    "https://beacons5.gvt3.com/domainreliability/upload",
+-    "https://clients2.google.com/domainreliability/upload",
+-};
+-
+-const char* const kGoogleOriginSpecificCollectorPathString =
+-    "/domainreliability/upload";
+-
+-std::unique_ptr<const DomainReliabilityConfig> CreateGoogleConfig(
+-    std::string_view hostname,
+-    const GoogleConfigParams& params,
+-    bool is_www) {
+-  CHECK(params.duplicate_for_www || !is_www);
+-
+-  bool include_subdomains = params.include_subdomains && !is_www;
+-
+-  auto config = std::make_unique<DomainReliabilityConfig>();
+-  GURL url(base::StrCat({"https://", (is_www ? "www." : ""), hostname, "/"}));
+-  config->origin = url::Origin::Create(url);
+-  config->include_subdomains = include_subdomains;
+-  config->collectors.clear();
+-  if (params.include_origin_specific_collector) {
+-    GURL::Replacements replacements;
+-    replacements.SetPathStr(kGoogleOriginSpecificCollectorPathString);
+-    config->collectors.push_back(
+-        std::make_unique<GURL>(url.ReplaceComponents(replacements)));
+-  }
+-  for (const char* collector : kGoogleStandardCollectors) {
+-    config->collectors.push_back(std::make_unique<GURL>(collector));
+-  }
+-  config->success_sample_rate = 0.05;
+-  config->failure_sample_rate = 1.00;
+-  config->path_prefixes.clear();
+-  return config;
+-}
+-
+-}  // namespace
+-
+ std::unique_ptr<const DomainReliabilityConfig> MaybeGetGoogleConfig(
+     const std::string& hostname) {
+-  bool is_www_subdomain =
+-      base::StartsWith(hostname, "www.", base::CompareCase::SENSITIVE);
+-
+-  const auto itr = kGoogleConfigs.find(hostname);
+-  if (itr != std::end(kGoogleConfigs)) {
+-    return CreateGoogleConfig(hostname, itr->second, /*is_www=*/false);
+-  }
+-  std::string hostname_parent = net::GetSuperdomain(hostname);
+-  const auto parent_it = kGoogleConfigs.find(hostname_parent);
+-  if (parent_it != std::end(kGoogleConfigs)) {
+-    const GoogleConfigParams& params = parent_it->second;
+-    if (is_www_subdomain && params.duplicate_for_www) {
+-      return CreateGoogleConfig(hostname_parent, params, /*is_www=*/true);
+-    }
+-    if (params.include_subdomains) {
+-      return CreateGoogleConfig(hostname_parent, params, /*is_www=*/false);
+-    }
+-  }
+-
+   return nullptr;
+ }
+ 
+@@ -583,12 +22,6 @@ std::vector<std::unique_ptr<const Domain
+ GetAllGoogleConfigsForTesting() {
+   std::vector<std::unique_ptr<const DomainReliabilityConfig>> configs_out;
+ 
+-  for (const auto& [hostname, params] : kGoogleConfigs) {
+-    configs_out.push_back(CreateGoogleConfig(hostname, params, false));
+-    if (params.duplicate_for_www) {
+-      configs_out.push_back(CreateGoogleConfig(hostname, params, true));
+-    }
+-  }
+   return configs_out;
+ }
+ 
+--- a/components/domain_reliability/uploader.cc
++++ b/components/domain_reliability/uploader.cc
+@@ -80,7 +80,7 @@ class DomainReliabilityUploaderImpl : pu
+     if (discard_uploads_)
+       discarded_upload_count_++;
+ 
+-    if (discard_uploads_ || shutdown_) {
++    if (true) {
+       DVLOG(1) << "Discarding report instead of uploading.";
+       UploadResult result;
+       result.status = UploadResult::SUCCESS;

--- a/patches/ungoogled/core/ungoogled-chromium/disable-fonts-googleapis-references.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/disable-fonts-googleapis-references.patch
@@ -1,0 +1,70 @@
+# Disables references to fonts.googleapis.com
+
+--- a/components/dom_distiller/content/browser/dom_distiller_viewer_source.cc
++++ b/components/dom_distiller/content/browser/dom_distiller_viewer_source.cc
+@@ -308,7 +308,7 @@ bool DomDistillerViewerSource::ShouldSer
+ std::string DomDistillerViewerSource::GetContentSecurityPolicy(
+     network::mojom::CSPDirectiveName directive) {
+   if (directive == network::mojom::CSPDirectiveName::StyleSrc) {
+-    return "style-src 'self' https://fonts.googleapis.com;";
++    return "style-src 'self';";
+   } else if (directive == network::mojom::CSPDirectiveName::ChildSrc) {
+     return "child-src *;";
+   } else if (directive ==
+--- a/components/dom_distiller/core/html/preview.html
++++ b/components/dom_distiller/core/html/preview.html
+@@ -11,7 +11,7 @@ found in the LICENSE file.
+   <meta name="theme-color" id="theme-color">
+   <title>Title goes here and it could be kind of lengthy - Publisher name</title>
+   <link href="../css/distilledpage.css" rel="stylesheet" type="text/css">
+-  <link href='https://fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'>
++  <link href='chrome://resources/css/roboto.css' rel='stylesheet' type='text/css'>
+   <style>
+     .english :lang(th) {display: none}
+     .english :lang(zh) {display: none}
+--- a/third_party/crashpad/crashpad/doc/support/crashpad_doxygen.css
++++ b/third_party/crashpad/crashpad/doc/support/crashpad_doxygen.css
+@@ -12,11 +12,11 @@
+  * See the License for the specific language governing permissions and
+  * limitations under the License. */
+ 
+-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap');
+-@import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@0,200..900;1,200..900&display=swap');
++@import "chrome://resources/css/roboto.css";
+ 
+ :root {
+   --font-family-normal: 'Noto Sans',
++    'Roboto',
+     'Lucida Grande',
+     'Lucida Sans Unicode',
+     Helvetica,
+--- a/tools/md_browser/base.css
++++ b/tools/md_browser/base.css
+@@ -16,8 +16,7 @@
+ 
+ /* Common styles and definitions. */
+ 
+-@import "//fonts.googleapis.com/css?family=Open+Sans:300,400,700&subset=latin,cyrillic-ext,greek-ext,cyrillic,greek,vietnamese,latin-ext";
+-@import "//fonts.googleapis.com/css?family=Source+Code+Pro";
++@import "chrome://resources/css/roboto.css";
+ *,
+ *::after,
+ *::before {
+@@ -72,7 +71,7 @@ ul, ol {
+   user-select: none;
+ }
+ .u-monospace {
+-  font-family: 'Source Code Pro', monospace;
++  font-family: monospace;
+ }
+ 
+ /* Common.soy */
+@@ -82,7 +81,7 @@ ul, ol {
+   color: #000;
+   display: -ms-flexbox;
+   display: flex;
+-  font: 14px/1.54 'Open Sans', sans-serif;
++  font: 14px/1.54 'Roboto', sans-serif;
+   min-height: 100vh;
+   -ms-flex-direction: column;
+   flex-direction: column;

--- a/patches/ungoogled/core/ungoogled-chromium/disable-gaia.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/disable-gaia.patch
@@ -1,0 +1,71 @@
+# Disables Gaia code
+# Somehow it is still activated even without being signed-in: https://github.com/ungoogled-software/ungoogled-chromium/issues/104
+
+--- a/google_apis/gaia/gaia_auth_fetcher.cc
++++ b/google_apis/gaia/gaia_auth_fetcher.cc
+@@ -246,65 +246,6 @@ void GaiaAuthFetcher::CreateAndStartGaia
+     network::mojom::CredentialsMode credentials_mode,
+     const net::NetworkTrafficAnnotationTag& traffic_annotation) {
+   DCHECK(!fetch_pending_) << "Tried to fetch two things at once!";
+-
+-  auto resource_request = std::make_unique<network::ResourceRequest>();
+-  resource_request->url = gaia_gurl;
+-  original_url_ = gaia_gurl;
+-
+-  if (credentials_mode != network::mojom::CredentialsMode::kOmit &&
+-      credentials_mode !=
+-          network::mojom::CredentialsMode::kOmitBug_775438_Workaround) {
+-    CHECK(gaia::HasGaiaSchemeHostPort(gaia_gurl) ||
+-          gaia_gurl.DomainIs("googleapis.com") ||
+-          GaiaConfig::GetInstance() != nullptr)
+-        << gaia_gurl;
+-
+-    url::Origin origin = url::Origin::Create(gaia_gurl);
+-    resource_request->site_for_cookies =
+-        net::SiteForCookies::FromOrigin(origin);
+-    resource_request->trusted_params =
+-        network::ResourceRequest::TrustedParams();
+-    resource_request->trusted_params->isolation_info =
+-        net::IsolationInfo::CreateForInternalRequest(origin);
+-  }
+-
+-  if (!body.empty()) {
+-    resource_request->method = "POST";
+-  }
+-
+-  resource_request->headers = request_headers;
+-
+-  resource_request->credentials_mode = credentials_mode;
+-
+-  url_loader_ = network::SimpleURLLoader::Create(std::move(resource_request),
+-                                                 traffic_annotation);
+-  if (!body.empty()) {
+-    DCHECK(!body_content_type.empty());
+-    url_loader_->AttachStringForUpload(body, body_content_type);
+-  }
+-
+-  url_loader_->SetAllowHttpErrorResults(true);
+-
+-  VLOG(2) << "Gaia fetcher URL: " << gaia_gurl.spec();
+-  VLOG(2) << "Gaia fetcher headers: " << request_headers.ToString();
+-  VLOG(2) << "Gaia fetcher body: " << body;
+-
+-  // Fetchers are sometimes cancelled because a network change was detected,
+-  // especially at startup and after sign-in on ChromeOS. Retrying once should
+-  // be enough in those cases; let the fetcher retry up to 3 times just in case.
+-  // http://crbug.com/163710
+-  url_loader_->SetRetryOptions(
+-      3, network::SimpleURLLoader::RETRY_ON_NETWORK_CHANGE);
+-
+-  fetch_pending_ = true;
+-
+-  // Unretained is OK below as |url_loader_| is owned by this.
+-  url_loader_->DownloadToString(
+-      url_loader_factory_.get(),
+-      base::BindOnce(&GaiaAuthFetcher::OnURLLoadComplete,
+-                     base::Unretained(this)),
+-      // Limit to 1 MiB.
+-      1024 * 1024);
+ }
+ 
+ // static

--- a/patches/ungoogled/core/ungoogled-chromium/disable-gcm.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/disable-gcm.patch
@@ -1,0 +1,156 @@
+# Disable Google Cloud Messaging (GCM) client
+
+--- a/components/gcm_driver/gcm_client_impl.cc
++++ b/components/gcm_driver/gcm_client_impl.cc
+@@ -296,38 +296,6 @@ void GCMClientImpl::Initialize(
+ }
+ 
+ void GCMClientImpl::Start(StartMode start_mode) {
+-  DCHECK_NE(UNINITIALIZED, state_);
+-  DCHECK(io_task_runner_->RunsTasksInCurrentSequence());
+-
+-  if (state_ == LOADED) {
+-    // Start the GCM if not yet.
+-    if (start_mode == IMMEDIATE_START) {
+-      // Give up the scheduling to wipe out the store since now some one starts
+-      // to use GCM.
+-      destroying_gcm_store_ptr_factory_.InvalidateWeakPtrs();
+-
+-      StartGCM();
+-    }
+-    return;
+-  }
+-
+-  // The delay start behavior will be abandoned when Start has been called
+-  // once with IMMEDIATE_START behavior.
+-  if (start_mode == IMMEDIATE_START)
+-    start_mode_ = IMMEDIATE_START;
+-
+-  // Bail out if the loading is not started or completed.
+-  if (state_ != INITIALIZED)
+-    return;
+-
+-  // Once the loading is completed, the check-in will be initiated.
+-  // If we're in lazy start mode, don't create a new store since none is really
+-  // using GCM functionality yet.
+-  gcm_store_->Load((start_mode == IMMEDIATE_START) ? GCMStore::CREATE_IF_MISSING
+-                                                   : GCMStore::DO_NOT_CREATE,
+-                   base::BindOnce(&GCMClientImpl::OnLoadCompleted,
+-                                  weak_ptr_factory_.GetWeakPtr()));
+-  state_ = LOADING;
+ }
+ 
+ void GCMClientImpl::OnLoadCompleted(
+@@ -431,6 +399,7 @@ void GCMClientImpl::StartGCM() {
+ 
+ void GCMClientImpl::InitializeMCSClient() {
+   DCHECK(network_connection_tracker_);
++  return;
+   std::vector<GURL> endpoints;
+   endpoints.push_back(gservices_settings_.GetMCSMainEndpoint());
+   GURL fallback_endpoint = gservices_settings_.GetMCSFallbackEndpoint();
+@@ -482,8 +451,6 @@ void GCMClientImpl::OnReady(const std::v
+ void GCMClientImpl::StartMCSLogin() {
+   DCHECK_EQ(READY, state_);
+   DCHECK(device_checkin_info_.IsValid());
+-  mcs_client_->Login(device_checkin_info_.android_id,
+-                     device_checkin_info_.secret);
+ }
+ 
+ void GCMClientImpl::DestroyStoreWhenNotNeeded() {
+@@ -554,8 +521,6 @@ void GCMClientImpl::SetLastTokenFetchTim
+ void GCMClientImpl::UpdateHeartbeatTimer(
+     std::unique_ptr<base::RetainingOneShotTimer> timer) {
+   DCHECK(io_task_runner_->RunsTasksInCurrentSequence());
+-  DCHECK(mcs_client_);
+-  mcs_client_->UpdateHeartbeatTimer(std::move(timer));
+ }
+ 
+ void GCMClientImpl::AddInstanceIDData(const std::string& app_id,
+@@ -598,35 +563,14 @@ void GCMClientImpl::GetInstanceIDData(co
+ void GCMClientImpl::AddHeartbeatInterval(const std::string& scope,
+                                          int interval_ms) {
+   DCHECK(io_task_runner_->RunsTasksInCurrentSequence());
+-  DCHECK(mcs_client_);
+-  mcs_client_->AddHeartbeatInterval(scope, interval_ms);
+ }
+ 
+ void GCMClientImpl::RemoveHeartbeatInterval(const std::string& scope) {
+   DCHECK(io_task_runner_->RunsTasksInCurrentSequence());
+-  DCHECK(mcs_client_);
+-  mcs_client_->RemoveHeartbeatInterval(scope);
+ }
+ 
+ void GCMClientImpl::StartCheckin() {
+   DCHECK(io_task_runner_->RunsTasksInCurrentSequence());
+-
+-  // Make sure no checkin is in progress.
+-  if (checkin_request_)
+-    return;
+-
+-  checkin_proto::ChromeBuildProto chrome_build_proto;
+-  ToCheckinProtoVersion(chrome_build_info_, &chrome_build_proto);
+-
+-  CheckinRequest::RequestInfo request_info(
+-      device_checkin_info_.android_id, device_checkin_info_.secret,
+-      gservices_settings_.digest(), chrome_build_proto);
+-  checkin_request_ = std::make_unique<CheckinRequest>(
+-      gservices_settings_.GetCheckinURL(), request_info, GetGCMBackoffPolicy(),
+-      base::BindOnce(&GCMClientImpl::OnCheckinCompleted,
+-                     weak_ptr_factory_.GetWeakPtr()),
+-      url_loader_factory_, io_task_runner_, &recorder_);
+-  checkin_request_->Start();
+ }
+ 
+ void GCMClientImpl::OnCheckinCompleted(
+@@ -683,24 +627,6 @@ void GCMClientImpl::SetGServicesSettings
+ 
+ void GCMClientImpl::SchedulePeriodicCheckin() {
+   DCHECK(io_task_runner_->RunsTasksInCurrentSequence());
+-
+-  // Make sure no checkin is in progress.
+-  if (checkin_request_.get() || !device_checkin_info_.accounts_set)
+-    return;
+-
+-  // There should be only one periodic checkin pending at a time. Removing
+-  // pending periodic checkin to schedule a new one.
+-  periodic_checkin_ptr_factory_.InvalidateWeakPtrs();
+-
+-  base::TimeDelta time_to_next_checkin = GetTimeToNextCheckin();
+-  if (time_to_next_checkin.is_negative())
+-    time_to_next_checkin = base::TimeDelta();
+-
+-  io_task_runner_->PostDelayedTask(
+-      FROM_HERE,
+-      base::BindOnce(&GCMClientImpl::StartCheckin,
+-                     periodic_checkin_ptr_factory_.GetWeakPtr()),
+-      time_to_next_checkin);
+ }
+ 
+ base::TimeDelta GCMClientImpl::GetTimeToNextCheckin() const {
+@@ -1124,25 +1050,6 @@ void GCMClientImpl::Send(const std::stri
+                          const OutgoingMessage& message) {
+   DCHECK_EQ(state_, READY);
+   DCHECK(io_task_runner_->RunsTasksInCurrentSequence());
+-
+-  mcs_proto::DataMessageStanza stanza;
+-  stanza.set_ttl(message.time_to_live);
+-  stanza.set_sent(clock_->Now().ToInternalValue() /
+-                  base::Time::kMicrosecondsPerSecond);
+-  stanza.set_id(message.id);
+-  stanza.set_from(kSendMessageFromValue);
+-  stanza.set_to(receiver_id);
+-  stanza.set_category(app_id);
+-
+-  for (auto iter = message.data.begin(); iter != message.data.end(); ++iter) {
+-    mcs_proto::AppData* app_data = stanza.add_app_data();
+-    app_data->set_key(iter->first);
+-    app_data->set_value(iter->second);
+-  }
+-
+-  MCSMessage mcs_message(stanza);
+-  DVLOG(1) << "MCS message size: " << mcs_message.size();
+-  mcs_client_->SendMessage(mcs_message);
+ }
+ 
+ std::string GCMClientImpl::GetStateString() const {

--- a/patches/ungoogled/core/ungoogled-chromium/disable-google-host-detection.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/disable-google-host-detection.patch
@@ -1,0 +1,797 @@
+# Disables various detections of Google hosts and functionality specific to them
+
+--- a/chrome/browser/glic/glic_user_status_request.cc
++++ b/chrome/browser/glic/glic_user_status_request.cc
+@@ -64,11 +64,6 @@ std::vector<std::string> GlicUserStatusR
+     return headers;
+   }
+ 
+-  // The endpoint is always a Google property.
+-  headers.push_back(
+-      base::StrCat({variations::kClientDataHeader, ": ",
+-                    variations->headers_map.at(
+-                        variations::mojom::GoogleWebVisibility::FIRST_PARTY)}));
+ 
+   return headers;
+ }
+--- a/chrome/browser/ui/webui/suggest_internals/suggest_internals_handler.cc
++++ b/chrome/browser/ui/webui/suggest_internals/suggest_internals_handler.cc
+@@ -70,9 +70,6 @@ void SuggestInternalsHandler::OnRequestC
+       suggest_internals::mojom::Request::New();
+   mojom_request->id = request_id;
+   mojom_request->url = request->url;
+-  std::string variations_header;
+-  variations::GetVariationsHeader(*request, &variations_header);
+-  mojom_request->data[variations::kClientDataHeader] = variations_header;
+   mojom_request->data[request->method] = request->url.spec();
+   mojom_request->status = suggest_internals::mojom::RequestStatus::kCreated;
+   page_->OnRequestCreated(std::move(mojom_request));
+--- a/chrome/common/google_url_loader_throttle.cc
++++ b/chrome/common/google_url_loader_throttle.cc
+@@ -24,10 +24,6 @@
+ #include "services/network/public/mojom/x_frame_options.mojom.h"
+ #include "url/origin.h"
+ 
+-#if BUILDFLAG(ENABLE_EXTENSIONS)
+-#include "extensions/common/extension_urls.h"
+-#endif
+-
+ #if BUILDFLAG(ENABLE_BOUND_SESSION_CREDENTIALS)
+ #include "chrome/common/bound_session_request_throttled_handler.h"
+ #include "net/cookies/cookie_util.h"
+@@ -172,71 +168,6 @@ void GoogleURLLoaderThrottle::DetachFrom
+ void GoogleURLLoaderThrottle::WillStartRequest(
+     network::ResourceRequest* request,
+     bool* defer) {
+-  if (dynamic_params_->force_safe_search) {
+-    GURL new_url;
+-    safe_search_api::ForceGoogleSafeSearch(request->url, &new_url);
+-    if (!new_url.is_empty()) {
+-      request->url = new_url;
+-    }
+-  }
+-
+-  static_assert(safe_search_api::YOUTUBE_RESTRICT_OFF == 0,
+-                "OFF must be first");
+-  if (dynamic_params_->youtube_restrict >
+-          safe_search_api::YOUTUBE_RESTRICT_OFF &&
+-      dynamic_params_->youtube_restrict <
+-          safe_search_api::YOUTUBE_RESTRICT_COUNT) {
+-    safe_search_api::ForceYouTubeRestrict(
+-        request->url, &request->cors_exempt_headers,
+-        static_cast<safe_search_api::YouTubeRestrictMode>(
+-            dynamic_params_->youtube_restrict));
+-  }
+-
+-  if (!dynamic_params_->allowed_domains_for_apps.empty() &&
+-      request->url.DomainIs("google.com")) {
+-    request->cors_exempt_headers.SetHeader(
+-        safe_search_api::kGoogleAppsAllowedDomains,
+-        dynamic_params_->allowed_domains_for_apps);
+-  }
+-
+-#if BUILDFLAG(IS_ANDROID)
+-  if (!client_data_header_.empty() &&
+-      google_util::IsGoogleAssociatedDomainUrl(request->url)) {
+-    request->cors_exempt_headers.SetHeader(kCCTClientDataHeader,
+-                                           client_data_header_);
+-  }
+-#endif
+-#if BUILDFLAG(ENABLE_BOUND_SESSION_CREDENTIALS)
+-  // `network::mojom::RequestDestination::kDocument` means that this is a
+-  // navigation request.
+-  is_main_frame_navigation_ =
+-      request->is_outermost_main_frame &&
+-      request->destination == network::mojom::RequestDestination::kDocument;
+-  // TODO(crbug.com/372169462): `request->SendsCookies()` cannot be used for now
+-  // because it excludes `kSameOrigin` requests.
+-  sends_cookies_ =
+-      request->credentials_mode == network::mojom::CredentialsMode::kInclude ||
+-      request->credentials_mode == network::mojom::CredentialsMode::kSameOrigin;
+-  if (sends_cookies_) {
+-    RequestBoundSessionStatus status = GetRequestBoundSessionStatus(
+-        request->url, dynamic_params_->bound_session_throttler_params);
+-    if (IsCoveredRequestBoundSessionStatus(status)) {
+-      is_covered_by_bound_session_ = true;
+-    }
+-    if (status == RequestBoundSessionStatus::kCoveredWithMissingCookie) {
+-      CHECK(bound_session_request_throttled_handler_);
+-      *defer = true;
+-      is_deferred_for_bound_session_ = true;
+-      CHECK(!bound_session_request_throttled_start_time_.has_value());
+-      bound_session_request_throttled_start_time_ = base::TimeTicks::Now();
+-      bound_session_request_throttled_handler_->HandleRequestBlockedOnCookie(
+-          request->url,
+-          base::BindOnce(
+-              &GoogleURLLoaderThrottle::OnDeferRequestForBoundSessionCompleted,
+-              weak_factory_.GetWeakPtr()));
+-    }
+-  }
+-#endif
+ }
+ 
+ void GoogleURLLoaderThrottle::WillRedirectRequest(
+@@ -246,97 +177,12 @@ void GoogleURLLoaderThrottle::WillRedire
+     std::vector<std::string>* to_be_removed_headers,
+     net::HttpRequestHeaders* modified_headers,
+     net::HttpRequestHeaders* modified_cors_exempt_headers) {
+-  // URLLoaderThrottles can only change the redirect URL when the network
+-  // service is enabled. The non-network service path handles this in
+-  // ChromeNetworkDelegate.
+-  if (dynamic_params_->force_safe_search) {
+-    safe_search_api::ForceGoogleSafeSearch(redirect_info->new_url,
+-                                           &redirect_info->new_url);
+-  }
+-
+-  if (dynamic_params_->youtube_restrict >
+-          safe_search_api::YOUTUBE_RESTRICT_OFF &&
+-      dynamic_params_->youtube_restrict <
+-          safe_search_api::YOUTUBE_RESTRICT_COUNT) {
+-    safe_search_api::ForceYouTubeRestrict(
+-        redirect_info->new_url, modified_cors_exempt_headers,
+-        static_cast<safe_search_api::YouTubeRestrictMode>(
+-            dynamic_params_->youtube_restrict));
+-  }
+-
+-  if (!dynamic_params_->allowed_domains_for_apps.empty() &&
+-      redirect_info->new_url.DomainIs("google.com")) {
+-    modified_cors_exempt_headers->SetHeader(
+-        safe_search_api::kGoogleAppsAllowedDomains,
+-        dynamic_params_->allowed_domains_for_apps);
+-  }
+-
+-#if BUILDFLAG(IS_ANDROID)
+-  if (!client_data_header_.empty() &&
+-      !google_util::IsGoogleAssociatedDomainUrl(redirect_info->new_url)) {
+-    to_be_removed_headers->push_back(kCCTClientDataHeader);
+-  }
+-#endif
+-#if BUILDFLAG(ENABLE_BOUND_SESSION_CREDENTIALS)
+-  if (sends_cookies_) {
+-    RequestBoundSessionStatus status = GetRequestBoundSessionStatus(
+-        redirect_info->new_url,
+-        dynamic_params_->bound_session_throttler_params);
+-    if (IsCoveredRequestBoundSessionStatus(status)) {
+-      is_covered_by_bound_session_ = true;
+-    }
+-    if (status == RequestBoundSessionStatus::kCoveredWithMissingCookie) {
+-      CHECK(bound_session_request_throttled_handler_);
+-      *defer = true;
+-      is_deferred_for_bound_session_ = true;
+-      CHECK(!bound_session_request_throttled_start_time_.has_value());
+-      bound_session_request_throttled_start_time_ = base::TimeTicks::Now();
+-      bound_session_request_throttled_handler_->HandleRequestBlockedOnCookie(
+-          redirect_info->new_url,
+-          base::BindOnce(
+-              &GoogleURLLoaderThrottle::OnDeferRequestForBoundSessionCompleted,
+-              weak_factory_.GetWeakPtr()));
+-    }
+-  }
+-#endif
+ }
+ 
+ void GoogleURLLoaderThrottle::WillProcessResponse(
+     const GURL& response_url,
+     network::mojom::URLResponseHead* response_head,
+     bool* defer) {
+-#if BUILDFLAG(ENABLE_BOUND_SESSION_CREDENTIALS)
+-  if (is_covered_by_bound_session_) {
+-    RecordBoundSessionStatusMetrics(is_deferred_for_bound_session_,
+-                                    is_main_frame_navigation_,
+-                                    /*is_request_succeeded=*/true);
+-  }
+-  if (deferred_request_resume_trigger_) {
+-    UMA_HISTOGRAM_ENUMERATION(
+-        "Signin.BoundSessionCredentials.DeferredRequestUnblockTrigger.Success",
+-        deferred_request_resume_trigger_.value());
+-  }
+-#endif  // BUILDFLAG(ENABLE_BOUND_SESSION_CREDENTIALS)
+-
+-#if BUILDFLAG(ENABLE_EXTENSIONS)
+-  // Built-in additional protection for the chrome web store origin by
+-  // ensuring that the X-Frame-Options protection mechanism is set to either
+-  // DENY or SAMEORIGIN.
+-  if (response_url.SchemeIsHTTPOrHTTPS() &&
+-      extension_urls::IsWebstoreDomain(response_url)) {
+-    // TODO(mkwst): Consider shifting this to a NavigationThrottle rather than
+-    // relying on implicit ordering between this check and the time at which
+-    // ParsedHeaders is created.
+-    CHECK(response_head);
+-    CHECK(response_head->parsed_headers);
+-    if (response_head->parsed_headers->xfo !=
+-        network::mojom::XFrameOptionsValue::kDeny) {
+-      response_head->headers->SetHeader("X-Frame-Options", "SAMEORIGIN");
+-      response_head->parsed_headers->xfo =
+-          network::mojom::XFrameOptionsValue::kSameOrigin;
+-    }
+-  }
+-#endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+ }
+ 
+ #if BUILDFLAG(ENABLE_BOUND_SESSION_CREDENTIALS)
+--- a/components/google/core/common/google_util.cc
++++ b/components/google/core/common/google_util.cc
+@@ -33,117 +33,6 @@ namespace google_util {
+ 
+ namespace {
+ 
+-bool IsPathHomePageBase(std::string_view path) {
+-  return (path == "/") || (path == "/webhp");
+-}
+-
+-// Removes a single trailing dot if present in |host|.
+-void StripTrailingDot(std::string_view* host) {
+-  if (base::EndsWith(*host, ".")) {
+-    host->remove_suffix(1);
+-  }
+-}
+-
+-// True if the given canonical |host| is "[www.]<domain_in_lower_case>.<TLD>"
+-// with a valid TLD that appears in |allowed_tlds|. If |subdomain_permission| is
+-// ALLOW_SUBDOMAIN, we check against host "*.<domain_in_lower_case>.<TLD>"
+-// instead.
+-template <typename Container>
+-bool IsValidHostName(std::string_view host,
+-                     std::string_view domain_in_lower_case,
+-                     SubdomainPermission subdomain_permission,
+-                     const Container& allowed_tlds) {
+-  // Fast path to avoid searching the registry set.
+-  if (host.find(domain_in_lower_case) == std::string_view::npos) {
+-    return false;
+-  }
+-
+-  size_t tld_length =
+-      net::registry_controlled_domains::GetCanonicalHostRegistryLength(
+-          host, net::registry_controlled_domains::EXCLUDE_UNKNOWN_REGISTRIES,
+-          net::registry_controlled_domains::EXCLUDE_PRIVATE_REGISTRIES);
+-  if ((tld_length == 0) || (tld_length == std::string::npos)) {
+-    return false;
+-  }
+-
+-  // Removes the tld and the preceding dot.
+-  std::string_view host_minus_tld =
+-      host.substr(0, host.length() - tld_length - 1);
+-
+-  std::string_view tld = host.substr(host.length() - tld_length);
+-  // Remove the trailing dot from tld if present, as for Google domains it's the
+-  // same page.
+-  StripTrailingDot(&tld);
+-  if (!allowed_tlds.contains(tld)) {
+-    return false;
+-  }
+-
+-  if (base::EqualsCaseInsensitiveASCII(host_minus_tld, domain_in_lower_case)) {
+-    return true;
+-  }
+-
+-  if (subdomain_permission == ALLOW_SUBDOMAIN) {
+-    std::string dot_domain = base::StrCat({".", domain_in_lower_case});
+-    return base::EndsWith(host_minus_tld, dot_domain,
+-                          base::CompareCase::INSENSITIVE_ASCII);
+-  }
+-
+-  std::string www_domain = base::StrCat({"www.", domain_in_lower_case});
+-  return base::EqualsCaseInsensitiveASCII(host_minus_tld, www_domain);
+-}
+-
+-// True if |url| is a valid URL with HTTP or HTTPS scheme. If |port_permission|
+-// is DISALLOW_NON_STANDARD_PORTS, this also requires |url| to use the standard
+-// port for its scheme (80 for HTTP, 443 for HTTPS).
+-bool IsValidURL(const GURL& url, PortPermission port_permission) {
+-  static bool g_ignore_port_numbers =
+-      base::CommandLine::ForCurrentProcess()->HasSwitch(
+-          switches::kIgnoreGooglePortNumbers);
+-  return url.is_valid() && url.SchemeIsHTTPOrHTTPS() &&
+-         (!url.has_port() || g_ignore_port_numbers ||
+-          (port_permission == ALLOW_NON_STANDARD_PORTS));
+-}
+-
+-bool IsCanonicalHostGoogleHostname(std::string_view canonical_host,
+-                                   SubdomainPermission subdomain_permission) {
+-  const GURL& base_url(CommandLineGoogleBaseURL());
+-  if (base_url.is_valid() && (canonical_host == base_url.host())) {
+-    return true;
+-  }
+-
+-  static constexpr auto google_tlds =
+-      base::MakeFixedFlatSet<std::string_view>({GOOGLE_TLD_LIST});
+-  return IsValidHostName(canonical_host, "google", subdomain_permission,
+-                         google_tlds);
+-}
+-
+-bool IsCanonicalHostYoutubeHostname(std::string_view canonical_host,
+-                                    SubdomainPermission subdomain_permission) {
+-  static constexpr auto youtube_tlds =
+-      base::MakeFixedFlatSet<std::string_view>({YOUTUBE_TLD_LIST});
+-
+-  return IsValidHostName(canonical_host, "youtube", subdomain_permission,
+-                         youtube_tlds);
+-}
+-
+-// True if |url| is a valid URL with a host that is in the static list of
+-// Google subdomains for google search, and an HTTP or HTTPS scheme. Requires
+-// |url| to use the standard port for its scheme (80 for HTTP, 443 for HTTPS).
+-bool IsGoogleSearchSubdomainUrl(const GURL& url) {
+-  if (!IsValidURL(url, PortPermission::DISALLOW_NON_STANDARD_PORTS)) {
+-    return false;
+-  }
+-
+-  std::string_view host(url.host());
+-  StripTrailingDot(&host);
+-
+-  static constexpr auto google_subdomains =
+-      base::MakeFixedFlatSet<std::string_view>(
+-          {"ipv4.google.com", "ipv6.google.com"});
+-
+-  return google_subdomains.contains(host);
+-}
+-
+ }  // namespace
+ 
+ BASE_FEATURE(kIsViewerGoogleSearchUrl, base::FEATURE_ENABLED_BY_DEFAULT);
+@@ -153,13 +42,6 @@ BASE_FEATURE(kIsViewerGoogleSearchUrl, b
+ const char kGoogleHomepageURL[] = "https://www.google.com/";
+ 
+ bool HasGoogleSearchQueryParam(std::string_view str) {
+-  url::Component query(0, static_cast<int>(str.length())), key, value;
+-  while (url::ExtractQueryKeyValue(str, &query, &key, &value)) {
+-    std::string_view key_str = str.substr(key.begin, key.len);
+-    if (key_str == "q" || key_str == "as_q" || key_str == "imgurl") {
+-      return true;
+-    }
+-  }
+   return false;
+ }
+ 
+@@ -170,175 +52,53 @@ std::string GetGoogleLocale(const std::s
+ 
+ GURL AppendGoogleLocaleParam(const GURL& url,
+                              const std::string& application_locale) {
+-  return net::AppendQueryParameter(url, "hl",
+-                                   GetGoogleLocale(application_locale));
++  return url;
+ }
+ 
+ std::string GetGoogleCountryCode(const GURL& google_homepage_url) {
+-  std::string_view google_hostname = google_homepage_url.host();
+-  // TODO(igorcov): This needs a fix for case when the host has a trailing dot,
+-  // like "google.com./". https://crbug.com/720295.
+-  const size_t last_dot = google_hostname.find_last_of('.');
+-  if (last_dot == std::string::npos) {
+-    return std::string();
+-  }
+-  std::string_view country_code = google_hostname.substr(last_dot + 1);
+-  // Assume the com TLD implies the US.
+-  if (country_code == "com") {
+-    return "us";
+-  }
+-  // Google uses the Unicode Common Locale Data Repository (CLDR), and the CLDR
+-  // code for the UK is "gb".
+-  if (country_code == "uk") {
+-    return "gb";
+-  }
+-  // Catalonia does not have a CLDR country code, since it's a region in Spain,
+-  // so use Spain instead.
+-  if (country_code == "cat") {
+-    return "es";
+-  }
+-  return std::string(country_code);
++  return "nolocale";
+ }
+ 
+ GURL GetGoogleSearchURL(const GURL& google_homepage_url) {
+-  // To transform the homepage URL into the corresponding search URL, add the
+-  // "search" and the "q=" query string.
+-  GURL::Replacements replacements;
+-  replacements.SetPathStr("search");
+-  replacements.SetQueryStr("q=");
+-  return google_homepage_url.ReplaceComponents(replacements);
++  return google_homepage_url;
+ }
+ 
+ const GURL& CommandLineGoogleBaseURL() {
+-  // Unit tests may add command-line flags after the first call to this
+-  // function, so we don't simply initialize a static |base_url| directly and
+-  // then unconditionally return it.
+-  static base::NoDestructor<std::string> switch_value;
+   static base::NoDestructor<GURL> base_url;
+-  std::string current_switch_value(
+-      base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(
+-          switches::kGoogleBaseURL));
+-  if (current_switch_value != *switch_value) {
+-    *switch_value = current_switch_value;
+-    *base_url = url_formatter::FixupURL(*switch_value);
+-    if (!base_url->is_valid() || base_url->has_query() || base_url->has_ref()) {
+-      *base_url = GURL();
+-    }
+-  }
++  *base_url = GURL();
+   return *base_url;
+ }
+ 
+ bool StartsWithCommandLineGoogleBaseURL(const GURL& url) {
+-  const GURL& base_url(CommandLineGoogleBaseURL());
+-  return base_url.is_valid() &&
+-         base::StartsWith(url.possibly_invalid_spec(), base_url.spec(),
+-                          base::CompareCase::SENSITIVE);
++  return false;
+ }
+ 
+ bool IsGoogleDomainUrl(const GURL& url,
+                        SubdomainPermission subdomain_permission,
+                        PortPermission port_permission) {
+-  return IsValidURL(url, port_permission) &&
+-         IsCanonicalHostGoogleHostname(url.host(), subdomain_permission);
++  return false;
+ }
+ 
+ bool IsGoogleHostname(std::string_view host,
+                       SubdomainPermission subdomain_permission) {
+-  url::CanonHostInfo host_info;
+-  return IsCanonicalHostGoogleHostname(net::CanonicalizeHost(host, &host_info),
+-                                       subdomain_permission);
++  return false;
+ }
+ 
+ bool IsGoogleHomePageUrl(const GURL& url) {
+-  // First check to see if this has a Google domain.
+-  if (!IsGoogleDomainUrl(url, DISALLOW_SUBDOMAIN,
+-                         DISALLOW_NON_STANDARD_PORTS) &&
+-      !IsGoogleSearchSubdomainUrl(url)) {
+-    return false;
+-  }
+-
+-  // Make sure the path is a known home page path.
+-  std::string_view path(url.path());
+-  return IsPathHomePageBase(path) ||
+-         base::StartsWith(path, "/ig", base::CompareCase::INSENSITIVE_ASCII);
++  return false;
+ }
+ 
+ bool IsGoogleSearchUrl(const GURL& url) {
+-  // First check to see if this has a Google domain.
+-  if (!IsGoogleDomainUrl(url, DISALLOW_SUBDOMAIN,
+-                         DISALLOW_NON_STANDARD_PORTS) &&
+-      !IsGoogleSearchSubdomainUrl(url)) {
+-    return false;
+-  }
+-
+-  // Make sure the path is a known search path.
+-  std::string_view path(url.path());
+-  bool is_home_page_base = IsPathHomePageBase(path);
+-  bool is_search_url =
+-      is_home_page_base || path == "/search" || path == "/imgres";
+-  if (base::FeatureList::IsEnabled(kIsViewerGoogleSearchUrl)) {
+-    is_search_url |= path == "/viewer" || base::StartsWith(path, "/viewer/");
+-  }
+-  if (!is_search_url) {
+-    return false;
+-  }
+-
+-  // Check for query parameter in URL parameter and hash fragment, depending on
+-  // the path type.
+-  return HasGoogleSearchQueryParam(url.ref()) ||
+-         (!is_home_page_base && HasGoogleSearchQueryParam(url.query()));
++  return false;
+ }
+ 
+ bool IsYoutubeDomainUrl(const GURL& url,
+                         SubdomainPermission subdomain_permission,
+                         PortPermission port_permission) {
+-  return IsValidURL(url, port_permission) &&
+-         IsCanonicalHostYoutubeHostname(url.host(), subdomain_permission);
++  return false;
+ }
+ 
+ bool IsGoogleAssociatedDomainUrl(const GURL& url) {
+-  if (IsGoogleDomainUrl(url, ALLOW_SUBDOMAIN, ALLOW_NON_STANDARD_PORTS)) {
+-    return true;
+-  }
+-
+-  if (IsYoutubeDomainUrl(url, ALLOW_SUBDOMAIN, ALLOW_NON_STANDARD_PORTS)) {
+-    return true;
+-  }
+-
+-  // Some domains don't have international TLD extensions, so testing for them
+-  // is very straightforward.
+-  static auto kSuffixesToSetHeadersFor = std::to_array<const char*>({
+-      ".android.com",
+-      ".doubleclick.com",
+-      ".doubleclick.net",
+-      ".ggpht.com",
+-      ".googleadservices.com",
+-      ".googleapis.com",
+-      ".googlesyndication.com",
+-      ".googleusercontent.com",
+-      ".googlevideo.com",
+-      ".gstatic.com",
+-      ".litepages.googlezip.net",
+-      ".youtubekids.com",
+-      ".ytimg.com",
+-  });
+-  const std::string_view host(url.host());
+-  for (auto* i : kSuffixesToSetHeadersFor) {
+-    if (base::EndsWith(host, i, base::CompareCase::INSENSITIVE_ASCII)) {
+-      return true;
+-    }
+-  }
+-
+-  // Exact hostnames in lowercase to set headers for.
+-  static auto kHostsToSetHeadersFor = std::to_array<const char*>({
+-      "googleweblight.com",
+-  });
+-  for (auto* i : kHostsToSetHeadersFor) {
+-    if (base::EqualsCaseInsensitiveASCII(host, i)) {
+-      return true;
+-    }
+-  }
+-
+   return false;
+ }
+ 
+--- a/components/page_load_metrics/google/browser/google_url_util.cc
++++ b/components/page_load_metrics/google/browser/google_url_util.cc
+@@ -14,39 +14,7 @@
+ namespace page_load_metrics {
+ 
+ std::optional<std::string> GetGoogleHostnamePrefix(const GURL& url) {
+-  const size_t registry_length =
+-      net::registry_controlled_domains::GetRegistryLength(
+-          url,
+-
+-          // Do not include unknown registries (registries that don't have any
+-          // matches in effective TLD names).
+-          net::registry_controlled_domains::EXCLUDE_UNKNOWN_REGISTRIES,
+-
+-          // Do not include private registries, such as appspot.com. We don't
+-          // want to match URLs like www.google.appspot.com.
+-          net::registry_controlled_domains::EXCLUDE_PRIVATE_REGISTRIES);
+-
+-  const std::string_view hostname = url.host();
+-  if (registry_length == 0 || registry_length == std::string::npos ||
+-      registry_length >= hostname.length()) {
+-    return std::nullopt;
+-  }
+-
+-  // Removes the tld and the preceding dot.
+-  const std::string_view hostname_minus_registry =
+-      hostname.substr(0, hostname.length() - (registry_length + 1));
+-
+-  if (hostname_minus_registry == "google") {
+-    return std::string("");
+-  }
+-
+-  if (!base::EndsWith(hostname_minus_registry, ".google",
+-                      base::CompareCase::INSENSITIVE_ASCII)) {
+     return std::nullopt;
+-  }
+-
+-  return std::string(hostname_minus_registry.substr(
+-      0, hostname_minus_registry.length() - strlen(".google")));
+ }
+ 
+ bool IsGoogleHostname(const GURL& url) {
+@@ -54,9 +22,7 @@ bool IsGoogleHostname(const GURL& url) {
+ }
+ 
+ bool IsGoogleSearchHostname(const GURL& url) {
+-  std::optional<std::string> result =
+-      page_load_metrics::GetGoogleHostnamePrefix(url);
+-  return result && result.value() == "www";
++  return false;
+ }
+ 
+ bool IsProbablyGoogleSearchUrl(const GURL& url) {
+--- a/components/search_engines/template_url.cc
++++ b/components/search_engines/template_url.cc
+@@ -625,10 +625,7 @@ std::u16string TemplateURLRef::SearchTer
+ bool TemplateURLRef::HasGoogleBaseURLs(
+     const SearchTermsData& search_terms_data) const {
+   ParseIfNecessary(search_terms_data);
+-  return std::ranges::any_of(replacements_, [](const Replacement& replacement) {
+-    return replacement.type == GOOGLE_BASE_URL ||
+-           replacement.type == GOOGLE_BASE_SUGGEST_URL;
+-  });
++  return false;
+ }
+ 
+ bool TemplateURLRef::ExtractSearchTermsFromURL(
+--- a/components/variations/net/variations_http_headers.cc
++++ b/components/variations/net/variations_http_headers.cc
+@@ -32,10 +32,6 @@
+ 
+ namespace variations {
+ 
+-// The name string for the header for variations information.
+-// Note that prior to M33 this header was named X-Chrome-Variations.
+-const char kClientDataHeader[] = "X-Client-Data";
+-
+ namespace {
+ 
+ // The result of checking whether a request to a URL should have variations
+@@ -124,16 +120,7 @@ URLValidationResult GetUrlValidationResu
+ // rather than `headers`, to be exempted from CORS checks, and to avoid exposing
+ // the header to service workers.
+ bool ShouldAppendVariationsHeader(const GURL& url, InIncognito incognito) {
+-  // Note the criteria for attaching client experiment headers:
+-  // 1. We only transmit to Google owned domains which can evaluate
+-  // experiments.
+-  //    1a. These include hosts which have a standard postfix such as:
+-  //         *.doubleclick.net or *.googlesyndication.com or
+-  //         exactly www.googleadservices.com or
+-  //         international TLD domains *.google.<TLD> or *.youtube.<TLD>.
+-  // 2. Only transmit for non-Incognito profiles.
+-  return incognito == InIncognito::kNo &&
+-         GetUrlValidationResult(url) == URLValidationResult::kShouldAppend;
++  return false;
+ }
+ 
+ // Returns non-empty `std::string` if `variations_headers` has a header value
+@@ -141,19 +128,7 @@ bool ShouldAppendVariationsHeader(const
+ std::optional<std::string> GetHeaderValue(
+     const variations::mojom::VariationsHeaders* variations_headers,
+     bool is_first_party_context) {
+-  if (!variations_headers) {
+-    return std::nullopt;
+-  }
+-
+-  const std::string& header = variations_headers->headers_map.at(
+-      is_first_party_context
+-          ? variations::mojom::GoogleWebVisibility::FIRST_PARTY
+-          : variations::mojom::GoogleWebVisibility::ANY);
+-  if (header.empty()) {
+-    // For the X-Client-Data header, only include non-empty variation IDs.
+     return std::nullopt;
+-  }
+-  return header;
+ }
+ 
+ // Returns true if the request is sent from a Google web property, i.e. from a
+@@ -289,15 +264,6 @@ bool AppendVariationsHeader(const GURL&
+                             InIncognito incognito,
+                             SignedIn signed_in,
+                             network::ResourceRequest* request) {
+-  // TODO(crbug.com/40135370): Consider passing the Owner instead of
+-  // `Owner::kUnknown` if we can get it. However, we really only care about
+-  // having the owner for requests initiated on the renderer side.
+-  if (auto header = GetVariationsHeaderValueToAppend(
+-          url, incognito, signed_in,
+-          IsFirstPartyContext(Owner::kUnknown, *request))) {
+-    request->cors_exempt_headers.SetHeaderIfMissing(kClientDataHeader, *header);
+-    return true;
+-  }
+   return false;
+ }
+ 
+@@ -321,14 +287,6 @@ bool AppendVariationsHeaderWithCustomVal
+     const variations::mojom::VariationsHeaders* variations_headers,
+     Owner owner,
+     network::ResourceRequest* request) {
+-  if (variations_headers && ShouldAppendVariationsHeader(url, incognito)) {
+-    if (std::optional<std::string> header_value = GetHeaderValue(
+-            variations_headers, IsFirstPartyContext(owner, *request))) {
+-      request->cors_exempt_headers.SetHeaderIfMissing(kClientDataHeader,
+-                                                      *header_value);
+-      return true;
+-    }
+-  }
+   return false;
+ }
+ 
+@@ -361,9 +319,6 @@ void RemoveVariationsHeaderIfNeeded(
+     const network::mojom::URLResponseHead& response_head,
+     InIncognito incognito,
+     std::vector<std::string>* to_be_removed_headers) {
+-  if (!ShouldAppendVariationsHeader(redirect_info.new_url, incognito)) {
+-    to_be_removed_headers->push_back(kClientDataHeader);
+-  }
+ }
+ 
+ std::unique_ptr<network::SimpleURLLoader>
+@@ -400,28 +355,21 @@ CreateSimpleURLLoaderWithVariationsHeade
+ }
+ 
+ bool HasVariationsHeader(const network::ResourceRequest& request) {
+-  std::string unused_header;
+-  return GetVariationsHeader(request, &unused_header);
++  return false;
+ }
+ 
+ bool GetVariationsHeader(const network::ResourceRequest& request,
+                          std::string* out) {
+-  std::optional<std::string> header_value =
+-      request.cors_exempt_headers.GetHeader(kClientDataHeader);
+-  if (header_value) {
+-    out->swap(header_value.value());
+-  }
+-  return header_value.has_value();
++  return false;
+ }
+ 
+ bool ShouldAppendVariationsHeaderForTesting(const GURL& url,  // IN-TEST
+                                             InIncognito incognito) {
+-  return ShouldAppendVariationsHeader(url, incognito);
++  return false;
+ }
+ 
+ void UpdateCorsExemptHeaderForVariations(
+     network::mojom::NetworkContextParams* params) {
+-  params->cors_exempt_header_list.push_back(kClientDataHeader);
+ }
+ 
+ }  // namespace variations
+--- a/content/browser/preloading/prefetch/prefetch_resource_request_utils.cc
++++ b/content/browser/preloading/prefetch/prefetch_resource_request_utils.cc
+@@ -165,41 +165,11 @@ void AddVariationsHeaderForPrefetch(
+     bool is_first_party_context_for_variations) {
+   CHECK(prefetch_request.browser_context());
+ 
+-  // Add X-Client-Data header with experiment IDs from field trials.
+-  if (std::optional<std::string> value =
+-          variations::GetVariationsHeaderValueToAppend(
+-              request_url,
+-              prefetch_request.browser_context()->IsOffTheRecord()
+-                  ? variations::InIncognito::kYes
+-                  : variations::InIncognito::kNo,
+-              variations::SignedIn::kNo,
+-              is_first_party_context_for_variations)) {
+-    cors_exempt_headers.SetHeaderIfMissing(variations::kClientDataHeader,
+-                                           *value);
+-  }
+ }
+ 
+ void UpdateVariationsHeaderForPrefetch(
+     network::ResourceRequest& resource_request,
+     const PrefetchRequest& prefetch_request) {
+-  // Remove `variations::kClientDataHeader` from `resource_request_->headers`,
+-  // to keep the existing behavior. While `AddVariationsHeaderForPrefetch()`
+-  // adds `variations::kClientDataHeader` to
+-  // `resource_request->cors_exempt_headers`, it's also possible that
+-  // `variations::kClientDataHeader` is added to `resource_request_->headers`
+-  // via `request().additional_headers()`.
+-  //
+-  // TODO(crbug.com/467177773): The processing of
+-  // `variations::kClientDataHeader` is separated from other headers, to keep
+-  // the behavior of `variations::kClientDataHeader` during the main fixes for
+-  // crbug.com/467177773. The behavior of `variations::kClientDataHeader` should
+-  // be fixed together with other related bugs, by e.g. restructuring
+-  // `variations::AppendVariationsHeader()` and plumbing the
+-  // `variations::kClientDataHeader` removal and modification to
+-  // `FollowRedirect()`.
+-  // TODO(crbug.com/454082776): Remove `variations::kClientDataHeader` from
+-  // `resource_request->cors_exempt_headers`.
+-  resource_request.headers.RemoveHeader(variations::kClientDataHeader);
+   AddVariationsHeaderForPrefetch(resource_request.cors_exempt_headers,
+                                  resource_request.url, prefetch_request,
+                                  IsFirstPartyContext(resource_request));
+--- a/net/base/url_util.cc
++++ b/net/base/url_util.cc
+@@ -549,28 +549,6 @@ bool HasGoogleHost(const GURL& url) {
+ }
+ 
+ bool IsGoogleHost(std::string_view host) {
+-  static const char* kGoogleHostSuffixes[] = {
+-      ".google.com",
+-      ".youtube.com",
+-      ".gmail.com",
+-      ".doubleclick.net",
+-      ".gstatic.com",
+-      ".googlevideo.com",
+-      ".googleusercontent.com",
+-      ".googlesyndication.com",
+-      ".google-analytics.com",
+-      ".googleadservices.com",
+-      ".googleapis.com",
+-      ".ytimg.com",
+-  };
+-  for (const char* suffix : kGoogleHostSuffixes) {
+-    // Here it's possible to get away with faster case-sensitive comparisons
+-    // because the list above is all lowercase, and a GURL's host name will
+-    // always be canonicalized to lowercase as well.
+-    if (host.ends_with(suffix)) {
+-      return true;
+-    }
+-  }
+   return false;
+ }
+ 

--- a/patches/ungoogled/core/ungoogled-chromium/disable-mei-preload.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/disable-mei-preload.patch
@@ -1,0 +1,35 @@
+# Disables use of a binary for preloading the Media Engagement index
+# Said binary is: chrome/browser/resources/media/mei_preload/preloaded_data.pb
+# According to media/base/media_switches (for PreloadMediaEngagementData), it
+# "enables a list of origins to be considered as having a high MEI until there
+# is enough local data to determine the user's preferred behavior." This feature
+# does not seem to outweigh the benefit of removing the binary, thus this patch.
+
+--- a/chrome/BUILD.gn
++++ b/chrome/BUILD.gn
+@@ -372,7 +372,6 @@ if (!is_android && !is_mac) {
+     }
+ 
+     data_deps += [
+-      "//chrome/browser/resources/media/mei_preload:component",
+       "//chrome/browser/web_applications/isolated_web_apps/key_distribution/preload:component",
+       "//components/privacy_sandbox/privacy_sandbox_attestations/preload:component",
+       "//third_party/widevine/cdm",
+@@ -1198,7 +1197,6 @@ if (is_win) {
+       ":optimization_guide_library",
+       ":swiftshader_binaries",
+       ":widevine_cdm_library",
+-      "//chrome/browser/resources/media/mei_preload:component_bundle",
+       "//chrome/browser/web_applications/isolated_web_apps/key_distribution/preload:component_bundle",
+       "//components/privacy_sandbox/privacy_sandbox_attestations/preload:component_bundle",
+     ]
+--- a/chrome/browser/resources/BUILD.gn
++++ b/chrome/browser/resources/BUILD.gn
+@@ -120,7 +120,6 @@ group("resources") {
+   if (is_mac) {
+     public_deps += [
+       "unexportable_keys_internals:resources",
+-      "//chrome/browser/resources/media/mei_preload:component",
+       "//components/privacy_sandbox/privacy_sandbox_attestations/preload:component",
+     ]
+   }

--- a/patches/ungoogled/core/ungoogled-chromium/disable-network-time-tracker.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/disable-network-time-tracker.patch
@@ -1,0 +1,17 @@
+# Disable Network Time Tracker
+# This connects to Google to check if the system time is correct when a website certificate
+# date seems incorrect, according to https://bugs.chromium.org/p/chromium/issues/detail?id=725232,
+# Fixes https://github.com/ungoogled-software/ungoogled-chromium/issues/302
+
+--- a/components/network_time/network_time_tracker.cc
++++ b/components/network_time/network_time_tracker.cc
+@@ -325,8 +325,7 @@ void NetworkTimeTracker::UpdateNetworkTi
+ }
+ 
+ bool NetworkTimeTracker::AreTimeFetchesEnabled() const {
+-  return is_initialized() &&
+-         base::FeatureList::IsEnabled(kNetworkTimeServiceQuerying);
++  return false;
+ }
+ 
+ NetworkTimeTracker::FetchBehavior NetworkTimeTracker::GetFetchBehavior() const {

--- a/patches/ungoogled/core/ungoogled-chromium/disable-privacy-sandbox.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/disable-privacy-sandbox.patch
@@ -1,0 +1,336 @@
+--- a/chrome/BUILD.gn
++++ b/chrome/BUILD.gn
+@@ -373,7 +373,6 @@ if (!is_android && !is_mac) {
+ 
+     data_deps += [
+       "//chrome/browser/web_applications/isolated_web_apps/key_distribution/preload:component",
+-      "//components/privacy_sandbox/privacy_sandbox_attestations/preload:component",
+       "//third_party/widevine/cdm",
+     ]
+ 
+@@ -1198,7 +1197,6 @@ if (is_win) {
+       ":swiftshader_binaries",
+       ":widevine_cdm_library",
+       "//chrome/browser/web_applications/isolated_web_apps/key_distribution/preload:component_bundle",
+-      "//components/privacy_sandbox/privacy_sandbox_attestations/preload:component_bundle",
+     ]
+ 
+     if (is_chrome_branded) {
+--- a/chrome/browser/resources/BUILD.gn
++++ b/chrome/browser/resources/BUILD.gn
+@@ -120,7 +120,6 @@ group("resources") {
+   if (is_mac) {
+     public_deps += [
+       "unexportable_keys_internals:resources",
+-      "//components/privacy_sandbox/privacy_sandbox_attestations/preload:component",
+     ]
+   }
+ 
+--- a/components/browsing_data/content/browsing_data_model.cc
++++ b/components/browsing_data/content/browsing_data_model.cc
+@@ -995,12 +995,6 @@ void BrowsingDataModel::PopulateFromDisk
+       base::FeatureList::IsEnabled(network::features::kSharedStorageAPI);
+   bool is_shared_dictionary_enabled = base::FeatureList::IsEnabled(
+       network::features::kCompressionDictionaryTransport);
+-  bool is_interest_group_enabled =
+-      base::FeatureList::IsEnabled(network::features::kInterestGroupStorage);
+-  bool is_attribution_reporting_enabled = base::FeatureList::IsEnabled(
+-      attribution_reporting::features::kConversionMeasurement);
+-  bool is_private_aggregation_enabled =
+-      base::FeatureList::IsEnabled(blink::features::kPrivateAggregationApi);
+ 
+   base::RepeatingClosure completion =
+       base::BindRepeating([](const base::OnceClosure&) {},
+@@ -1037,27 +1031,7 @@ void BrowsingDataModel::PopulateFromDisk
+         base::BindOnce(&OnSharedDictionaryUsageLoaded, this, completion));
+   }
+ 
+-  // Interest Groups
+-  if (is_interest_group_enabled) {
+-    content::InterestGroupManager* manager =
+-        storage_partition_->GetInterestGroupManager();
+-    if (manager) {
+-      manager->GetAllInterestGroupDataKeys(
+-          base::BindOnce(&OnInterestGroupsLoaded, this, completion));
+-    }
+-  }
+-
+-  // Attribution Reporting
+-  if (is_attribution_reporting_enabled) {
+-    storage_partition_->GetAttributionDataModel()->GetAllDataKeys(
+-        base::BindOnce(&OnAttributionReportingLoaded, this, completion));
+-  }
+ 
+-  // Private Aggregation
+-  if (is_private_aggregation_enabled) {
+-    storage_partition_->GetPrivateAggregationDataModel()->GetAllDataKeys(
+-        base::BindOnce(&OnPrivateAggregationLoaded, this, completion));
+-  }
+ 
+ #if BUILDFLAG(ENABLE_LIBRARY_CDMS)
+   storage_partition_->GetCdmStorageDataModel()->GetUsagePerAllStorageKeys(
+--- a/components/privacy_sandbox/privacy_sandbox_settings_impl.cc
++++ b/components/privacy_sandbox/privacy_sandbox_settings_impl.cc
+@@ -129,7 +129,7 @@ std::set<browsing_topics::Topic> GetTopi
+ 
+ // static
+ bool PrivacySandboxSettingsImpl::IsAllowed(Status status) {
+-  return status == Status::kAllowed;
++  return false;
+ }
+ 
+ // static
+@@ -808,7 +808,7 @@ void PrivacySandboxSettingsImpl::SetTopi
+ }
+ 
+ bool PrivacySandboxSettingsImpl::IsPrivacySandboxRestricted() const {
+-  return delegate_->IsPrivacySandboxRestricted();
++  return true;
+ }
+ 
+ bool PrivacySandboxSettingsImpl::IsPrivacySandboxCurrentlyUnrestricted() const {
+@@ -877,11 +877,7 @@ PrivacySandboxSettingsImpl::GetPrivacySa
+     return Status::kIncognitoProfile;
+   }
+ 
+-  if (IsPrivacySandboxRestricted() && !should_ignore_restriction) {
+     return Status::kRestricted;
+-  }
+-
+-  return Status::kAllowed;
+ }
+ 
+ PrivacySandboxSettingsImpl::Status
+--- a/content/browser/attribution_reporting/attribution_suitable_context.cc
++++ b/content/browser/attribution_reporting/attribution_suitable_context.cc
+@@ -44,82 +44,13 @@ bool UkmSourceIdAllowed(RenderFrameHostI
+ // static
+ std::optional<AttributionSuitableContext> AttributionSuitableContext::Create(
+     NavigationHandle* navigation_handle) {
+-  RenderFrameHostImpl* rfh = static_cast<RenderFrameHostImpl*>(
+-      navigation_handle->GetRenderFrameHost());
+-  std::optional<AttributionSuitableContext> context = Create(rfh);
+-  // Override the UKM source ID from the associated ongoing navigation handle as
+-  // `AttributionHost::GetPageUkmSourceId()` is not updated until the navigation
+-  // finishes.
+-  if (context && UkmSourceIdAllowed(rfh)) {
+-    context->ukm_source_id_ = navigation_handle->GetNextPageUkmSourceId();
+-  }
+-  return context;
++  return std::nullopt;
+ }
+ 
+ // static
+ std::optional<AttributionSuitableContext> AttributionSuitableContext::Create(
+     RenderFrameHostImpl* initiator_frame) {
+-  if (!initiator_frame) {
+     return std::nullopt;
+-  }
+-
+-  if (!base::FeatureList::IsEnabled(
+-          attribution_reporting::features::kConversionMeasurement)) {
+-    return std::nullopt;
+-  }
+-
+-  if (!initiator_frame->IsFeatureEnabled(
+-          network::mojom::PermissionsPolicyFeature::kAttributionReporting)) {
+-    return std::nullopt;
+-  }
+-  RenderFrameHostImpl* initiator_root_frame =
+-      initiator_frame->GetOutermostMainFrame();
+-  CHECK(initiator_root_frame);
+-
+-  // We need a suitable origin here because we need to be able to eventually
+-  // store it as either the source or destination origin. Using
+-  // `is_web_secure_context` only would allow opaque origins to pass through,
+-  // but they cannot be handled by the storage layer.
+-  std::optional<attribution_reporting::SuitableOrigin>
+-      initiator_root_frame_origin = SuitableOrigin::Create(
+-          initiator_root_frame->GetLastCommittedOrigin());
+-  if (!initiator_root_frame_origin.has_value()) {
+-    return std::nullopt;
+-  }
+-  // If the `initiator_frame` is a subframe, it's origin's security isn't
+-  // covered by the SuitableOrigin check above, we therefore validate that it's
+-  // origin is secure using `is_web_secure_context`.
+-  if (initiator_frame != initiator_root_frame &&
+-      !initiator_frame->policy_container_host()
+-           ->policies()
+-           .is_web_secure_context) {
+-    return std::nullopt;
+-  }
+-
+-  auto* web_contents = WebContents::FromRenderFrameHost(initiator_frame);
+-  if (!web_contents) {
+-    return std::nullopt;
+-  }
+-  auto* manager = AttributionManager::FromWebContents(web_contents);
+-  CHECK(manager);
+-
+-  auto* attribution_host = AttributionHost::FromWebContents(web_contents);
+-  CHECK(attribution_host);
+-
+-  AttributionDataHostManager* data_host_manager = manager->GetDataHostManager();
+-  CHECK(data_host_manager);
+-
+-  return AttributionSuitableContext(
+-      /*context_origin=*/std::move(initiator_root_frame_origin.value()),
+-      initiator_frame->IsNestedWithinFencedFrame(),
+-      initiator_root_frame->GetGlobalId(), initiator_frame->navigation_id(),
+-      attribution_host->GetMostRecentNavigationInputEvent(),
+-      AttributionOsLevelManager::GetAttributionReportingOsRegistrars(
+-          web_contents),
+-      UkmSourceIdAllowed(initiator_root_frame)
+-          ? attribution_host->GetPageUkmSourceId()
+-          : ukm::kInvalidSourceId,
+-      data_host_manager->AsWeakPtr());
+ }
+ 
+ // static
+--- a/content/browser/interest_group/ad_auction_service_impl.cc
++++ b/content/browser/interest_group/ad_auction_service_impl.cc
+@@ -190,11 +190,6 @@ AdAuctionServiceImpl::BiddingAndAuctionD
+ void AdAuctionServiceImpl::CreateMojoService(
+     RenderFrameHost* render_frame_host,
+     mojo::PendingReceiver<blink::mojom::AdAuctionService> receiver) {
+-  CHECK(render_frame_host);
+-
+-  // The object is bound to the lifetime of `render_frame_host` and the mojo
+-  // connection. See DocumentService for details.
+-  new AdAuctionServiceImpl(*render_frame_host, std::move(receiver));
+ }
+ 
+ void AdAuctionServiceImpl::JoinInterestGroup(
+--- a/content/browser/storage_partition_impl.cc
++++ b/content/browser/storage_partition_impl.cc
+@@ -1465,38 +1465,7 @@ void StoragePartitionImpl::Initialize(
+ 
+   bucket_manager_ = std::make_unique<BucketManager>(this);
+ 
+-  if (base::FeatureList::IsEnabled(
+-          attribution_reporting::features::kConversionMeasurement)) {
+-    // The Conversion Measurement API is not available in Incognito mode, but
+-    // this is enforced by the `AttributionManagerImpl` itself for better error
+-    // reporting and metrics.
+-    attribution_manager_ = std::make_unique<AttributionManagerImpl>(
+-        this, path, special_storage_policy_);
+-  }
+ 
+-  if (base::FeatureList::IsEnabled(network::features::kInterestGroupStorage)) {
+-    // Auction worklets on non-Android use dedicated processes; on Android due
+-    // to high cost of process launch they try to reuse renderers.
+-    interest_group_manager_ = std::make_unique<InterestGroupManagerImpl>(
+-        path, is_in_memory(),
+-#if BUILDFLAG(IS_ANDROID)
+-        InterestGroupManagerImpl::ProcessMode::kInRenderer,
+-#else
+-        InterestGroupManagerImpl::ProcessMode::kDedicated,
+-#endif
+-        GetURLLoaderFactoryForBrowserProcess(),
+-        base::BindRepeating(&BrowserContext::GetKAnonymityServiceDelegate,
+-                            // This use of Unretained is safe since the browser
+-                            // context owns this storage partition.
+-                            base::Unretained(browser_context_)));
+-  }
+-
+-  // The Topics API is not available in Incognito mode.
+-  if (!is_in_memory() &&
+-      base::FeatureList::IsEnabled(network::features::kBrowsingTopics)) {
+-    browsing_topics_site_data_manager_ =
+-        std::make_unique<BrowsingTopicsSiteDataManagerImpl>(path);
+-  }
+ 
+   GeneratedCodeCacheSettings settings =
+       GetContentClient()->browser()->GetGeneratedCodeCacheSettings(
+@@ -1525,8 +1494,6 @@ void StoragePartitionImpl::Initialize(
+ 
+   font_access_manager_ = FontAccessManager::Create();
+ 
+-  aggregation_service_ =
+-      std::make_unique<AggregationServiceImpl>(is_in_memory(), path, this);
+ 
+ #if BUILDFLAG(ENABLE_LIBRARY_CDMS)
+   if (is_in_memory()) {
+@@ -1550,11 +1517,6 @@ void StoragePartitionImpl::Initialize(
+         std::make_unique<SharedStorageHeaderObserver>(this);
+   }
+ 
+-  if (base::FeatureList::IsEnabled(blink::features::kPrivateAggregationApi)) {
+-    private_aggregation_manager_ =
+-        std::make_unique<PrivateAggregationManagerImpl>(is_in_memory(), path,
+-                                                        this);
+-  }
+ }
+ 
+ void StoragePartitionImpl::ResetSessionStorageConnections() {
+--- a/content/browser/web_contents/web_contents_impl.cc
++++ b/content/browser/web_contents/web_contents_impl.cc
+@@ -4322,12 +4322,6 @@ void WebContentsImpl::Init(const WebCont
+   DateTimeChooser::CreateDateTimeChooser(this);
+ #endif
+ 
+-  // AttributionHost must be created after `view_->CreateView()` is called as it
+-  // may invoke `WebContentsAndroid::AddObserver()`.
+-  if (base::FeatureList::IsEnabled(
+-          attribution_reporting::features::kConversionMeasurement)) {
+-    AttributionHost::CreateForWebContents(this);
+-  }
+ 
+   SchedulerLoopQuarantineWebContentsObserver::MaybeCreateForWebContents(this);
+   RedirectChainDetector::CreateForWebContents(this);
+--- a/content/services/auction_worklet/private_aggregation_bindings.cc
++++ b/content/services/auction_worklet/private_aggregation_bindings.cc
+@@ -407,53 +407,6 @@ PrivateAggregationBindings::~PrivateAggr
+ 
+ void PrivateAggregationBindings::AttachToContext(
+     v8::Local<v8::Context> context) {
+-  if (!base::FeatureList::IsEnabled(blink::features::kPrivateAggregationApi) ||
+-      !blink::features::kPrivateAggregationApiEnabledInProtectedAudience
+-           .Get()) {
+-    return;
+-  }
+-
+-  v8::Local<v8::External> v8_this = v8::External::New(
+-      v8_helper_->isolate(), this, gin::kPrivateAggregationBindingsTag);
+-
+-  v8::Local<v8::Object> private_aggregation =
+-      v8::Object::New(v8_helper_->isolate());
+-
+-  v8::Local<v8::Function> send_histogram_report_function =
+-      v8::Function::New(
+-          context, &PrivateAggregationBindings::ContributeToHistogram, v8_this)
+-          .ToLocalChecked();
+-  private_aggregation
+-      ->Set(context,
+-            v8_helper_->CreateStringFromLiteral("contributeToHistogram"),
+-            send_histogram_report_function)
+-      .Check();
+-
+-    v8::Local<v8::Function> report_contribution_for_event_function =
+-        v8::Function::New(
+-            context, &PrivateAggregationBindings::ContributeToHistogramOnEvent,
+-            v8_this)
+-            .ToLocalChecked();
+-    private_aggregation
+-        ->Set(
+-            context,
+-            v8_helper_->CreateStringFromLiteral("contributeToHistogramOnEvent"),
+-            report_contribution_for_event_function)
+-        .Check();
+-
+-  v8::Local<v8::Function> enable_debug_mode_function =
+-      v8::Function::New(context, &PrivateAggregationBindings::EnableDebugMode,
+-                        v8_this)
+-          .ToLocalChecked();
+-  private_aggregation
+-      ->Set(context, v8_helper_->CreateStringFromLiteral("enableDebugMode"),
+-            enable_debug_mode_function)
+-      .Check();
+-
+-  context->Global()
+-      ->Set(context, v8_helper_->CreateStringFromLiteral("privateAggregation"),
+-            private_aggregation)
+-      .Check();
+ }
+ 
+ void PrivateAggregationBindings::Reset() {

--- a/patches/ungoogled/core/ungoogled-chromium/disable-profile-avatar-downloading.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/disable-profile-avatar-downloading.patch
@@ -1,0 +1,14 @@
+# Stop downloading of profile avatar (trk:271:...)
+
+--- a/chrome/browser/profiles/profile_avatar_downloader.cc
++++ b/chrome/browser/profiles/profile_avatar_downloader.cc
+@@ -27,8 +27,7 @@ ProfileAvatarDownloader::ProfileAvatarDo
+                                                  FetchCompleteCallback callback)
+     : icon_index_(icon_index), callback_(std::move(callback)) {
+   DCHECK(!callback_.is_null());
+-  GURL url(std::string(kHighResAvatarDownloadUrlPrefix) +
+-           profiles::GetDefaultAvatarIconFileNameAtIndex(icon_index));
++  GURL url(std::string("about:blank"));
+   net::NetworkTrafficAnnotationTag traffic_annotation =
+       net::DefineNetworkTrafficAnnotation("profile_avatar", R"(
+         semantics {

--- a/patches/ungoogled/core/ungoogled-chromium/disable-untraceable-urls.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/disable-untraceable-urls.patch
@@ -1,0 +1,33 @@
+# Disable additional URLs that are not caught by the "trk" scheme
+
+--- a/rlz/lib/financial_ping.cc
++++ b/rlz/lib/financial_ping.cc
+@@ -306,7 +306,7 @@ FinancialPing::PingResponse FinancialPin
+   response->clear();
+ 
+   std::string url =
+-      base::StringPrintf("https://%s%s", kFinancialServer, request);
++      base::StringPrintf("https://%s%s", "about:blank", request);
+ 
+   // Use a waitable event to cause this function to block, to match the
+   // wininet implementation.
+--- a/rlz/lib/lib_values.cc
++++ b/rlz/lib/lib_values.cc
+@@ -45,7 +45,6 @@ const char kSetDccResponseVariable[] = "
+ //
+ 
+ const char kFinancialPingPath[] = "/tools/pso/ping";
+-const char kFinancialServer[]   = "clients1.google.com";
+ const int kFinancialPort = 443;
+ 
+ // Ping times in 100-nanosecond intervals.
+--- a/rlz/lib/lib_values.h
++++ b/rlz/lib/lib_values.h
+@@ -72,7 +72,6 @@ extern const char kSetDccResponseVariabl
+ //
+ 
+ extern const char kFinancialPingPath[];
+-extern const char kFinancialServer[];
+ 
+ extern const int kFinancialPort;
+ 

--- a/patches/ungoogled/core/ungoogled-chromium/disable-webrtc-log-uploader.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/disable-webrtc-log-uploader.patch
@@ -1,0 +1,127 @@
+# Disables WebRTC log uploading to Google
+
+--- a/chrome/browser/media/webrtc/webrtc_log_uploader.cc
++++ b/chrome/browser/media/webrtc/webrtc_log_uploader.cc
+@@ -177,31 +177,13 @@ void WebRtcLogUploader::OnLoggingStopped
+   DCHECK(meta_data.get());
+   DCHECK(!upload_done_data.paths.directory.empty());
+ 
+-  std::string compressed_log = CompressLog(log_buffer.get());
+-
+-  std::string local_log_id;
+-
+   if (base::PathExists(upload_done_data.paths.directory)) {
+     webrtc_logging::DeleteOldWebRtcLogFiles({upload_done_data.paths.directory});
+-
+-    local_log_id =
+-        base::NumberToString(base::Time::Now().InSecondsFSinceUnixEpoch());
+-    base::FilePath log_file_path =
+-        upload_done_data.paths.directory.AppendASCII(local_log_id)
+-            .AddExtension(FILE_PATH_LITERAL(".gz"));
+-    WriteCompressedLogToFile(compressed_log, log_file_path);
+-
+-    base::FilePath log_list_path =
+-        webrtc_logging::TextLogList::GetWebRtcLogListFileForDirectory(
+-            upload_done_data.paths.directory);
+-    AddLocallyStoredLogInfoToUploadListFile(log_list_path, local_log_id);
+   }
+ 
+-  upload_done_data.local_log_id = local_log_id;
+ 
+   if (is_text_log_upload_allowed) {
+-    PrepareMultipartPostData(site, compressed_log, std::move(meta_data),
+-                             std::move(upload_done_data));
++    NotifyUploadDoneAndLogStats(net::HTTP_OK, net::OK, "", std::move(upload_done_data));
+   } else {
+     main_task_runner_->PostTask(
+         FROM_HERE,
+@@ -219,28 +201,7 @@ void WebRtcLogUploader::PrepareMultipart
+   DCHECK(!compressed_log.empty());
+   DCHECK(meta_data.get());
+ 
+-  std::unique_ptr<std::string> post_data(new std::string());
+-  SetupMultipart(post_data.get(), site, compressed_log,
+-                 upload_done_data.paths.incoming_rtp_dump,
+-                 upload_done_data.paths.outgoing_rtp_dump, *meta_data.get());
+-
+-  // If a test has set the test string pointer, write to it and skip uploading.
+-  // Still fire the upload callback so that we can run an extension API test
+-  // using the test framework for that without hanging.
+-  // TODO(grunell): Remove this when the api test for this feature is fully
+-  // implemented according to the test plan. http://crbug.com/41023787.
+-  if (post_data_) {
+-    *post_data_ = *post_data;
+-    NotifyUploadDoneAndLogStats(net::HTTP_OK, net::OK, "",
+-                                std::move(upload_done_data));
+-    return;
+-  }
+-
+-  main_task_runner_->PostTask(
+-      FROM_HERE,
+-      base::BindOnce(&WebRtcLogUploader::UploadCompressedLog,
+-                     base::Unretained(this), std::move(upload_done_data),
+-                     std::move(post_data)));
++  NotifyUploadDoneAndLogStats(net::HTTP_OK, net::OK, "", std::move(upload_done_data));
+ }
+ 
+ void WebRtcLogUploader::LoggingStoppedDoStore(
+@@ -254,48 +215,6 @@ void WebRtcLogUploader::LoggingStoppedDo
+   DCHECK(log_buffer.get());
+   DCHECK(!log_paths.directory.empty());
+ 
+-  webrtc_logging::DeleteOldWebRtcLogFiles({log_paths.directory});
+-
+-  base::FilePath log_list_path =
+-      webrtc_logging::TextLogList::GetWebRtcLogListFileForDirectory(
+-          log_paths.directory);
+-
+-  // Store the native log with a ".gz" extension.
+-  std::string compressed_log = CompressLog(log_buffer.get());
+-  base::FilePath native_log_path =
+-      log_paths.directory.AppendASCII(log_id).AddExtension(
+-          FILE_PATH_LITERAL(".gz"));
+-  WriteCompressedLogToFile(compressed_log, native_log_path);
+-  AddLocallyStoredLogInfoToUploadListFile(log_list_path, log_id);
+-
+-  // Move the rtp dump files to the log directory with a name of
+-  // <log id>.rtp_[in|out].
+-  if (!log_paths.incoming_rtp_dump.empty()) {
+-    base::FilePath rtp_path =
+-        log_paths.directory.AppendASCII(log_id).AddExtension(
+-            FILE_PATH_LITERAL(".rtp_in"));
+-    base::Move(log_paths.incoming_rtp_dump, rtp_path);
+-  }
+-
+-  if (!log_paths.outgoing_rtp_dump.empty()) {
+-    base::FilePath rtp_path =
+-        log_paths.directory.AppendASCII(log_id).AddExtension(
+-            FILE_PATH_LITERAL(".rtp_out"));
+-    base::Move(log_paths.outgoing_rtp_dump, rtp_path);
+-  }
+-
+-  if (meta_data.get() && !meta_data->empty()) {
+-    base::Pickle pickle;
+-    for (const auto& it : *meta_data.get()) {
+-      pickle.WriteString(it.first);
+-      pickle.WriteString(it.second);
+-    }
+-    base::FilePath meta_path =
+-        log_paths.directory.AppendASCII(log_id).AddExtension(
+-            FILE_PATH_LITERAL(".meta"));
+-    base::WriteFile(meta_path, pickle);
+-  }
+-
+   main_task_runner_->PostTask(
+       FROM_HERE, base::BindOnce(std::move(done_callback), true, ""));
+ 
+--- a/chrome/browser/ui/browser_ui_prefs.cc
++++ b/chrome/browser/ui/browser_ui_prefs.cc
+@@ -156,7 +156,7 @@ void RegisterBrowserUserPrefs(user_prefs
+   registry->RegisterStringPref(prefs::kWebRTCUDPPortRange, std::string());
+   registry->RegisterBooleanPref(prefs::kWebRtcEventLogCollectionAllowed, false);
+   registry->RegisterListPref(prefs::kWebRtcLocalIpsAllowedUrls);
+-  registry->RegisterBooleanPref(prefs::kWebRtcTextLogCollectionAllowed, true);
++  registry->RegisterBooleanPref(prefs::kWebRtcTextLogCollectionAllowed, false);
+   registry->RegisterListPref(
+       prefs::kWebRTCDiagnosticLogCollectionAllowedForOrigins,
+       base::ListValue());

--- a/patches/ungoogled/core/ungoogled-chromium/disable-webstore-urls.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/disable-webstore-urls.patch
@@ -1,0 +1,184 @@
+# Disables Chrome Webstore-related URLs and other internal functionality. Mainly for disabling auto updates via the Chrome Webstore.
+
+--- a/chrome/browser/extensions/chrome_content_browser_client_extensions_part.cc
++++ b/chrome/browser/extensions/chrome_content_browser_client_extensions_part.cc
+@@ -682,12 +682,6 @@ std::vector<url::Origin> ChromeContentBr
+     GetOriginsRequiringDedicatedProcess() {
+   std::vector<url::Origin> list;
+ 
+-  // Require a dedicated process for the webstore origin.  See
+-  // https://crbug.com/40094229.
+-  list.push_back(url::Origin::Create(extension_urls::GetWebstoreLaunchURL()));
+-  list.push_back(
+-      url::Origin::Create(extension_urls::GetNewWebstoreLaunchURL()));
+-
+   return list;
+ }
+ 
+--- a/chrome/browser/extensions/chrome_content_verifier_delegate.cc
++++ b/chrome/browser/extensions/chrome_content_verifier_delegate.cc
+@@ -305,17 +305,7 @@ bool ChromeContentVerifierDelegate::IsFr
+   // between which extensions are considered in-store.
+   // See https://crbug.com/40540778 for details.
+   if (!InstallVerifier::IsFromStore(extension, context_)) {
+-    // It's possible that the webstore update url was overridden for testing
+-    // so also consider extensions with the default (production) update url
+-    // to be from the store as well. Therefore update URL is compared with
+-    // |GetDefaultWebstoreUpdateUrl|, not the |GetWebstoreUpdateUrl| used by
+-    // |IsWebstoreUpdateUrl|.
+-    ExtensionManagement* extension_management =
+-        ExtensionManagementFactory::GetForBrowserContext(context_);
+-    if (extension_management->GetEffectiveUpdateURL(extension) !=
+-        extension_urls::GetDefaultWebstoreUpdateUrl()) {
+-      return false;
+-    }
++    return false;
+   }
+   return true;
+ }
+--- a/chrome/browser/extensions/extension_migrator.cc
++++ b/chrome/browser/extensions/extension_migrator.cc
+@@ -22,7 +22,9 @@ namespace extensions {
+ ExtensionMigrator::ExtensionMigrator(Profile* profile,
+                                      const std::string& old_id,
+                                      const std::string& new_id)
+-    : profile_(profile), old_id_(old_id), new_id_(new_id) {}
++    : profile_(profile), old_id_(old_id), new_id_(new_id) {
++    chrome_blank_ = GURL("chrome://blank/");
++}
+ 
+ ExtensionMigrator::~ExtensionMigrator() = default;
+ 
+@@ -34,7 +36,7 @@ void ExtensionMigrator::StartLoading() {
+   if (should_have_extension) {
+     base::DictValue entry;
+     entry.Set(ExternalProviderImpl::kExternalUpdateUrl,
+-              extension_urls::GetWebstoreUpdateUrl().spec());
++              chrome_blank_.spec());
+ 
+     prefs.Set(new_id_, std::move(entry));
+   }
+--- a/chrome/browser/extensions/extension_migrator.h
++++ b/chrome/browser/extensions/extension_migrator.h
+@@ -10,6 +10,7 @@
+ #include "base/memory/raw_ptr.h"
+ #include "chrome/browser/extensions/external_loader.h"
+ #include "extensions/buildflags/buildflags.h"
++#include "url/gurl.h"
+ 
+ static_assert(BUILDFLAG(ENABLE_EXTENSIONS_CORE));
+ 
+@@ -43,6 +44,7 @@ class ExtensionMigrator : public Externa
+   raw_ptr<Profile> profile_;
+   const std::string old_id_;
+   const std::string new_id_;
++  GURL chrome_blank_;
+ };
+ 
+ }  // namespace extensions
+--- a/extensions/browser/updater/extension_downloader.cc
++++ b/extensions/browser/updater/extension_downloader.cc
+@@ -93,25 +93,16 @@ const char kNotFromWebstoreInstallSource
+ const char kDefaultInstallSource[] = "";
+ const char kReinstallInstallSource[] = "reinstall";
+ 
+-const char kGoogleDotCom[] = "google.com";
+ 
+ ExtensionDownloader::TestObserver* g_test_observer = nullptr;
+ ExtensionDownloaderTestDelegate* g_test_delegate = nullptr;
+ 
+ #define RETRY_HISTOGRAM(name, retry_count, url)                           \
+-  if ((url).DomainIs(kGoogleDotCom)) {                                    \
+-    UMA_HISTOGRAM_CUSTOM_COUNTS("Extensions." name "RetryCountGoogleUrl", \
+-                                retry_count,                              \
+-                                1,                                        \
+-                                kMaxRetries,                              \
+-                                kMaxRetries + 1);                         \
+-  } else {                                                                \
+     UMA_HISTOGRAM_CUSTOM_COUNTS("Extensions." name "RetryCountOtherUrl",  \
+                                 retry_count,                              \
+                                 1,                                        \
+                                 kMaxRetries,                              \
+-                                kMaxRetries + 1);                         \
+-  }
++                                kMaxRetries + 1);
+ 
+ bool ShouldRetryRequest(const network::SimpleURLLoader* loader) {
+   DCHECK(loader);
+@@ -167,7 +158,7 @@ std::optional<GURL> SanitizeUpdateURL(co
+                                       const GURL& update_url) {
+   if (update_url.is_empty()) {
+     // Fill in default update URL.
+-    return extension_urls::GetWebstoreUpdateUrl();
++    return std::nullopt;
+   }
+ 
+   // Skip extensions with non-empty invalid update URLs.
+@@ -185,11 +176,6 @@ std::optional<GURL> SanitizeUpdateURL(co
+     return std::nullopt;
+   }
+ 
+-  // Make sure we use SSL for store-hosted extensions.
+-  if (extension_urls::IsWebstoreUpdateUrl(update_url) &&
+-      !update_url.SchemeIsCryptographic()) {
+-    return extension_urls::GetWebstoreUpdateUrl();
+-  }
+ 
+   return update_url;
+ }
+@@ -361,10 +347,6 @@ void ExtensionDownloader::DoStartAllPend
+     AddToFetches(fetches_preparing, std::move(task));
+   pending_tasks_.clear();
+ 
+-  for (auto& fetch_list : fetches_preparing) {
+-    for (auto& fetch : fetch_list.second)
+-      StartUpdateCheck(std::move(fetch));
+-  }
+ }
+ 
+ void ExtensionDownloader::SetIdentityManager(
+@@ -825,20 +807,6 @@ void ExtensionDownloader::HandleManifest
+         update.second->info);
+   }
+ 
+-  // If the manifest response included a <daystart> element, we want to save
+-  // that value for any extensions which had sent a ping in the request.
+-  if (fetch_data->base_url().DomainIs(kGoogleDotCom) &&
+-      results->daystart_elapsed_seconds >= 0) {
+-    Time day_start =
+-        Time::Now() - base::Seconds(results->daystart_elapsed_seconds);
+-
+-    for (const ExtensionId& id : extension_ids) {
+-      ExtensionDownloaderDelegate::PingResult& result = ping_results_[id];
+-      result.did_ping = fetch_data->DidPing(id, ManifestFetchData::ROLLCALL);
+-      result.day_start = day_start;
+-    }
+-  }
+-
+   ExtensionIdSet extension_ids_with_errors;
+   for (const auto& failure : failures)
+     extension_ids_with_errors.insert(failure.first.id);
+@@ -1433,11 +1401,7 @@ bool ExtensionDownloader::IterateFetchCr
+   // fetch.
+   switch (fetch->credentials) {
+     case ExtensionFetch::CREDENTIALS_NONE:
+-      if (fetch->url.DomainIs(kGoogleDotCom) && identity_manager_) {
+-        fetch->credentials = ExtensionFetch::CREDENTIALS_OAUTH2_TOKEN;
+-      } else {
+-        fetch->credentials = ExtensionFetch::CREDENTIALS_COOKIES;
+-      }
++      fetch->credentials = ExtensionFetch::CREDENTIALS_COOKIES;
+       return true;
+     case ExtensionFetch::CREDENTIALS_OAUTH2_TOKEN:
+       fetch->oauth2_attempt_count++;
+--- a/extensions/common/extension_urls.cc
++++ b/extensions/common/extension_urls.cc
+@@ -82,8 +82,6 @@ GURL AppendUtmSource(const GURL& url, st
+ 
+ GURL GetWebstoreExtensionsCategoryURL() {
+   GURL base_url = GetNewWebstoreLaunchURL();
+-  CHECK_EQ(base_url.path(), "/")
+-      << "GURL::Resolve() won't work with a URL with a path.";
+   return base_url.Resolve("category/extensions");
+ }
+ 

--- a/patches/ungoogled/core/ungoogled-chromium/doh-changes.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/doh-changes.patch
@@ -1,0 +1,73 @@
+--- a/chrome/browser/net/default_dns_over_https_config_source.cc
++++ b/chrome/browser/net/default_dns_over_https_config_source.cc
+@@ -29,7 +29,7 @@ DefaultDnsOverHttpsConfigSource::Default
+   if (set_up_pref_defaults) {
+     local_state->SetDefaultPrefValue(prefs::kDnsOverHttpsMode,
+                                      base::Value(SecureDnsConfig::ModeToString(
+-                                         net::SecureDnsMode::kAutomatic)));
++                                         net::SecureDnsMode::kOff)));
+   }
+ }
+ 
+--- a/chrome/browser/net/dns_probe_runner.cc
++++ b/chrome/browser/net/dns_probe_runner.cc
+@@ -18,7 +18,7 @@
+ 
+ namespace chrome_browser_net {
+ 
+-const char DnsProbeRunner::kKnownGoodHostname[] = "google.com";
++const char DnsProbeRunner::kKnownGoodHostname[] = "example.com";
+ 
+ namespace {
+ 
+--- a/net/dns/public/doh_provider_entry.cc
++++ b/net/dns/public/doh_provider_entry.cc
+@@ -224,33 +224,6 @@ const DohProviderEntry::List& DohProvide
+            /*display_countries=*/{"EE", "DE"},
+        },
+        {
+-           "Google",
+-           MAKE_STATIC_STORAGE_BASE_FEATURE(kDohProviderGoogle,
+-                                            base::FEATURE_ENABLED_BY_DEFAULT),
+-           {"8.8.8.8", "8.8.4.4", "2001:4860:4860::8888",
+-            "2001:4860:4860::8844"},
+-           /*dns_over_tls_hostnames=*/
+-           {"dns.google", "dns.google.com", "8888.google"},
+-           "https://dns.google/dns-query{?dns}",
+-           /*ui_name=*/"Google (Public DNS)",
+-           "https://developers.google.com/speed/public-dns/"
+-           /*privacy_policy=*/"privacy",
+-           /*display_globally=*/true,
+-           /*display_countries=*/{},
+-       },
+-       {
+-           "GoogleDns64",
+-           MAKE_STATIC_STORAGE_BASE_FEATURE(kDohProviderGoogleDns64,
+-                                            base::FEATURE_ENABLED_BY_DEFAULT),
+-           {"2001:4860:4860::64", "2001:4860:4860::6464"},
+-           /*dns_over_tls_hostnames=*/{"dns64.dns.google"},
+-           "https://dns64.dns.google/dns-query{?dns}",
+-           /*ui_name=*/"",
+-           /*privacy_policy=*/"",
+-           /*display_globally=*/false,
+-           /*display_countries=*/{},
+-       },
+-       {
+            "Iij",
+            MAKE_STATIC_STORAGE_BASE_FEATURE(kDohProviderIij,
+                                             base::FEATURE_ENABLED_BY_DEFAULT),
+--- a/services/network/public/cpp/features.cc
++++ b/services/network/public/cpp/features.cc
+@@ -94,12 +94,7 @@ BASE_FEATURE(kSplitAuthCacheByNetworkIso
+ 
+ // Enable usage of hardcoded DoH upgrade mapping for use in automatic mode.
+ BASE_FEATURE(kDnsOverHttpsUpgrade,
+-#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_MAC) || \
+-    BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_LINUX)
+-             base::FEATURE_ENABLED_BY_DEFAULT
+-#else
+              base::FEATURE_DISABLED_BY_DEFAULT
+-#endif
+ );
+ 
+ // When enabled, the requests in a third party context to domains included in

--- a/patches/ungoogled/core/ungoogled-chromium/extensions-manifestv2.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/extensions-manifestv2.patch
@@ -1,0 +1,149 @@
+--- a/chrome/browser/extensions/api/developer_private/extension_info_generator.cc
++++ b/chrome/browser/extensions/api/developer_private/extension_info_generator.cc
+@@ -865,19 +865,6 @@ void ExtensionInfoGenerator::FillExtensi
+         toolbar_actions_model->IsActionPinned(extension.id());
+   }
+ 
+-  // MV2 deprecation.
+-  ManifestV2ExperimentManager* mv2_experiment_manager =
+-      ManifestV2ExperimentManager::Get(profile);
+-  CHECK(mv2_experiment_manager);
+-  info.is_affected_by_mv2_deprecation =
+-      mv2_experiment_manager->IsExtensionAffected(extension);
+-  info.did_acknowledge_mv2_deprecation_notice =
+-      mv2_experiment_manager->DidUserAcknowledgeNotice(extension.id());
+-  if (info.web_store_url.length() > 0) {
+-    info.recommendations_url =
+-        extension_urls::GetNewWebstoreItemRecommendationsUrl(extension.id())
+-            .spec();
+-  }
+ 
+   info.can_upload_as_account_extension =
+       AccountExtensionTracker::Get(profile)->CanUploadAsAccountExtension(
+--- a/chrome/browser/extensions/extension_management.cc
++++ b/chrome/browser/extensions/extension_management.cc
+@@ -370,31 +370,7 @@ bool ExtensionManagement::IsAllowedManif
+     int manifest_version,
+     const std::string& extension_id,
+     Manifest::Type manifest_type) {
+-  bool enabled_by_default =
+-      !base::FeatureList::IsEnabled(
+-          extensions_features::kExtensionsManifestV3Only) ||
+-      manifest_version >= 3;
+-
+-  // Manifest version policy only supports normal extensions and Chrome OS login
+-  // screen extension.
+-  if (manifest_type != Manifest::Type::TYPE_EXTENSION &&
+-      manifest_type != Manifest::Type::TYPE_LOGIN_SCREEN_EXTENSION) {
+-    return enabled_by_default;
+-  }
+-  switch (global_settings_->manifest_v2_setting) {
+-    case internal::GlobalSettings::ManifestV2Setting::kDefault:
+-      return enabled_by_default;
+-    case internal::GlobalSettings::ManifestV2Setting::kDisabled:
+-      return manifest_version >= 3;
+-    case internal::GlobalSettings::ManifestV2Setting::kEnabled:
+       return true;
+-    case internal::GlobalSettings::ManifestV2Setting::kEnabledForForceInstalled:
+-      auto installation_mode =
+-          GetInstallationMode(extension_id, /*update_url=*/std::string());
+-      return manifest_version >= 3 ||
+-             installation_mode == ManagedInstallationMode::kForced ||
+-             installation_mode == ManagedInstallationMode::kRecommended;
+-  }
+ }
+ 
+ bool ExtensionManagement::IsAllowedManifestVersion(const Extension* extension) {
+@@ -415,26 +391,8 @@ bool ExtensionManagement::IsExemptFromMV
+     return false;
+   }
+ 
+-  switch (global_settings_->manifest_v2_setting) {
+-    case internal::GlobalSettings::ManifestV2Setting::kDefault:
+-      // Default browser behavior. Not exempt.
+-      return false;
+-    case internal::GlobalSettings::ManifestV2Setting::kDisabled:
+-      // All MV2 extensions are disallowed. Not exempt.
+-      return false;
+-    case internal::GlobalSettings::ManifestV2Setting::kEnabled:
+       // All MV2 extensions are allowed. Exempt.
+       return true;
+-    case internal::GlobalSettings::ManifestV2Setting::kEnabledForForceInstalled:
+-      // Force-installed MV2 extensions are allowed. Exempt if it's a force-
+-      // installed extension only.
+-      auto installation_mode =
+-          GetInstallationMode(extension_id, /*update_url=*/std::string());
+-      return installation_mode == ManagedInstallationMode::kForced ||
+-             installation_mode == ManagedInstallationMode::kRecommended;
+-  }
+-
+-  return false;
+ }
+ 
+ bool ExtensionManagement::IsAllowedByUnpublishedAvailabilityPolicy(
+--- a/chrome/browser/ui/webui/extensions/extensions_ui.cc
++++ b/chrome/browser/ui/webui/extensions/extensions_ui.cc
+@@ -488,7 +488,7 @@ content::WebUIDataSource* CreateAndAddEx
+           extensions_features::kExtensionsMenuAccessControlWithPermittedSites));
+   source->AddBoolean(
+       "safetyHubThreeDotDetails",
+-      base::FeatureList::IsEnabled(features::kSafetyHubThreeDotDetails));
++      false);
+   source->AddBoolean("enableGlobalScopedShortcuts", IsGlobalShortcutEnabled());
+ 
+   // MV2 deprecation.
+--- a/extensions/browser/manifest_v2_experiment_manager.cc
++++ b/extensions/browser/manifest_v2_experiment_manager.cc
+@@ -151,17 +151,6 @@ bool ManifestV2ExperimentManagerFactory:
+ 
+ // Determines the current stage of the MV2 deprecation experiments.
+ MV2ExperimentStage CalculateCurrentExperimentStage() {
+-  // Return the "highest" stage that is currently active for the user.
+-  if (base::FeatureList::IsEnabled(
+-          extensions_features::kExtensionManifestV2Unsupported)) {
+-    return MV2ExperimentStage::kUnsupported;
+-  }
+-
+-  if (base::FeatureList::IsEnabled(
+-          extensions_features::kExtensionManifestV2Disabled)) {
+-    return MV2ExperimentStage::kDisableWithReEnable;
+-  }
+-
+   return MV2ExperimentStage::kWarning;
+ }
+ 
+@@ -195,18 +184,7 @@ PrefMap GetGlobalNoticeAcknowledgedPrefF
+ // Returns true if legacy extensions should be disabled, looking at both
+ // experiment stage and global state.
+ bool ShouldDisableLegacyExtensions(MV2ExperimentStage stage) {
+-  if (g_allow_mv2_for_testing) {
+-    // We allow legacy MV2 extensions for testing purposes.
+-    return false;
+-  }
+-
+-  switch (stage) {
+-    case MV2ExperimentStage::kWarning:
+       return false;
+-    case MV2ExperimentStage::kDisableWithReEnable:
+-    case MV2ExperimentStage::kUnsupported:
+-      return true;
+-  }
+ }
+ 
+ // Returns true if the given `stage` is one in which extension enablement should
+--- a/extensions/common/extension.cc
++++ b/extensions/common/extension.cc
+@@ -103,13 +103,6 @@ bool IsManifestSupported(int manifest_ve
+   // Supported versions are always safe.
+   if (manifest_version >= kMinimumSupportedManifestVersion &&
+       manifest_version <= kMaximumSupportedManifestVersion) {
+-    // Emit a warning for unpacked extensions on Manifest V2 warning that
+-    // MV2 is deprecated.
+-    if (type == Manifest::Type::kExtension && manifest_version == 2 &&
+-        Manifest::IsUnpackedLocation(location) &&
+-        !g_silence_deprecated_manifest_version_warnings) {
+-      *warning = errors::kManifestV2IsDeprecatedWarning;
+-    }
+     return true;
+   }
+ 

--- a/patches/ungoogled/core/ungoogled-chromium/fix-building-without-safebrowsing.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/fix-building-without-safebrowsing.patch
@@ -1,0 +1,3520 @@
+# Additional changes to Inox's fix-building-without-safebrowsing.patch
+
+--- a/chrome/browser/BUILD.gn
++++ b/chrome/browser/BUILD.gn
+@@ -421,10 +421,6 @@ static_library("browser") {
+     # c/b/metrics/process_memory_metrics_emitter.h is componentized.
+     "//chrome/browser/resource_coordinator:impl",
+ 
+-    "//chrome/browser/safe_browsing",
+-    "//chrome/browser/safe_browsing:advanced_protection",
+-    "//chrome/browser/safe_browsing:metrics_collector",
+-    "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
+     "//chrome/browser/search",
+     "//chrome/browser/search_engine_choice:impl",
+     "//chrome/browser/signin:impl",
+@@ -932,10 +928,6 @@ static_library("browser") {
+     "//chrome/browser/resource_coordinator:impl",
+     "//chrome/browser/resource_coordinator:utils",
+     "//chrome/browser/resources/accessibility:resources",
+-    "//chrome/browser/safe_browsing",
+-    "//chrome/browser/safe_browsing:advanced_protection",
+-    "//chrome/browser/safe_browsing:metrics_collector",
+-    "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
+     "//chrome/browser/search",
+     "//chrome/browser/search/background",
+     "//chrome/browser/search_engine_choice",
+@@ -1395,7 +1387,6 @@ static_library("browser") {
+     "//components/resources",
+     "//components/safe_browsing/content/browser",
+     "//components/safe_browsing/content/browser:safe_browsing_service",
+-    "//components/safe_browsing/content/browser/notification_content_detection",
+     "//components/safe_browsing/content/browser/password_protection",
+     "//components/safe_browsing/content/browser/web_ui",
+     "//components/safe_browsing/content/common/proto:download_file_types_proto",
+@@ -5516,8 +5507,6 @@ static_library("test_support") {
+     "//components/reporting/util:status",
+     "//components/reporting/util:status_macros",
+     "//components/reporting/util:task_runner_context",
+-    "//components/safe_browsing/content/browser/notification_content_detection",
+-    "//components/safe_browsing/content/browser/notification_content_detection:test_utils",
+     "//components/safe_browsing/core/common/proto:crx_info_proto",
+     "//components/safe_browsing/core/common/proto:csd_proto",
+     "//components/search_engines:test_support",
+--- a/chrome/browser/content_settings/generated_javascript_optimizer_pref.cc
++++ b/chrome/browser/content_settings/generated_javascript_optimizer_pref.cc
+@@ -30,15 +30,10 @@ GeneratedJavascriptOptimizerPref::Genera
+   user_prefs_registrar_.Init(profile->GetPrefs());
+   user_prefs_registrar_.AddMultiple(
+       {prefs::kJavascriptOptimizerBlockedForUnfamiliarSites,
+-       prefs::kSafeBrowsingEnabled},
++       },
+       base::BindRepeating(
+           &GeneratedJavascriptOptimizerPref::OnPreferencesChanged,
+           base::Unretained(this)));
+-  user_prefs_registrar_.Add(
+-      prefs::kSecuritySettingsBundle,
+-      base::BindRepeating(
+-          &GeneratedJavascriptOptimizerPref::OnSettingsBundleChanged,
+-          base::Unretained(this)));
+ 
+   host_content_settings_map_ =
+       HostContentSettingsMapFactory::GetForProfile(profile_);
+@@ -103,7 +98,6 @@ PrefObject GeneratedJavascriptOptimizerP
+         &pref_object, SettingSource::kPolicy);
+   }
+ 
+-  if (!safe_browsing::IsSafeBrowsingEnabled(*profile_->GetPrefs())) {
+     pref_object.enforcement =
+         extensions::api::settings_private::Enforcement::kEnforced;
+     pref_object.controlled_by =
+@@ -114,7 +108,6 @@ PrefObject GeneratedJavascriptOptimizerP
+     user_selectable_values.Append(
+         base::Value(static_cast<int>(JavascriptOptimizerSetting::kBlocked)));
+     pref_object.user_selectable_values = std::move(user_selectable_values);
+-  }
+ 
+   return pref_object;
+ }
+@@ -124,35 +117,7 @@ void GeneratedJavascriptOptimizerPref::O
+ }
+ 
+ void GeneratedJavascriptOptimizerPref::OnSettingsBundleChanged() {
+-  auto bundle = safe_browsing::GetSecurityBundleSetting(*profile_->GetPrefs());
+-  switch (bundle) {
+-    case safe_browsing::SecuritySettingsBundleSetting::STANDARD: {
+-      base::Value pref_value(
+-          static_cast<int>(JavascriptOptimizerSetting::kAllowed));
+-      SetPref(&pref_value);
+-      break;
+-    }
+-    case safe_browsing::SecuritySettingsBundleSetting::ENHANCED: {
+-      base::Value pref_value(static_cast<int>(
+-          JavascriptOptimizerSetting::kBlockedForUnfamiliarSites));
+-      SetPref(&pref_value);
+-      break;
+-    }
+-    default:
+-      NOTREACHED();
+-  }
+ }
+ 
+-content_settings::JavascriptOptimizerSetting
+-GeneratedJavascriptOptimizerPref::GetDefaultJsOptimizerSetting(
+-    safe_browsing::SecuritySettingsBundleSetting bundle_setting) {
+-  switch (bundle_setting) {
+-    case safe_browsing::SecuritySettingsBundleSetting::STANDARD:
+-      return content_settings::JavascriptOptimizerSetting::kAllowed;
+-    case safe_browsing::SecuritySettingsBundleSetting::ENHANCED:
+-      return content_settings::JavascriptOptimizerSetting::
+-          kBlockedForUnfamiliarSites;
+-  }
+-}
+ 
+ }  // namespace content_settings
+--- a/chrome/browser/content_settings/generated_javascript_optimizer_pref.h
++++ b/chrome/browser/content_settings/generated_javascript_optimizer_pref.h
+@@ -12,7 +12,6 @@
+ #include "components/content_settings/browser/ui/javascript_optimizer_setting.h"
+ #include "components/content_settings/core/browser/host_content_settings_map.h"
+ #include "components/prefs/pref_change_registrar.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ namespace content_settings {
+ 
+@@ -44,11 +43,6 @@ class GeneratedJavascriptOptimizerPref
+   // Fired when the selected bundled setting is changed programmatically.
+   void OnSettingsBundleChanged();
+ 
+-  // Returns the default Javascript Optimizer setting for the passed-in
+-  // security-bundle type.
+-  static content_settings::JavascriptOptimizerSetting
+-  GetDefaultJsOptimizerSetting(
+-      safe_browsing::SecuritySettingsBundleSetting bundle_setting);
+ 
+  private:
+   // Profile this preference is generated for.
+--- a/chrome/browser/download/bubble/download_bubble_ui_controller.cc
++++ b/chrome/browser/download/bubble/download_bubble_ui_controller.cc
+@@ -46,7 +46,6 @@
+ #include "components/offline_items_collection/core/offline_content_aggregator.h"
+ #include "components/safe_browsing/buildflags.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "content/public/browser/download_item_utils.h"
+ #include "content/public/browser/download_manager.h"
+ 
+@@ -279,14 +278,6 @@ void DownloadBubbleUIController::Process
+   switch (command) {
+     case DownloadCommands::KEEP:
+     case DownloadCommands::DISCARD: {
+-      if (safe_browsing::IsSafeBrowsingSurveysEnabled(*profile_->GetPrefs())) {
+-        TrustSafetySentimentService* trust_safety_sentiment_service =
+-            TrustSafetySentimentServiceFactory::GetForProfile(profile_);
+-        if (trust_safety_sentiment_service) {
+-          trust_safety_sentiment_service->InteractedWithDownloadWarningUI(
+-              warning_surface, warning_action);
+-        }
+-      }
+       DownloadItemWarningData::AddWarningActionEvent(item, warning_surface,
+                                                      warning_action);
+       // Launch a HaTS survey. Note this needs to come before the command is
+--- a/chrome/browser/download/chrome_download_manager_delegate.cc
++++ b/chrome/browser/download/chrome_download_manager_delegate.cc
+@@ -181,7 +181,6 @@ using content::DownloadManager;
+ using download::DownloadItem;
+ using download::DownloadPathReservationTracker;
+ using download::PathValidationResult;
+-using safe_browsing::DownloadFileType;
+ using ConnectionType = net::NetworkChangeNotifier::ConnectionType;
+ 
+ #if BUILDFLAG(SAFE_BROWSING_DOWNLOAD_PROTECTION)
+@@ -2021,7 +2020,6 @@ void ChromeDownloadManagerDelegate::OnDo
+     DownloadItemModel model(item);
+     model.DetermineAndSetShouldPreferOpeningInBrowser(
+         target_info.target_path, target_info.is_filetype_handled_safely);
+-    model.SetDangerLevel(danger_level);
+   }
+   if (ShouldBlockFile(item, target_info.danger_type)) {
+     MaybeReportDangerousDownloadBlocked(
+@@ -2102,50 +2100,20 @@ bool ChromeDownloadManagerDelegate::IsOp
+ bool ChromeDownloadManagerDelegate::ShouldBlockFile(
+     download::DownloadItem* item,
+     download::DownloadDangerType danger_type) const {
+-  // Chrome-initiated background downloads should not be blocked.
+-  if (item && !item->RequireSafetyChecks()) {
+-    return false;
+-  }
+-
+   policy::DownloadRestriction download_restriction =
+       download_prefs_->download_restriction();
+ 
+-  if (IsDangerTypeBlocked(danger_type)) {
+-    return true;
+-  }
+-
+-  bool file_type_dangerous =
+-      (item && DownloadItemModel(item).GetDangerLevel() !=
+-                   DownloadFileType::NOT_DANGEROUS);
+-
+   switch (download_restriction) {
+     case (policy::DownloadRestriction::NONE):
+       return false;
+ 
+-    case (policy::DownloadRestriction::POTENTIALLY_DANGEROUS_FILES):
+-      return danger_type != download::DOWNLOAD_DANGER_TYPE_NOT_DANGEROUS ||
+-             file_type_dangerous;
+-
+-    case (policy::DownloadRestriction::DANGEROUS_FILES): {
+-      return (danger_type == download::DOWNLOAD_DANGER_TYPE_DANGEROUS_CONTENT ||
+-              danger_type == download::DOWNLOAD_DANGER_TYPE_DANGEROUS_FILE ||
+-              danger_type == download::DOWNLOAD_DANGER_TYPE_DANGEROUS_URL ||
+-              danger_type ==
+-                  download::DOWNLOAD_DANGER_TYPE_DANGEROUS_ACCOUNT_COMPROMISE ||
+-              file_type_dangerous);
+-    }
+-
+-    case (policy::DownloadRestriction::MALICIOUS_FILES): {
+-      return (danger_type == download::DOWNLOAD_DANGER_TYPE_DANGEROUS_CONTENT ||
+-              danger_type == download::DOWNLOAD_DANGER_TYPE_DANGEROUS_HOST ||
+-              danger_type == download::DOWNLOAD_DANGER_TYPE_DANGEROUS_URL ||
+-              danger_type ==
+-                  download::DOWNLOAD_DANGER_TYPE_DANGEROUS_ACCOUNT_COMPROMISE);
+-    }
+-
+     case (policy::DownloadRestriction::ALL_FILES):
+       return true;
+ 
++    // DownloadRestrictions policy key values 1, 2 and 4 treated as invalid
++    case (policy::DownloadRestriction::POTENTIALLY_DANGEROUS_FILES):
++    case (policy::DownloadRestriction::DANGEROUS_FILES):
++    case (policy::DownloadRestriction::MALICIOUS_FILES):
+     default:
+       LOG(ERROR) << "Invalid download restriction value: "
+                  << static_cast<int>(download_restriction);
+--- a/chrome/browser/download/download_target_determiner.cc
++++ b/chrome/browser/download/download_target_determiner.cc
+@@ -1305,14 +1305,7 @@ DownloadFileType::DangerLevel DownloadTa
+ 
+ std::optional<base::Time>
+ DownloadTargetDeterminer::GetLastDownloadBypassTimestamp() const {
+-  safe_browsing::SafeBrowsingMetricsCollector* metrics_collector =
+-      safe_browsing::SafeBrowsingMetricsCollectorFactory::GetForProfile(
+-          GetProfile());
+-  // metrics_collector can be null in incognito.
+-  return metrics_collector ? metrics_collector->GetLatestEventTimestamp(
+-                                 safe_browsing::SafeBrowsingMetricsCollector::
+-                                     EventType::DANGEROUS_DOWNLOAD_BYPASS)
+-                           : std::nullopt;
++  return std::nullopt;
+ }
+ 
+ void DownloadTargetDeterminer::OnDownloadDestroyed(
+--- a/chrome/browser/download/download_warning_desktop_hats_utils.cc
++++ b/chrome/browser/download/download_warning_desktop_hats_utils.cc
+@@ -32,7 +32,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/safe_browsing/buildflags.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "content/public/browser/download_item_utils.h"
+ 
+ namespace {
+@@ -106,17 +105,6 @@ std::string ElapsedTimeToSecondsString(b
+   return base::NumberToString(elapsed_time.InSeconds());
+ }
+ 
+-std::string SafeBrowsingStateToString(
+-    safe_browsing::SafeBrowsingState sb_state) {
+-  switch (sb_state) {
+-    case safe_browsing::SafeBrowsingState::NO_SAFE_BROWSING:
+-      return "No Safe Browsing";
+-    case safe_browsing::SafeBrowsingState::STANDARD_PROTECTION:
+-      return "Standard Protection";
+-    case safe_browsing::SafeBrowsingState::ENHANCED_PROTECTION:
+-      return "Enhanced Protection";
+-  }
+-}
+ 
+ // Produces a string consisting of comma-separated action events, each of which
+ // consists of the surface, action, and relative timestamp (ms) separated by
+@@ -243,49 +231,21 @@ DownloadWarningHatsProductSpecificData::
+     return psd;
+   }
+ 
+-  psd.string_data_.insert(
+-      {Fields::kSafeBrowsingState,
+-       SafeBrowsingStateToString(
+-           safe_browsing::GetSafeBrowsingState(*profile->GetPrefs()))});
+ 
+   psd.bits_data_.insert({Fields::kPartialViewEnabled,
+                          profile->GetPrefs()->GetBoolean(
+                              prefs::kDownloadBubblePartialViewEnabled)});
+ 
+-  // URL and filename logged only for Safe Browsing users.
+-  if (safe_browsing::IsSafeBrowsingEnabled(*profile->GetPrefs())) {
+-    psd.string_data_.insert({Fields::kUrlDownload,
+-                             download_item->GetURL().possibly_invalid_spec()});
+-    psd.string_data_.insert(
+-        {Fields::kUrlReferrer,
+-         download_item->GetReferrerUrl().possibly_invalid_spec()});
+-    psd.string_data_.insert(
+-        {Fields::kFilename,
+-         base::UTF16ToUTF8(
+-             download_item->GetFileNameToReportUser().LossyDisplayName())});
+-  } else {
+     psd.string_data_.insert({Fields::kUrlDownload, kNotLoggedNoSafeBrowsing});
+     psd.string_data_.insert({Fields::kUrlReferrer, kNotLoggedNoSafeBrowsing});
+     psd.string_data_.insert({Fields::kFilename, kNotLoggedNoSafeBrowsing});
+-  }
+ 
+   // Interaction details logged only for ESB users.
+   std::optional<DownloadItemWarningData::WarningSurface>
+       warning_first_shown_surface =
+           DownloadItemWarningData::WarningFirstShownSurface(download_item);
+-  if (warning_first_shown_surface &&
+-      safe_browsing::IsEnhancedProtectionEnabled(*profile->GetPrefs())) {
+-    std::vector<DownloadItemWarningData::WarningActionEvent>
+-        warning_action_events =
+-            DownloadItemWarningData::GetWarningActionEvents(download_item);
+-    psd.string_data_.insert(
+-        {Fields::kWarningInteractions,
+-         SerializeWarningActionEvents(*warning_first_shown_surface,
+-                                      warning_action_events)});
+-  } else {
+     psd.string_data_.insert(
+         {Fields::kWarningInteractions, kNotLoggedNoEnhancedProtection});
+-  }
+ 
+   return psd;
+ }
+@@ -477,40 +437,7 @@ bool CanShowDownloadWarningHatsSurvey(do
+ 
+ std::optional<std::string> MaybeGetDownloadWarningHatsTrigger(
+     DownloadWarningHatsType survey_type) {
+-  if (!base::FeatureList::IsEnabled(safe_browsing::kDownloadWarningSurvey)) {
+-    return std::nullopt;
+-  }
+-
+-  const int eligible_survey_type =
+-      safe_browsing::kDownloadWarningSurveyType.Get();
+-
+-  // Configuration error.
+-  if (eligible_survey_type < 0 ||
+-      eligible_survey_type >
+-          static_cast<int>(DownloadWarningHatsType::kMaxValue)) {
+-    return std::nullopt;
+-  }
+-
+-  // User is not assigned to be eligible for this type.
+-  if (static_cast<DownloadWarningHatsType>(eligible_survey_type) !=
+-      survey_type) {
+     return std::nullopt;
+-  }
+-
+-  switch (survey_type) {
+-    case DownloadWarningHatsType::kDownloadBubbleBypass:
+-      return kHatsSurveyTriggerDownloadWarningBubbleBypass;
+-    case DownloadWarningHatsType::kDownloadBubbleHeed:
+-      return kHatsSurveyTriggerDownloadWarningBubbleHeed;
+-    case DownloadWarningHatsType::kDownloadBubbleIgnore:
+-      return kHatsSurveyTriggerDownloadWarningBubbleIgnore;
+-    case DownloadWarningHatsType::kDownloadsPageBypass:
+-      return kHatsSurveyTriggerDownloadWarningPageBypass;
+-    case DownloadWarningHatsType::kDownloadsPageHeed:
+-      return kHatsSurveyTriggerDownloadWarningPageHeed;
+-    case DownloadWarningHatsType::kDownloadsPageIgnore:
+-      return kHatsSurveyTriggerDownloadWarningPageIgnore;
+-  }
+ }
+ 
+ base::TimeDelta GetIgnoreDownloadBubbleWarningDelay() {
+--- a/chrome/browser/enterprise/BUILD.gn
++++ b/chrome/browser/enterprise/BUILD.gn
+@@ -394,7 +394,6 @@ source_set("impl") {
+     "connectors/interstitials/enterprise_warn_page.cc",
+     "connectors/referrer_cache_utils.cc",
+     "core/dependency_factory_impl.cc",
+-    "data_protection/view_source_navigation_throttle.cc",
+     "encryption/cache_encryption_provider_impl.cc",
+     "identifiers/profile_id_delegate_impl.cc",
+     "identifiers/profile_id_service_factory.cc",
+--- a/chrome/browser/enterprise/connectors/analysis/content_analysis_delegate.cc
++++ b/chrome/browser/enterprise/connectors/analysis/content_analysis_delegate.cc
+@@ -39,8 +39,6 @@
+ #include "chrome/browser/profiles/profile.h"
+ #include "chrome/browser/safe_browsing/chrome_enterprise_url_lookup_service_factory.h"
+ #include "chrome/browser/safe_browsing/cloud_content_scanning/deep_scanning_utils.h"
+-#include "chrome/browser/safe_browsing/cloud_content_scanning/file_analysis_request.h"
+-#include "chrome/browser/safe_browsing/download_protection/check_client_download_request.h"
+ #include "chrome/browser/safe_browsing/safe_browsing_navigation_observer_manager_factory.h"
+ #include "chrome/browser/signin/identity_manager_factory.h"
+ #include "chrome/grit/generated_resources.h"
+--- a/chrome/browser/enterprise/connectors/analysis/content_analysis_downloads_delegate.cc
++++ b/chrome/browser/enterprise/connectors/analysis/content_analysis_downloads_delegate.cc
+@@ -135,7 +135,7 @@ ContentAnalysisDownloadsDelegate::GetCus
+ }
+ 
+ bool ContentAnalysisDownloadsDelegate::BypassRequiresJustification() const {
+-  return bypass_justification_required_;
++  return false;
+ }
+ 
+ std::u16string ContentAnalysisDownloadsDelegate::GetBypassJustificationLabel()
+--- a/chrome/browser/enterprise/connectors/connectors_manager.cc
++++ b/chrome/browser/enterprise/connectors/connectors_manager.cc
+@@ -169,26 +169,7 @@ void ConnectorsManager::OnAnalysisPrefCh
+ }
+ 
+ DataRegion ConnectorsManager::GetDataRegion(AnalysisConnector connector) const {
+-#if BUILDFLAG(IS_ANDROID)
+   return DataRegion::NO_PREFERENCE;
+-#else
+-  // Connector's policy scope determines the DRZ policy scope to use.
+-  policy::PolicyScope scope = static_cast<policy::PolicyScope>(
+-      prefs()->GetInteger(AnalysisConnectorScopePref(connector)));
+-
+-  const PrefService* pref_service =
+-      (scope == policy::PolicyScope::POLICY_SCOPE_MACHINE)
+-          ? g_browser_process->local_state()
+-          : prefs();
+-
+-  if (!pref_service ||
+-      !pref_service->HasPrefPath(prefs::kChromeDataRegionSetting)) {
+-    return DataRegion::NO_PREFERENCE;
+-  }
+-
+-  return ChromeDataRegionSettingToEnum(
+-      pref_service->GetInteger(prefs::kChromeDataRegionSetting));
+-#endif
+ }
+ 
+ }  // namespace enterprise_connectors
+--- a/chrome/browser/enterprise/connectors/device_trust/signals/decorators/common/context_signals_decorator.cc
++++ b/chrome/browser/enterprise/connectors/device_trust/signals/decorators/common/context_signals_decorator.cc
+@@ -26,24 +26,6 @@ enum class PasswordProtectionTrigger {
+   kPhisingReuse = 3
+ };
+ 
+-PasswordProtectionTrigger ConvertPasswordProtectionTrigger(
+-    const std::optional<safe_browsing::PasswordProtectionTrigger>&
+-        policy_value) {
+-  if (!policy_value) {
+-    return PasswordProtectionTrigger::kUnset;
+-  }
+-
+-  switch (policy_value.value()) {
+-    case safe_browsing::PASSWORD_PROTECTION_OFF:
+-      return PasswordProtectionTrigger::kOff;
+-    case safe_browsing::PASSWORD_REUSE:
+-      return PasswordProtectionTrigger::kPasswordReuse;
+-    case safe_browsing::PHISHING_REUSE:
+-      return PasswordProtectionTrigger::kPhisingReuse;
+-    case safe_browsing::PASSWORD_PROTECTION_TRIGGER_MAX:
+-      NOTREACHED();
+-  }
+-}
+ 
+ }  // namespace
+ 
+@@ -73,16 +55,8 @@ void ContextSignalsDecorator::OnSignalsF
+               ToListValue(context_info.browser_affiliation_ids));
+   signals.Set(device_signals::names::kProfileAffiliationIds,
+               ToListValue(context_info.profile_affiliation_ids));
+-  signals.Set(device_signals::names::kRealtimeUrlCheckMode,
+-              static_cast<int32_t>(context_info.realtime_url_check_mode));
+-  signals.Set(
+-      device_signals::names::kSafeBrowsingProtectionLevel,
+-      static_cast<int32_t>(context_info.safe_browsing_protection_level));
+   signals.Set(device_signals::names::kSiteIsolationEnabled,
+               context_info.site_isolation_enabled);
+-  signals.Set(device_signals::names::kPasswordProtectionWarningTrigger,
+-              static_cast<int32_t>(ConvertPasswordProtectionTrigger(
+-                  context_info.password_protection_warning_trigger)));
+   signals.Set(device_signals::names::kChromeRemoteDesktopAppBlocked,
+               context_info.chrome_remote_desktop_app_blocked);
+   signals.Set(device_signals::names::kBuiltInDnsClientEnabled,
+--- a/chrome/browser/enterprise/connectors/referrer_cache_utils.cc
++++ b/chrome/browser/enterprise/connectors/referrer_cache_utils.cc
+@@ -44,11 +44,6 @@ safe_browsing::ReferrerChain GetSafeBrow
+     const GURL& url,
+     content::WebContents& web_contents) {
+   safe_browsing::ReferrerChain referrers;
+-  safe_browsing::SafeBrowsingNavigationObserverManagerFactory::
+-      GetForBrowserContext(web_contents.GetBrowserContext())
+-          ->IdentifyReferrerChainByEventURL(
+-              url, sessions::SessionTabHelper::IdForTab(&web_contents),
+-              kReferrerUserGestureLimit, &referrers);
+   return referrers;
+ }
+ 
+--- a/chrome/browser/enterprise/connectors/reporting/realtime_reporting_client.cc
++++ b/chrome/browser/enterprise/connectors/reporting/realtime_reporting_client.cc
+@@ -278,20 +278,7 @@ void RealtimeReportingClient::SetProfile
+ }
+ 
+ std::string RealtimeReportingClient::GetProfileUserName() {
+-  if (!username_.empty()) {
+-    return username_;
+-  }
+-  username_ =
+-      identity_manager_ ? GetProfileEmail(identity_manager_) : std::string();
+-
+-#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
+-  if (username_.empty()) {
+-    username_ = Profile::FromBrowserContext(context_)->GetPrefs()->GetString(
+-        enterprise_signin::prefs::kProfileUserEmail);
+-  }
+-#endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
+-
+-  return username_;
++  return std::string();
+ }
+ 
+ std::string RealtimeReportingClient::GetProfileIdentifier() {
+--- a/chrome/browser/enterprise/connectors/reporting/telomere_reporting_context.cc
++++ b/chrome/browser/enterprise/connectors/reporting/telomere_reporting_context.cc
+@@ -178,19 +178,6 @@ TelomereReportingContext* TelomereReport
+ }
+ 
+ RealtimeReportingClient* TelomereReportingContext::GetReportingClient() const {
+-  for (auto& it : active_profiles_) {
+-    Profile* profile = it.second;
+-    RealtimeReportingClient* reporting_client =
+-        RealtimeReportingClientFactory::GetForProfile(profile);
+-    if (!reporting_client) {
+-      continue;
+-    }
+-    std::optional<ReportingSettings> settings =
+-        reporting_client->GetReportingSettings();
+-    if (settings.has_value() && !settings->per_profile) {
+-      return reporting_client;
+-    }
+-  }
+   return nullptr;
+ }
+ 
+--- a/chrome/browser/enterprise/data_controls/chrome_clipboard_context.cc
++++ b/chrome/browser/enterprise/data_controls/chrome_clipboard_context.cc
+@@ -147,23 +147,11 @@ std::optional<size_t> ChromeClipboardCon
+ }
+ 
+ std::string ChromeClipboardContext::source_active_user() const {
+-  auto* profile = Profile::FromBrowserContext(source_.browser_context());
+-  if (!profile) {
+     return "";
+-  }
+-
+-  return enterprise_connectors::ContentAreaUserProvider::GetUser(
+-      profile, source_.web_contents(), source_url());
+ }
+ 
+ std::string ChromeClipboardContext::destination_active_user() const {
+-  auto* profile = Profile::FromBrowserContext(destination_.browser_context());
+-  if (!profile) {
+     return "";
+-  }
+-
+-  return enterprise_connectors::ContentAreaUserProvider::GetUser(
+-      profile, destination_.web_contents(), destination_url());
+ }
+ 
+ }  // namespace data_controls
+--- a/chrome/browser/enterprise/data_protection/data_protection_navigation_observer.cc
++++ b/chrome/browser/enterprise/data_protection/data_protection_navigation_observer.cc
+@@ -196,9 +196,7 @@ void LogVerdictSource(
+ 
+ bool IsScreenshotAllowedByDataControls(content::BrowserContext* context,
+                                        const GURL& url) {
+-  auto* rules = data_controls::ChromeRulesServiceFactory::GetInstance()
+-                    ->GetForBrowserContext(context);
+-  return rules ? !rules->BlockScreenshots(url) : true;
++  return true;
+ }
+ 
+ }  // namespace
+--- a/chrome/browser/enterprise/data_protection/data_protection_url_lookup_service_factory.cc
++++ b/chrome/browser/enterprise/data_protection/data_protection_url_lookup_service_factory.cc
+@@ -13,8 +13,7 @@ namespace enterprise_data_protection {
+ // static
+ DataProtectionUrlLookupServiceFactory*
+ DataProtectionUrlLookupServiceFactory::GetInstance() {
+-  static base::NoDestructor<DataProtectionUrlLookupServiceFactory> instance;
+-  return instance.get();
++  return nullptr;
+ }
+ 
+ // static
+--- a/chrome/browser/enterprise/data_protection/data_protection_url_lookup_service_factory.h
++++ b/chrome/browser/enterprise/data_protection/data_protection_url_lookup_service_factory.h
+@@ -26,7 +26,6 @@ class DataProtectionUrlLookupServiceFact
+  private:
+   DataProtectionUrlLookupServiceFactory();
+   ~DataProtectionUrlLookupServiceFactory() override;
+-  friend base::NoDestructor<DataProtectionUrlLookupServiceFactory>;
+ 
+   // BrowserContextKeyedServiceFactory:
+   std::unique_ptr<KeyedService> BuildServiceInstanceForBrowserContext(
+--- a/chrome/browser/enterprise/reporting/saas_usage/saas_usage_report_scheduler_delegate_desktop.cc
++++ b/chrome/browser/enterprise/reporting/saas_usage/saas_usage_report_scheduler_delegate_desktop.cc
+@@ -36,21 +36,6 @@ bool SaasUsageReportSchedulerDelegateDes
+ }
+ 
+ void SaasUsageReportSchedulerDelegateDesktop::OnProfileAdded(Profile* profile) {
+-  // If browser is managed, any profile with a RealtimeReportingClient will be
+-  // able to upload reports using browser DM token.
+-  if (!enterprise_connectors::RealtimeReportingClientFactory::GetForProfile(
+-          profile)) {
+-    return;
+-  }
+-
+-  bool was_ready = IsReady();
+-  profile_observation_.AddObservation(profile);
+-  if (ready_state_changed_callback_ && !was_ready) {
+-    VLOG_POLICY(1, REPORTING)
+-        << "SaaS usage reporting is enabled because a reporting-enabled "
+-           "profile has been added.";
+-    ready_state_changed_callback_.Run();
+-  }
+ }
+ 
+ void SaasUsageReportSchedulerDelegateDesktop::OnProfileManagerDestroying() {
+--- a/chrome/browser/enterprise/reporting/saas_usage/saas_usage_report_uploader_desktop.cc
++++ b/chrome/browser/enterprise/reporting/saas_usage/saas_usage_report_uploader_desktop.cc
+@@ -96,8 +96,7 @@ SaasUsageProfileReportUploaderDesktop::S
+ 
+ enterprise_connectors::RealtimeReportingClientBase*
+ SaasUsageProfileReportUploaderDesktop::GetRealTimeReportingClient() {
+-  return enterprise_connectors::RealtimeReportingClientFactory::GetForProfile(
+-      &profile_.get());
++  return nullptr;
+ }
+ 
+ bool SaasUsageProfileReportUploaderDesktop::ShouldUseProfileClient() {
+@@ -130,18 +129,6 @@ std::optional<std::string> SaasUsageBrow
+ 
+ enterprise_connectors::RealtimeReportingClientBase*
+ SaasUsageBrowserReportUploaderDesktop::GetRealTimeReportingClient() {
+-  // Browser-level reporting can use client from any profile.
+-  // Report scheduler ensures that the client is available before scheduling
+-  // the report upload.
+-  for (auto* profile :
+-       g_browser_process->profile_manager()->GetLoadedProfiles()) {
+-    auto* client =
+-        enterprise_connectors::RealtimeReportingClientFactory::GetForProfile(
+-            profile);
+-    if (client) {
+-      return client;
+-    }
+-  }
+   return nullptr;
+ }
+ 
+--- a/chrome/browser/enterprise/signals/context_info_fetcher.h
++++ b/chrome/browser/enterprise/signals/context_info_fetcher.h
+@@ -6,6 +6,7 @@
+ #define CHROME_BROWSER_ENTERPRISE_SIGNALS_CONTEXT_INFO_FETCHER_H_
+ 
+ #include <string>
++#include <memory>
+ #include <vector>
+ 
+ #include "base/functional/callback_forward.h"
+@@ -41,7 +42,6 @@ struct ContextInfo {
+   std::vector<std::string> on_bulk_data_entry_providers;
+   std::vector<std::string> on_print_providers;
+   std::vector<std::string> on_security_event_providers;
+-  enterprise_connectors::EnterpriseRealTimeUrlCheckMode realtime_url_check_mode;
+   std::string browser_version;
+   safe_browsing::SafeBrowsingState safe_browsing_protection_level;
+   bool site_isolation_enabled;
+--- a/chrome/browser/enterprise/signals/profile_signals_collector.cc
++++ b/chrome/browser/enterprise/signals/profile_signals_collector.cc
+@@ -78,12 +78,8 @@ void ProfileSignalsCollector::GetProfile
+   signal_response.chrome_remote_desktop_app_blocked =
+       device_signals::GetChromeRemoteDesktopAppBlocked(
+           policy_blocklist_service_);
+-  signal_response.password_protection_warning_trigger =
+-      device_signals::GetPasswordProtectionWarningTrigger(profile_prefs_);
+   signal_response.profile_enrollment_domain =
+       device_signals::TryGetEnrollmentDomain(policy_manager_);
+-  signal_response.safe_browsing_protection_level =
+-      device_signals::GetSafeBrowsingProtectionLevel(profile_prefs_);
+   signal_response.site_isolation_enabled =
+       device_signals::GetSiteIsolationEnabled();
+   signal_response.profile_id = profile_id_service_->GetProfileId();
+--- a/chrome/browser/extensions/BUILD.gn
++++ b/chrome/browser/extensions/BUILD.gn
+@@ -383,8 +383,6 @@ source_set("extensions") {
+     "menu_manager_factory.h",
+     "navigation_extension_enabler.cc",
+     "navigation_extension_enabler.h",
+-    "omaha_attributes_handler.cc",
+-    "omaha_attributes_handler.h",
+     "open_tab_helper.cc",
+     "open_tab_helper.h",
+     "pack_extension_job.cc",
+--- a/chrome/browser/extensions/api/downloads/downloads_api.cc
++++ b/chrome/browser/extensions/api/downloads/downloads_api.cc
+@@ -59,7 +59,6 @@
+ #include "components/download/public/common/download_interrupt_reasons.h"
+ #include "components/download/public/common/download_item.h"
+ #include "components/download/public/common/download_url_parameters.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/web_modal/web_contents_modal_dialog_manager.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "content/public/browser/render_frame_host.h"
+@@ -1070,21 +1069,6 @@ bool IsDownloadDeltaField(const std::str
+ // dangerous download.
+ // NOTE: Android does not support the TrustSafetySentimentService.
+ void MaybeTriggerTrustSafetySentimentSurvey(Profile* profile, bool accept) {
+-#if !BUILDFLAG(IS_ANDROID)
+-  // Survey triggered on ACCEPT action, since this is where the user
+-  // confirms their choice to keep a dangerous download, rather than
+-  // triggering a survey after selecting to KEEP in the downloads page UI.
+-  if (safe_browsing::IsSafeBrowsingSurveysEnabled(*profile->GetPrefs()) &&
+-      accept) {
+-    TrustSafetySentimentService* trust_safety_sentiment_service =
+-        TrustSafetySentimentServiceFactory::GetForProfile(profile);
+-    if (trust_safety_sentiment_service) {
+-      trust_safety_sentiment_service->InteractedWithDownloadWarningUI(
+-          DownloadItemWarningData::WarningSurface::DOWNLOAD_PROMPT,
+-          DownloadItemWarningData::WarningAction::PROCEED);
+-    }
+-  }
+-#endif  // !BUILDFLAG(IS_ANDROID)
+ }
+ 
+ }  // namespace
+--- a/chrome/browser/extensions/api/enterprise_reporting_private/enterprise_reporting_private_api.cc
++++ b/chrome/browser/extensions/api/enterprise_reporting_private/enterprise_reporting_private_api.cc
+@@ -97,16 +97,8 @@ api::enterprise_reporting_private::Conte
+       signals.chrome_remote_desktop_app_blocked;
+   info.os_firewall = ToInfoSettingValue(signals.os_firewall);
+   info.system_dns_servers = std::move(signals.system_dns_servers);
+-  switch (signals.realtime_url_check_mode) {
+-    case enterprise_connectors::REAL_TIME_CHECK_DISABLED:
+       info.realtime_url_check_mode = extensions::api::
+           enterprise_reporting_private::RealtimeUrlCheckMode::kDisabled;
+-      break;
+-    case enterprise_connectors::REAL_TIME_CHECK_FOR_MAINFRAME_ENABLED:
+-      info.realtime_url_check_mode = extensions::api::
+-          enterprise_reporting_private::RealtimeUrlCheckMode::kEnabledMainFrame;
+-      break;
+-  }
+   info.browser_version = std::move(signals.browser_version);
+   info.built_in_dns_client_enabled = signals.built_in_dns_client_enabled;
+   info.enterprise_profile_id = signals.enterprise_profile_id;
+--- a/chrome/browser/extensions/api/settings_private/generated_prefs.cc
++++ b/chrome/browser/extensions/api/settings_private/generated_prefs.cc
+@@ -108,11 +108,6 @@ void GeneratedPrefs::CreatePrefs() {
+       content_settings::GeneratedThirdPartyCookieBlockingSettingPref>(profile_);
+   prefs_[kGeneratedPasswordLeakDetectionPref] =
+       std::make_unique<GeneratedPasswordLeakDetectionPref>(profile_);
+-  prefs_[safe_browsing::kGeneratedSafeBrowsingPref] =
+-      std::make_unique<safe_browsing::GeneratedSafeBrowsingPref>(profile_);
+-  prefs_[safe_browsing::kGeneratedSecuritySettingsBundlePref] =
+-      std::make_unique<safe_browsing::GeneratedSecuritySettingsBundlePref>(
+-          profile_);
+   prefs_[content_settings::kGeneratedNotificationPref] = std::make_unique<
+       content_settings::GeneratedPermissionPromptingBehaviorPref>(
+       profile_, ContentSettingsType::NOTIFICATIONS);
+--- a/chrome/browser/extensions/api/settings_private/prefs_util.cc
++++ b/chrome/browser/extensions/api/settings_private/prefs_util.cc
+@@ -427,8 +427,6 @@ const PrefsUtil::TypedPrefMap& PrefsUtil
+       settings_api::PrefType::kBoolean;
+   (*s_allowlist)[::kGeneratedHttpsFirstModePref] =
+       settings_api::PrefType::kNumber;
+-  (*s_allowlist)[::prefs::kSecuritySettingsBundle] =
+-      settings_api::PrefType::kNumber;
+   (*s_allowlist)[::safe_browsing::kGeneratedSecuritySettingsBundlePref] =
+       settings_api::PrefType::kNumber;
+ 
+--- a/chrome/browser/extensions/chrome_extension_system.cc
++++ b/chrome/browser/extensions/chrome_extension_system.cc
+@@ -474,8 +474,6 @@ void ChromeExtensionSystem::InstallUpdat
+ void ChromeExtensionSystem::PerformActionBasedOnOmahaAttributes(
+     const std::string& extension_id,
+     const base::DictValue& attributes) {
+-  extension_service()->PerformActionBasedOnOmahaAttributes(extension_id,
+-                                                           attributes);
+ }
+ 
+ }  // namespace extensions
+--- a/chrome/browser/extensions/extension_allowlist_factory.cc
++++ b/chrome/browser/extensions/extension_allowlist_factory.cc
+@@ -49,7 +49,6 @@ ExtensionAllowlistFactory::ExtensionAllo
+   DependsOn(ExtensionPrefsFactory::GetInstance());
+   DependsOn(ExtensionRegistrarFactory::GetInstance());
+   DependsOn(ExtensionRegistryFactory::GetInstance());
+-  DependsOn(safe_browsing::SafeBrowsingMetricsCollectorFactory::GetInstance());
+ }
+ 
+ ExtensionAllowlistFactory::~ExtensionAllowlistFactory() = default;
+@@ -60,8 +59,7 @@ ExtensionAllowlistFactory::BuildServiceI
+   // Use `new` because the constructor is private.
+   return base::WrapUnique(new ExtensionAllowlist(
+       context,
+-      safe_browsing::SafeBrowsingMetricsCollectorFactory::GetForProfile(
+-          Profile::FromBrowserContext(context))));
++      nullptr));
+ }
+ 
+ }  // namespace extensions
+--- a/chrome/browser/extensions/extension_safety_check_utils.cc
++++ b/chrome/browser/extensions/extension_safety_check_utils.cc
+@@ -266,9 +266,6 @@ developer::SafetyCheckWarningReason GetS
+       top_warning_reason =
+           developer::SafetyCheckWarningReason::kNoPrivacyPractice;
+ 
+-    } else if (SafetyCheckShouldShowOffstoreExtension(extension, profile,
+-                                                      cws_info)) {
+-      top_warning_reason = developer::SafetyCheckWarningReason::kOffstore;
+     }
+   }
+ 
+--- a/chrome/browser/extensions/extension_service.cc
++++ b/chrome/browser/extensions/extension_service.cc
+@@ -52,7 +52,6 @@
+ #include "chrome/browser/extensions/external_provider_manager.h"
+ #include "chrome/browser/extensions/install_verifier_factory.h"
+ #include "chrome/browser/extensions/installed_loader.h"
+-#include "chrome/browser/extensions/omaha_attributes_handler.h"
+ #include "chrome/browser/extensions/profile_util.h"
+ #include "chrome/browser/extensions/sync/extension_sync_service.h"
+ #include "chrome/browser/extensions/updater/chrome_extension_downloader_factory.h"
+@@ -223,9 +222,6 @@ ExtensionService::ExtensionService(
+       extension_telemetry_service_verdict_handler_(extension_prefs,
+                                                    registry_,
+                                                    extension_registrar_),
+-      omaha_attributes_handler_(extension_prefs,
+-                                registry_,
+-                                extension_registrar_),
+       force_installed_tracker_(registry_, profile_),
+       force_installed_metrics_(registry_, profile_, &force_installed_tracker_),
+       corrupted_extension_reinstaller_(
+@@ -421,11 +417,6 @@ void ExtensionService::LoadExtensionsFro
+         << "--load-extension is not allowed in Google Chrome, ignoring.";
+     return;
+ #else   // BUILDFLAG(GOOGLE_CHROME_BRANDING) && !BUILDFLAG(IS_CHROMEOS)
+-    if (safe_browsing::IsEnhancedProtectionEnabled(*profile_->GetPrefs())) {
+-      VLOG(1) << "--load-extension is not allowed for users opted into "
+-              << "Enhanced Safe Browsing, ignoring.";
+-      return;
+-    }
+     if (ShouldBlockCommandLineExtension(*profile_)) {
+       // TODO(crbug.com/401529219): Deprecate this restriction once
+       // --load-extension removal on Chrome builds is fully launched.
+@@ -481,17 +472,6 @@ void ExtensionService::LoadSigninProfile
+ }
+ #endif
+ 
+-void ExtensionService::PerformActionBasedOnOmahaAttributes(
+-    const std::string& extension_id,
+-    const base::DictValue& attributes) {
+-  DCHECK_CURRENTLY_ON(BrowserThread::UI);
+-  omaha_attributes_handler_.PerformActionBasedOnOmahaAttributes(extension_id,
+-                                                                attributes);
+-  allowlist_->PerformActionBasedOnOmahaAttributes(extension_id, attributes);
+-  // Show an error for the newly blocklisted extension.
+-  error_controller_->ShowErrorIfNeeded();
+-}
+-
+ void ExtensionService::PerformActionBasedOnExtensionTelemetryServiceVerdicts(
+     const Blocklist::BlocklistStateMap& blocklist_state_map) {
+   DCHECK_CURRENTLY_ON(BrowserThread::UI);
+--- a/chrome/browser/extensions/extension_service.h
++++ b/chrome/browser/extensions/extension_service.h
+@@ -24,7 +24,6 @@
+ #include "chrome/browser/extensions/extension_telemetry_service_verdict_handler.h"
+ #include "chrome/browser/extensions/forced_extensions/force_installed_metrics.h"
+ #include "chrome/browser/extensions/forced_extensions/force_installed_tracker.h"
+-#include "chrome/browser/extensions/omaha_attributes_handler.h"
+ #include "chrome/browser/extensions/safe_browsing_verdict_handler.h"
+ #include "chrome/browser/policy/cloud/extension_install_policy_service.h"
+ #include "chrome/browser/profiles/profile_manager_observer.h"
+@@ -170,10 +169,6 @@ class ExtensionService : public Extensio
+   // KeyedService two-phase shutdown.
+   void Shutdown();
+ 
+-  // Performs action based on Omaha attributes for the extension.
+-  void PerformActionBasedOnOmahaAttributes(const std::string& extension_id,
+-                                           const base::DictValue& attributes);
+-
+   // Performs action based on verdicts received from the Extension Telemetry
+   // server. Currently, these verdicts are limited to off-store extensions.
+   void PerformActionBasedOnExtensionTelemetryServiceVerdicts(
+@@ -388,8 +383,6 @@ class ExtensionService : public Extensio
+   ExtensionTelemetryServiceVerdictHandler
+       extension_telemetry_service_verdict_handler_;
+ 
+-  // Needs `extension_registrar_` during construction.
+-  OmahaAttributesHandler omaha_attributes_handler_;
+ 
+   // Tracker of enterprise policy forced installation.
+   ForceInstalledTracker force_installed_tracker_;
+--- a/chrome/browser/extensions/extension_telemetry_service_verdict_handler.cc
++++ b/chrome/browser/extensions/extension_telemetry_service_verdict_handler.cc
+@@ -76,14 +76,12 @@ void ExtensionTelemetryServiceVerdictHan
+         blocklist_prefs::SetExtensionTelemetryServiceBlocklistState(
+             extension_id, BitMapBlocklistState::NOT_BLOCKLISTED,
+             extension_prefs_);
+-        registrar_->OnBlocklistStateRemoved(extension_id);
+         ReportOffstoreExtensionReenabled(current_state);
+         break;
+       case BLOCKLISTED_MALWARE:
+         blocklist_prefs::SetExtensionTelemetryServiceBlocklistState(
+             extension_id, BitMapBlocklistState::BLOCKLISTED_MALWARE,
+             extension_prefs_);
+-        registrar_->OnBlocklistStateAdded(extension_id);
+         ReportOffstoreExtensionDisabled(
+             ExtensionTelemetryDisableReason::kMalware);
+         break;
+--- a/chrome/browser/extensions/safe_browsing_verdict_handler.cc
++++ b/chrome/browser/extensions/safe_browsing_verdict_handler.cc
+@@ -123,7 +123,6 @@ void SafeBrowsingVerdictHandler::UpdateB
+     blocklist_.Remove(id);
+     blocklist_prefs::SetSafeBrowsingExtensionBlocklistState(
+         id, BitMapBlocklistState::NOT_BLOCKLISTED, extension_prefs_);
+-    registrar_->OnBlocklistStateRemoved(id);
+     UMA_HISTOGRAM_ENUMERATION("ExtensionBlacklist.UnblacklistInstalled",
+                               extension->location());
+   }
+@@ -137,7 +136,6 @@ void SafeBrowsingVerdictHandler::UpdateB
+     blocklist_.Insert(extension);
+     blocklist_prefs::SetSafeBrowsingExtensionBlocklistState(
+         id, BitMapBlocklistState::BLOCKLISTED_MALWARE, extension_prefs_);
+-    registrar_->OnBlocklistStateAdded(id);
+     UMA_HISTOGRAM_ENUMERATION("ExtensionBlacklist.BlacklistInstalled",
+                               extension->location());
+   }
+@@ -161,7 +159,6 @@ void SafeBrowsingVerdictHandler::UpdateG
+     blocklist_prefs::SetSafeBrowsingExtensionBlocklistState(
+         extension->id(), BitMapBlocklistState::NOT_BLOCKLISTED,
+         extension_prefs_);
+-    registrar_->OnGreylistStateRemoved(extension->id());
+     UMA_HISTOGRAM_ENUMERATION("Extensions.Greylist.Enabled",
+                               extension->location());
+   }
+@@ -181,7 +178,6 @@ void SafeBrowsingVerdictHandler::UpdateG
+         blocklist_prefs::BlocklistStateToBitMapBlocklistState(greylist_state);
+     blocklist_prefs::SetSafeBrowsingExtensionBlocklistState(
+         extension->id(), bitmap_greylist_state, extension_prefs_);
+-    registrar_->OnGreylistStateAdded(id, bitmap_greylist_state);
+     UMA_HISTOGRAM_ENUMERATION("Extensions.Greylist.Disabled",
+                               extension->location());
+   }
+--- a/chrome/browser/feedback/BUILD.gn
++++ b/chrome/browser/feedback/BUILD.gn
+@@ -141,7 +141,6 @@ source_set("feedback_impl") {
+       "//components/device_event_log",
+       "//components/feedback",
+       "//components/performance_manager",
+-      "//components/safe_browsing/content/browser:client_side_detection",
+       "//components/supervised_user/core/browser",
+       "//extensions/browser",
+       "//extensions/browser/api/feedback_private",
+--- a/chrome/browser/feedback/report_unsafe_site/screenshot_taker.cc
++++ b/chrome/browser/feedback/report_unsafe_site/screenshot_taker.cc
+@@ -7,7 +7,6 @@
+ #include <algorithm>
+ #include <memory>
+ 
+-#include "components/safe_browsing/content/browser/client_side_detection_host.h"
+ #include "components/viz/common/frame_sinks/copy_output_result.h"
+ #include "content/public/browser/render_widget_host_view.h"
+ #include "content/public/browser/web_contents.h"
+@@ -60,8 +59,7 @@ ScreenshotTaker::ScreenshotTaker(
+   gfx::Size target_size = ComputeTargetSize(
+       view_size,
+       gfx::Size(
+-          safe_browsing::ClientSideDetectionHost::kMaxHighResScreenshotWidth,
+-          safe_browsing::ClientSideDetectionHost::kMaxHighResScreenshotHeight));
++          4096, 2160));
+   std::move(copy_from_surface_callback)
+       .Run(gfx::Rect(view_size), target_size,
+            base::BindOnce(&ScreenshotTaker::OnGotScreenshot,
+--- a/chrome/browser/feedback/report_unsafe_site_dialog_views.cc
++++ b/chrome/browser/feedback/report_unsafe_site_dialog_views.cc
+@@ -23,7 +23,6 @@
+ #include "chrome/common/webui_url_constants.h"
+ #include "chrome/grit/branded_strings.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "content/public/browser/web_contents.h"
+ #include "ui/base/metadata/metadata_header_macros.h"
+ #include "ui/base/metadata/metadata_impl_macros.h"
+@@ -115,10 +114,7 @@ DEFINE_CLASS_ELEMENT_IDENTIFIER_VALUE(Re
+ 
+ // static
+ bool ReportUnsafeSiteDialog::IsEnabled(const Profile& profile) {
+-  const PrefService* prefs = profile.GetPrefs();
+-  return base::FeatureList::IsEnabled(features::kReportUnsafeSite) &&
+-         !profile.IsOffTheRecord() && chrome::CanShowFeedback(&profile) &&
+-         safe_browsing::IsSafeBrowsingEnabled(*prefs);
++  return false;
+ }
+ 
+ // static
+--- a/chrome/browser/lifetime/smart_restart_policy.cc
++++ b/chrome/browser/lifetime/smart_restart_policy.cc
+@@ -6,7 +6,6 @@
+ 
+ #include "chrome/browser/profiles/profile.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ namespace smart_restart {
+ 
+--- a/chrome/browser/metrics/chrome_metrics_service_client.cc
++++ b/chrome/browser/metrics/chrome_metrics_service_client.cc
+@@ -856,13 +856,6 @@ void ChromeMetricsServiceClient::Registe
+   metrics_service_->RegisterMetricsProvider(MakeDemographicMetricsProvider(
+       metrics::MetricsLogUploader::MetricServiceType::UMA));
+ 
+-  // TODO(crbug.com/40765618): Add metrics registration for WebView and iOS.
+-  metrics_service_->RegisterMetricsProvider(
+-      std::make_unique<safe_browsing::SafeBrowsingMetricsProvider>());
+-  if (base::FeatureList::IsEnabled(safe_browsing::kBundledSecuritySettings)) {
+-    metrics_service_->RegisterMetricsProvider(
+-        std::make_unique<safe_browsing::BundledSettingsMetricsProvider>());
+-  }
+ 
+ #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS)
+   metrics_service_->RegisterMetricsProvider(
+--- a/chrome/browser/net/profile_network_context_service.cc
++++ b/chrome/browser/net/profile_network_context_service.cc
+@@ -577,19 +577,6 @@ ProfileNetworkContextService::ProfileNet
+                               UpdateCorsNonWildcardRequestHeadersSupport,
+                           base::Unretained(this)));
+ 
+-  // Register a callback for both kSafeBrowsingEnabled and kSafeBrowsingEnhanced
+-  // since `safe_browsing::IsEnhancedProtectionEnabled` returns an answer based
+-  // on both prefs.
+-  pref_change_registrar_.Add(
+-      prefs::kSafeBrowsingEnabled,
+-      base::BindRepeating(
+-          &ProfileNetworkContextService::UpdateDohFallbackUpgradeAllowed,
+-          base::Unretained(this)));
+-  pref_change_registrar_.Add(
+-      prefs::kSafeBrowsingEnhanced,
+-      base::BindRepeating(
+-          &ProfileNetworkContextService::UpdateDohFallbackUpgradeAllowed,
+-          base::Unretained(this)));
+ }
+ 
+ ProfileNetworkContextService::~ProfileNetworkContextService() = default;
+@@ -719,7 +706,7 @@ void ProfileNetworkContextService::Updat
+ 
+ void ProfileNetworkContextService::UpdateDohFallbackUpgradeAllowed() {
+   const bool allowed =
+-      safe_browsing::IsEnhancedProtectionEnabled(*profile_->GetPrefs());
++      false;
+ 
+   profile_->ForEachLoadedStoragePartition(
+       [allowed](content::StoragePartition* storage_partition) {
+@@ -1350,7 +1337,7 @@ void ProfileNetworkContextService::Confi
+   network_context_params->enable_referrers = enable_referrers_.GetValue();
+ 
+   network_context_params->doh_fallback_upgrade_allowed =
+-      safe_browsing::IsEnhancedProtectionEnabled(*profile_->GetPrefs());
++      false;
+ 
+   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+   if (command_line->HasSwitch(embedder_support::kShortReportingDelay)) {
+--- a/chrome/browser/net/stub_resolver_config_reader.cc
++++ b/chrome/browser/net/stub_resolver_config_reader.cc
+@@ -31,7 +31,6 @@
+ #include "components/prefs/pref_registry_simple.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/webui/flags/pref_service_flags_storage.h"
+ #include "content/public/browser/network_service_instance.h"
+ #include "net/base/features.h"
+--- a/chrome/browser/notifications/platform_notification_service_impl.cc
++++ b/chrome/browser/notifications/platform_notification_service_impl.cc
+@@ -792,68 +792,8 @@ void PlatformNotificationServiceImpl::
+         std::unique_ptr<PersistentNotificationMetadata> persistent_metadata,
+         bool should_show_warning,
+         std::optional<std::string> serialized_content_detection_metadata) {
+-  bool suspicious_notification_revoked = false;
+-  if (base::FeatureList::IsEnabled(
+-          safe_browsing::kAutoRevokeSuspiciousNotification) &&
+-      should_show_warning) {
+-#if BUILDFLAG(IS_ANDROID)
+-    suspicious_notification_revoked = AbusiveNotificationPermissionsManager::
+-        MaybeRevokeSuspiciousNotificationPermission(profile_,
+-                                                    notification.origin_url());
+-#endif
+-
+-    auto* service =
+-        NotificationsEngagementServiceFactory::GetForProfile(profile_);
+-    // This service might be missing for incognito profiles and in tests.
+-    if (!suspicious_notification_revoked && service) {
+-      // Increment suspicious count if the notification permission has not been
+-      // revoked.
+-      service->RecordNotificationSuspicious(notification.origin_url());
+-    }
+-  }
+-  if (base::FeatureList::IsEnabled(
+-          safe_browsing::kReportNotificationContentDetectionData)) {
+-    // If the notification permission has been revoked, we do still want to
+-    // record the notification in the database for re-grant scenario; however;
+-    // there is no need to trigger `DidUpdatePersistentMetadata` callback.
+-    content::PlatformNotificationContext::WriteResourcesResultCallback
+-        callback = suspicious_notification_revoked
+-                       ? base::DoNothing()
+-                       : base::BindOnce(&PlatformNotificationServiceImpl::
+-                                            DidUpdatePersistentMetadata,
+-                                        weak_ptr_factory_.GetWeakPtr(),
+-                                        std::move(persistent_metadata),
+-                                        notification, should_show_warning);
+-#if BUILDFLAG(IS_ANDROID)
+-    if (should_show_warning && !suspicious_notification_revoked) {
+-      // Keep track of suspicious notification ids.
+-      safe_browsing::UpdateSuspiciousNotificationIds(
+-          HostContentSettingsMapFactory::GetForProfile(profile_),
+-          notification.origin_url(), notification.id());
+-    }
+-#endif
+-    if (serialized_content_detection_metadata.has_value()) {
+-      scoped_refptr<content::PlatformNotificationContext> notification_context =
+-          profile_->GetStoragePartitionForUrl(notification.origin_url())
+-              ->GetPlatformNotificationContext();
+-      if (notification_context) {
+-        notification_context->WriteNotificationMetadata(
+-            notification.id(), notification.origin_url(),
+-            safe_browsing::kNotificationContentDetectionMetadataDictionaryKey,
+-            serialized_content_detection_metadata.value(), std::move(callback));
+-        return;
+-      }
+-    }
+-    std::move(callback).Run(/*success=*/false);
+-  } else {
+-    // Notification permission has been revoked due to suspicious content; do
+-    // not show notification.
+-    if (suspicious_notification_revoked) {
+-      return;
+-    }
+     DoUpdatePersistentMetadataThenDisplay(std::move(persistent_metadata),
+                                           notification, should_show_warning);
+-  }
+ }
+ 
+ void PlatformNotificationServiceImpl::LogPersistentNotificationShownMetrics(
+--- a/chrome/browser/permissions/permission_revocation_request.cc
++++ b/chrome/browser/permissions/permission_revocation_request.cc
+@@ -212,32 +212,6 @@ void PermissionRevocationRequest::OnSite
+         base::TimeTicks::Now() - crowd_deny_request_start_time_.value();
+   }
+ 
+-  if (site_reputation && !site_reputation->warning_only()) {
+-    bool should_revoke_permission = false;
+-    switch (site_reputation->notification_ux_quality()) {
+-      case CrowdDenyPreloadData::SiteReputation::ABUSIVE_PROMPTS:
+-      case CrowdDenyPreloadData::SiteReputation::ABUSIVE_CONTENT:
+-        should_revoke_permission = NotificationsPermissionRevocationConfig::
+-            IsAbusiveOriginPermissionRevocationEnabled();
+-        break;
+-      case CrowdDenyPreloadData::SiteReputation::DISRUPTIVE_BEHAVIOR:
+-        should_revoke_permission = true;
+-        break;
+-      default:
+-        should_revoke_permission = false;
+-    }
+-    DCHECK(g_browser_process->safe_browsing_service());
+-    if (should_revoke_permission &&
+-        g_browser_process->safe_browsing_service()) {
+-      safe_browsing_request_.emplace(
+-          g_browser_process->safe_browsing_service()->database_manager(),
+-          base::DefaultClock::GetInstance(), url::Origin::Create(origin_),
+-          base::BindOnce(
+-              &PermissionRevocationRequest::OnSafeBrowsingVerdictReceived,
+-              weak_factory_.GetWeakPtr(), site_reputation));
+-      return;
+-    }
+-  }
+   NotifyCallback(Outcome::PERMISSION_NOT_REVOKED);
+ }
+ 
+--- a/chrome/browser/permissions/prediction_service/contextual_notification_permission_ui_selector.cc
++++ b/chrome/browser/permissions/prediction_service/contextual_notification_permission_ui_selector.cc
+@@ -16,7 +16,6 @@
+ #include "chrome/browser/browser_process.h"
+ #include "chrome/browser/permissions/quiet_notification_permission_ui_config.h"
+ #include "chrome/browser/permissions/quiet_notification_permission_ui_state.h"
+-#include "chrome/browser/safe_browsing/safe_browsing_service.h"
+ #include "chrome/common/chrome_features.h"
+ #include "components/permissions/permission_request.h"
+ #include "components/permissions/request_type.h"
+@@ -151,9 +150,6 @@ void ContextualNotificationPermissionUiS
+ }
+ 
+ void ContextualNotificationPermissionUiSelector::Cancel() {
+-  // The computation either finishes synchronously above, or is waiting on the
+-  // Safe Browsing check.
+-  safe_browsing_request_.reset();
+ }
+ 
+ bool ContextualNotificationPermissionUiSelector::IsPermissionRequestSupported(
+@@ -179,24 +175,14 @@ void ContextualNotificationPermissionUiS
+   std::optional<Decision> decision =
+       GetDecisionBasedOnSiteReputation(reputation);
+ 
+-  // If the PreloadData suggests this is an unacceptable site, ping Safe
+-  // Browsing to verify; but do not ping if it is not warranted.
++  // If the PreloadData suggests this is an unacceptable site, assume it is
++  // correct, since we can't access safe browsing.
+   if (!decision || (!decision->quiet_ui_reason && !decision->warning_reason)) {
+     Notify(Decision::UseNormalUiAndShowNoWarning());
+-    return;
++  } else {
++    // decision has a value, unwrap with .value()
++    Notify(decision.value());
+   }
+-
+-  DCHECK(!safe_browsing_request_);
+-  DCHECK(g_browser_process->safe_browsing_service());
+-
+-  // It is fine to use base::Unretained() here, as |safe_browsing_request_|
+-  // guarantees not to fire the callback after its destruction.
+-  safe_browsing_request_.emplace(
+-      g_browser_process->safe_browsing_service()->database_manager(),
+-      base::DefaultClock::GetInstance(), origin,
+-      base::BindOnce(&ContextualNotificationPermissionUiSelector::
+-                         OnSafeBrowsingVerdictReceived,
+-                     base::Unretained(this), *decision));
+ }
+ 
+ void ContextualNotificationPermissionUiSelector::OnSafeBrowsingVerdictReceived(
+--- a/chrome/browser/permissions/prediction_service/permissions_ai_ui_selector.cc
++++ b/chrome/browser/permissions/prediction_service/permissions_ai_ui_selector.cc
+@@ -648,69 +648,6 @@ bool PermissionsAiUiSelector::ShouldHold
+ 
+ PredictionSource PermissionsAiUiSelector::GetPredictionTypeToUse(
+     permissions::RequestType request_type) {
+-  const bool is_msbb_enabled = profile_->GetPrefs()->GetBoolean(
+-      unified_consent::prefs::kUrlKeyedAnonymizedDataCollectionEnabled);
+-
+-  base::UmaHistogramBoolean("Permissions.PredictionService.MSBB",
+-                            is_msbb_enabled);
+-
+-  VLOG(1) << "[CPSS] GetPredictionTypeToUse MSBB: " << is_msbb_enabled;
+-
+-  const bool is_notification_cpss_enabled =
+-      profile_->GetPrefs()->GetBoolean(prefs::kEnableNotificationCPSS);
+-
+-  VLOG(1) << "[CPSS] GetPredictionTypeToUse NotificationCPSS: "
+-          << is_notification_cpss_enabled;
+-
+-  const bool is_geolocation_cpss_enabled =
+-      profile_->GetPrefs()->GetBoolean(prefs::kEnableGeolocationCPSS);
+-
+-  VLOG(1) << "[CPSS] GetPredictionTypeToUse GeolocationCPSS: "
+-          << is_geolocation_cpss_enabled;
+-
+-  if (request_type == permissions::RequestType::kNotifications &&
+-      !is_notification_cpss_enabled) {
+-    VLOG(1) << "[CPSS] GetPredictionTypeToUse NoCpssModel";
+-    return PredictionSource::kNoCpssModel;
+-  }
+-
+-  if (request_type == permissions::RequestType::kGeolocation &&
+-      !is_geolocation_cpss_enabled) {
+-    VLOG(1) << "[CPSS] GetPredictionTypeToUse NoCpssModel";
+-    return PredictionSource::kNoCpssModel;
+-  }
+-
+-  bool use_server_side = false;
+-  if (is_msbb_enabled) {
+-#if BUILDFLAG(IS_ANDROID)
+-    use_server_side = base::FeatureList::IsEnabled(
+-        permissions::features::kPermissionDedicatedCpssSettingAndroid);
+-#else
+-    use_server_side = base::FeatureList::IsEnabled(
+-        permissions::features::kPermissionPredictionsV2);
+-#endif  // BUILDFLAG(IS_ANDROID)
+-  }
+-  if (use_server_side) {
+-    // The AIv4 model takes priority over the server-side CPSSv3 model if
+-    // enabled.
+-    if (PredictionModelHandlerProvider::IsAIv4FeatureEnabled()) {
+-      VLOG(1) << "[CPSS] GetPredictionTypeToUse AIv4";
+-      return PredictionSource::kOnDeviceAiv4AndServerSideModel;
+-    }
+-    VLOG(1) << "[CPSS] GetPredictionTypeToUse CPSSv3";
+-    return PredictionSource::kServerSideCpssV3Model;
+-  }
+-
+-  if ((request_type == permissions::RequestType::kNotifications &&
+-       base::FeatureList::IsEnabled(
+-           permissions::features::
+-               kPermissionOnDeviceNotificationPredictions)) ||
+-      (request_type == permissions::RequestType::kGeolocation &&
+-       base::FeatureList::IsEnabled(
+-           permissions::features::kPermissionOnDeviceGeolocationPredictions))) {
+-    VLOG(1) << "[CPSS] GetPredictionTypeToUse CPSSv1";
+-    return PredictionSource::kOnDeviceCpssV1Model;
+-  }
+ 
+   VLOG(1) << "[CPSS] GetPredictionTypeToUse NoCpssModel";
+   return PredictionSource::kNoCpssModel;
+--- a/chrome/browser/policy/configuration_policy_handler_list_factory.cc
++++ b/chrome/browser/policy/configuration_policy_handler_list_factory.cc
+@@ -2606,8 +2606,6 @@ std::unique_ptr<ConfigurationPolicyHandl
+   handlers->AddHandler(
+       std::make_unique<bookmarks::ManagedBookmarksPolicyHandler>(
+           chrome_schema));
+-  handlers->AddHandler(
+-      std::make_unique<safe_browsing::SafeBrowsingPolicyHandler>());
+   handlers->AddHandler(std::make_unique<syncer::SyncPolicyHandler>());
+   handlers->AddHandler(
+       std::make_unique<URLAllowlistPolicyHandler>(key::kURLAllowlist));
+--- a/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
++++ b/chrome/browser/profiles/chrome_browser_main_extra_parts_profiles.cc
+@@ -937,9 +937,7 @@ void ChromeBrowserMainExtraPartsProfiles
+     enterprise_connectors::TelomereEventRouterFactory::GetInstance();
+   }
+ #endif
+-  enterprise_connectors::BrowserCrashEventRouterFactory::GetInstance();
+   enterprise_connectors::ConnectorsServiceFactory::GetInstance();
+-  enterprise_connectors::ReportingEventRouterFactory::GetInstance();
+ #if BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC) || \
+     BUILDFLAG(IS_WIN)
+   enterprise_connectors::DeviceTrustConnectorServiceFactory::GetInstance();
+--- a/chrome/browser/resources/settings/privacy_page/privacy_page_index.ts
++++ b/chrome/browser/resources/settings/privacy_page/privacy_page_index.ts
+@@ -148,7 +148,7 @@ export class SettingsPrivacyPageIndexEle
+       enableSafeBrowsingSubresourceFilter_: {
+         type: Boolean,
+         value: () => {
+-          return loadTimeData.getBoolean('enableSafeBrowsingSubresourceFilter');
++          return false;
+         },
+       },
+ 
+--- a/chrome/browser/safe_browsing/BUILD.gn
++++ b/chrome/browser/safe_browsing/BUILD.gn
+@@ -107,9 +107,6 @@ static_library("safe_browsing") {
+   ]
+   }
+ 
+-  if (enable_extensions) {
+-    deps += [ "//chrome/browser/ui/web_applications" ]
+-  }
+ 
+   # Note: is_android is not equivalent to safe_browsing_mode == 2.
+   # Sources and dependencies added to this block must not depend on anything
+@@ -123,16 +120,6 @@ static_library("safe_browsing") {
+     ]
+   }
+ 
+-  if (!is_android) {
+-    public += [
+-      "generated_safe_browsing_pref.h",
+-      "generated_security_settings_bundle_pref.h",
+-    ]
+-    sources += [
+-      "generated_safe_browsing_pref.cc",
+-      "generated_security_settings_bundle_pref.cc",
+-    ]
+-  }
+ 
+   if (is_chromeos) {
+     deps += [ "//chrome/browser/ash/file_manager" ]
+@@ -140,15 +127,6 @@ static_library("safe_browsing") {
+     allow_circular_includes_from += [ "//chrome/browser/ash/file_manager" ]
+   }
+ 
+-  if (is_win || is_mac || is_linux || is_chromeos) {
+-    public += [ "security_settings_bundle_toast_helper.h" ]
+-    sources += [ "security_settings_bundle_toast_helper.cc" ]
+-    deps += [
+-      "//chrome/browser/ui/browser_window",
+-      "//chrome/browser/ui/toasts",
+-      "//chrome/browser/ui/toasts/api:toasts",
+-    ]
+-  }
+ 
+   if (safe_browsing_mode != 0) {
+     # "Safe Browsing Basic" files used for safe browsing in full mode
+--- a/chrome/browser/safe_browsing/generated_safe_browsing_pref.cc
++++ b/chrome/browser/safe_browsing/generated_safe_browsing_pref.cc
+@@ -9,7 +9,6 @@
+ #include "chrome/browser/profiles/profile.h"
+ #include "chrome/common/extensions/api/settings_private.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ namespace settings_api = extensions::api::settings_private;
+ 
+@@ -19,77 +18,19 @@ const char kGeneratedSafeBrowsingPref[]
+ GeneratedSafeBrowsingPref::GeneratedSafeBrowsingPref(Profile* profile)
+     : profile_(profile) {
+   user_prefs_registrar_.Init(profile->GetPrefs());
+-  user_prefs_registrar_.AddMultiple(
+-      {prefs::kSafeBrowsingEnabled, prefs::kSafeBrowsingEnhanced,
+-       prefs::kSafeBrowsingScoutReportingEnabled},
+-      base::BindRepeating(
+-          &GeneratedSafeBrowsingPref::OnSafeBrowsingPreferencesChanged,
+-          base::Unretained(this)));
+-  user_prefs_registrar_.Add(
+-      prefs::kSecuritySettingsBundle,
+-      base::BindRepeating(&GeneratedSafeBrowsingPref::OnSettingsBundleChanged,
+-                          base::Unretained(this)));
+ }
+ 
+ extensions::settings_private::SetPrefResult GeneratedSafeBrowsingPref::SetPref(
+     const base::Value* value) {
+-  if (!value->is_int()) {
+-    return extensions::settings_private::SetPrefResult::PREF_TYPE_MISMATCH;
+-  }
+-
+-  auto selection = static_cast<SafeBrowsingState>(value->GetInt());
+-
+-  if (selection != SafeBrowsingState::NO_SAFE_BROWSING &&
+-      selection != SafeBrowsingState::STANDARD_PROTECTION &&
+-      selection != SafeBrowsingState::ENHANCED_PROTECTION) {
+-    return extensions::settings_private::SetPrefResult::PREF_TYPE_MISMATCH;
+-  }
+-
+-  // If SBER is forcefully disabled, Enhanced cannot be selected by the user.
+-  const PrefService::Preference* reporting_pref =
+-      profile_->GetPrefs()->FindPreference(
+-          prefs::kSafeBrowsingScoutReportingEnabled);
+-  const bool reporting_on = reporting_pref->GetValue()->GetBool();
+-  const bool reporting_enforced = !reporting_pref->IsUserModifiable();
+-
+-  if (reporting_enforced && !reporting_on &&
+-      selection == SafeBrowsingState::ENHANCED_PROTECTION) {
+-    return extensions::settings_private::SetPrefResult::PREF_NOT_MODIFIABLE;
+-  }
+-
+-  // kSafeBrowsingEnabled is considered the canonical source for Safe Browsing
+-  // management.
+-  const PrefService::Preference* enabled_pref =
+-      profile_->GetPrefs()->FindPreference(prefs::kSafeBrowsingEnabled);
+-  if (!enabled_pref->IsUserModifiable()) {
+     return extensions::settings_private::SetPrefResult::PREF_NOT_MODIFIABLE;
+-  }
+-
+-  // Update both Safe Browsing preferences to match selection.
+-  profile_->GetPrefs()->SetBoolean(
+-      prefs::kSafeBrowsingEnabled,
+-      selection != SafeBrowsingState::NO_SAFE_BROWSING);
+-  profile_->GetPrefs()->SetBoolean(
+-      prefs::kSafeBrowsingEnhanced,
+-      selection == SafeBrowsingState::ENHANCED_PROTECTION);
+-
+-  // Set ESB not set in sync with Account ESB through TailoredSecurity.
+-  if (selection == SafeBrowsingState::ENHANCED_PROTECTION) {
+-    profile_->GetPrefs()->SetBoolean(
+-        prefs::kEnhancedProtectionEnabledViaTailoredSecurity, false);
+-  }
+-
+-  return extensions::settings_private::SetPrefResult::SUCCESS;
+ }
+ 
+ extensions::api::settings_private::PrefObject
+ GeneratedSafeBrowsingPref::GetPrefObject() const {
+-  SafeBrowsingState safe_browsing_state =
+-      GetSafeBrowsingState(*profile_->GetPrefs());
+   extensions::api::settings_private::PrefObject pref_object;
+   pref_object.key = kGeneratedSafeBrowsingPref;
+   pref_object.type = extensions::api::settings_private::PrefType::kNumber;
+-  pref_object.value = base::Value(static_cast<int>(safe_browsing_state));
++  pref_object.value = base::Value(0);
+ 
+   ApplySafeBrowsingManagementState(*profile_, pref_object);
+ 
+@@ -101,97 +42,12 @@ void GeneratedSafeBrowsingPref::OnSafeBr
+ }
+ 
+ void GeneratedSafeBrowsingPref::OnSettingsBundleChanged() {
+-  auto bundle = GetSecurityBundleSetting(*profile_->GetPrefs());
+-  switch (bundle) {
+-    case SecuritySettingsBundleSetting::STANDARD:
+-      SetPref(std::make_unique<base::Value>(
+-                  static_cast<int>(SafeBrowsingState::STANDARD_PROTECTION))
+-                  .get());
+-      break;
+-    case SecuritySettingsBundleSetting::ENHANCED:
+-      SetPref(std::make_unique<base::Value>(
+-                  static_cast<int>(SafeBrowsingState::ENHANCED_PROTECTION))
+-                  .get());
+-      break;
+-    default:
+-      NOTREACHED();
+-  }
+ }
+ 
+ /* static */
+ void GeneratedSafeBrowsingPref::ApplySafeBrowsingManagementState(
+     const Profile& profile,
+     settings_api::PrefObject& pref_object) {
+-  // Computing the effective Safe Browsing managed state requires inspecting
+-  // three different preferences. It is possible that these may be in
+-  // temporarily conflicting managed states. The enabled preference is always
+-  // taken as the canonical source of management.
+-  const PrefService::Preference* enabled_pref =
+-      profile.GetPrefs()->FindPreference(prefs::kSafeBrowsingEnabled);
+-  const bool enabled_enforced = !enabled_pref->IsUserModifiable();
+-  const bool enabled_recommended =
+-      (enabled_pref && enabled_pref->GetRecommendedValue());
+-  const bool enabled_recommended_on =
+-      enabled_recommended && enabled_pref->GetRecommendedValue()->GetBool();
+-
+-  // The enhanced preference may have a recommended setting. This only takes
+-  // effect if the enabled preference also has a recommended setting.
+-  const PrefService::Preference* enhanced_pref =
+-      profile.GetPrefs()->FindPreference(prefs::kSafeBrowsingEnhanced);
+-  const bool enhanced_recommended_on =
+-      enhanced_pref->GetRecommendedValue() &&
+-      enhanced_pref->GetRecommendedValue()->GetBool();
+-
+-  // A forcefully disabled reporting preference will disallow enhanced from
+-  // being selected and thus it must also be considered.
+-  const PrefService::Preference* reporting_pref =
+-      profile.GetPrefs()->FindPreference(
+-          prefs::kSafeBrowsingScoutReportingEnabled);
+-  const bool reporting_on = reporting_pref->GetValue()->GetBool();
+-  const bool reporting_enforced = !reporting_pref->IsUserModifiable();
+-
+-  if (!enabled_enforced && !enabled_recommended && !reporting_enforced) {
+-    // No relevant policies are applied.
+-    return;
+-  }
+-
+-  if (enabled_enforced) {
+-    // Preference is fully controlled.
+-    pref_object.enforcement = settings_api::Enforcement::kEnforced;
+-    extensions::settings_private::GeneratedPref::ApplyControlledByFromPref(
+-        &pref_object, enabled_pref);
+-    return;
+-  }
+-
+-  if (enabled_recommended) {
+-    // Set enforcement to recommended. This may be upgraded to enforced later
+-    // in this function.
+-    pref_object.enforcement = settings_api::Enforcement::kRecommended;
+-    if (enhanced_recommended_on) {
+-      pref_object.recommended_value =
+-          base::Value(static_cast<int>(SafeBrowsingState::ENHANCED_PROTECTION));
+-    } else if (enabled_recommended_on) {
+-      pref_object.recommended_value =
+-          base::Value(static_cast<int>(SafeBrowsingState::STANDARD_PROTECTION));
+-    } else {
+-      pref_object.recommended_value =
+-          base::Value(static_cast<int>(SafeBrowsingState::NO_SAFE_BROWSING));
+-    }
+-  }
+-
+-  if (reporting_enforced && !reporting_on) {
+-    // Reporting has been forcefully disabled by policy. Enhanced protection is
+-    // thus also implicitly disabled by the same policy.
+-    pref_object.enforcement = settings_api::Enforcement::kEnforced;
+-    extensions::settings_private::GeneratedPref::ApplyControlledByFromPref(
+-        &pref_object, reporting_pref);
+-
+-    pref_object.user_selectable_values.emplace();
+-    pref_object.user_selectable_values->Append(
+-        std::to_underlying(SafeBrowsingState::STANDARD_PROTECTION));
+-    pref_object.user_selectable_values->Append(
+-        std::to_underlying(SafeBrowsingState::NO_SAFE_BROWSING));
+-  }
+ }
+ 
+ }  // namespace safe_browsing
+--- a/chrome/browser/safe_browsing/generated_safe_browsing_pref.h
++++ b/chrome/browser/safe_browsing/generated_safe_browsing_pref.h
+@@ -9,7 +9,6 @@
+ #include "chrome/browser/extensions/api/settings_private/generated_pref.h"
+ #include "chrome/browser/profiles/profile.h"
+ #include "components/prefs/pref_change_registrar.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ namespace safe_browsing {
+ 
+--- a/chrome/browser/safe_browsing/generated_security_settings_bundle_pref.cc
++++ b/chrome/browser/safe_browsing/generated_security_settings_bundle_pref.cc
+@@ -11,7 +11,6 @@
+ #include "chrome/common/pref_names.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ namespace safe_browsing {
+ 
+@@ -19,59 +18,20 @@ GeneratedSecuritySettingsBundlePref::Gen
+     Profile* profile)
+     : profile_(profile) {
+   user_prefs_registrar_.Init(profile->GetPrefs());
+-  user_prefs_registrar_.Add(
+-      prefs::kSecuritySettingsBundle,
+-      base::BindRepeating(&GeneratedSecuritySettingsBundlePref::
+-                              OnSecuritySettingsBundlePreferencesChanged,
+-                          base::Unretained(this)));
+ }
+ 
+ extensions::settings_private::SetPrefResult
+ GeneratedSecuritySettingsBundlePref::SetPref(const base::Value* value) {
+-  if (!value->is_int()) {
+-    return extensions::settings_private::SetPrefResult::PREF_TYPE_MISMATCH;
+-  }
+-
+-  auto selection = static_cast<int>(value->GetInt());
+-
+-  if (selection != static_cast<int>(SecuritySettingsBundleSetting::STANDARD) &&
+-      selection != static_cast<int>(SecuritySettingsBundleSetting::ENHANCED)) {
+-    return extensions::settings_private::SetPrefResult::PREF_TYPE_MISMATCH;
+-  }
+-
+-  // Update Security Settings Bundle preference to match selection.
+-  SetSecurityBundleSetting(
+-      *(profile_->GetPrefs()),
+-      static_cast<SecuritySettingsBundleSetting>(selection));
+-
+-  PrefService* local_state = g_browser_process->local_state();
+-
+-  // This is how the bundle controls each security setting.
+-  if (base::FeatureList::IsEnabled(
+-          safe_browsing::kBundledSecuritySettingsSecureDnsV2)) {
+-    // Secure DNS Setting.
+-    // TODO(crbug.com/460180440): migrate to a per-profile setting.
+-    const bool fallback_to_doh =
+-        selection == static_cast<int>(SecuritySettingsBundleSetting::ENHANCED);
+-    local_state->SetString(prefs::kDnsOverHttpsMode,
+-                           SecureDnsConfig::kModeAutomatic);
+-    local_state->SetString(prefs::kDnsOverHttpsTemplates, "");
+-    local_state->SetBoolean(prefs::kDnsOverHttpsAutomaticModeFallbackToDoh,
+-                            fallback_to_doh);
+-  }
+-
+   return extensions::settings_private::SetPrefResult::SUCCESS;
+ }
+ 
+ extensions::api::settings_private::PrefObject
+ GeneratedSecuritySettingsBundlePref::GetPrefObject() const {
+-  SecuritySettingsBundleSetting bundle_setting =
+-      GetSecurityBundleSetting(*profile_->GetPrefs());
+ 
+   extensions::api::settings_private::PrefObject pref_object;
+   pref_object.key = kGeneratedSecuritySettingsBundlePref;
+   pref_object.type = extensions::api::settings_private::PrefType::kNumber;
+-  pref_object.value = base::Value(static_cast<int>(bundle_setting));
++  pref_object.value = base::Value(0);
+   return pref_object;
+ }
+ 
+--- a/chrome/browser/safe_browsing/metrics/safe_browsing_metrics_provider.cc
++++ b/chrome/browser/safe_browsing/metrics/safe_browsing_metrics_provider.cc
+@@ -17,15 +17,6 @@ SafeBrowsingMetricsProvider::~SafeBrowsi
+ 
+ void SafeBrowsingMetricsProvider::ProvideCurrentSessionData(
+     metrics::ChromeUserMetricsExtension* uma_proto) {
+-  Profile* profile = cached_profile_.GetMetricsProfile();
+-
+-  if (!profile)
+-    return;
+-
+-  SafeBrowsingState state = GetSafeBrowsingState(*profile->GetPrefs());
+-
+-  base::UmaHistogramEnumeration(
+-      "SafeBrowsing.Pref.MainProfile.SafeBrowsingState", state);
+ }
+ 
+ }  // namespace safe_browsing
+--- a/chrome/browser/safe_browsing/url_lookup_service_factory.cc
++++ b/chrome/browser/safe_browsing/url_lookup_service_factory.cc
+@@ -74,32 +74,7 @@ RealTimeUrlLookupServiceFactory::~RealTi
+ std::unique_ptr<KeyedService>
+ RealTimeUrlLookupServiceFactory::BuildServiceInstanceForBrowserContext(
+     content::BrowserContext* context) const {
+-  if (!g_browser_process->safe_browsing_service()) {
+     return nullptr;
+-  }
+-  Profile* profile = Profile::FromBrowserContext(context);
+-  return std::make_unique<RealTimeUrlLookupService>(
+-      GetURLLoaderFactory(context),
+-      VerdictCacheManagerFactory::GetForProfile(profile),
+-      base::BindRepeating(&safe_browsing::GetUserPopulationForProfile, profile),
+-      profile->GetPrefs(),
+-      std::make_unique<SafeBrowsingPrimaryAccountTokenFetcher>(
+-          IdentityManagerFactory::GetForProfile(profile)),
+-      base::BindRepeating(&safe_browsing::SyncUtils::
+-                              AreSigninAndSyncSetUpForSafeBrowsingTokenFetches,
+-                          SyncServiceFactory::GetForProfile(profile),
+-                          IdentityManagerFactory::GetForProfile(profile)),
+-      profile->IsOffTheRecord(),
+-      base::BindRepeating(
+-          &RealTimeUrlLookupServiceFactory::GetVariationsService),
+-      base::BindRepeating(&RealTimeUrlLookupServiceFactory::
+-                              GetMinAllowedTimestampForReferrerChains,
+-                          profile),
+-      SafeBrowsingNavigationObserverManagerFactory::GetForBrowserContext(
+-          profile),
+-      WebUIContentInfoSingleton::GetInstance(),
+-      ClientSideDetectionIntelligentScanDelegateFactory::GetForProfile(
+-          profile));
+ }
+ 
+ scoped_refptr<network::SharedURLLoaderFactory>
+--- a/chrome/browser/site_protection/site_familiarity_utils.cc
++++ b/chrome/browser/site_protection/site_familiarity_utils.cc
+@@ -41,10 +41,6 @@ bool AreV8OptimizationsDisabledOnUnfamil
+ }
+ 
+ bool CanEnableBlockingJavascriptOptimizersForUnfamiliarSites(Profile* profile) {
+-  if (!safe_browsing::IsSafeBrowsingEnabled(*profile->GetPrefs())) {
+-    // Blocking js-opt on unfamiliar sites requires Safe Browsing to be enabled.
+-    return false;
+-  }
+ 
+   if (!(base::FeatureList::IsEnabled(
+             features::kProcessSelectionDeferringConditions) &&
+--- a/chrome/browser/ssl/chrome_security_blocking_page_factory.cc
++++ b/chrome/browser/ssl/chrome_security_blocking_page_factory.cc
+@@ -125,15 +125,6 @@ CreateSettingsPageHelper() {
+       CreateChromeSettingsPageHelper();
+ }
+ 
+-void LogSafeBrowsingSecuritySensitiveAction(
+-    safe_browsing::SafeBrowsingMetricsCollector* metrics_collector) {
+-  if (metrics_collector) {
+-    metrics_collector->AddSafeBrowsingEventToPref(
+-        safe_browsing::SafeBrowsingMetricsCollector::EventType::
+-            SECURITY_SENSITIVE_SSL_INTERSTITIAL);
+-  }
+-}
+-
+ }  // namespace
+ 
+ std::unique_ptr<SSLBlockingPage>
+@@ -151,10 +142,6 @@ ChromeSecurityBlockingPageFactory::Creat
+           web_contents, request_url,
+           overridable ? "ssl_overridable" : "ssl_nonoverridable", overridable));
+ 
+-  LogSafeBrowsingSecuritySensitiveAction(
+-      safe_browsing::SafeBrowsingMetricsCollectorFactory::GetForProfile(
+-          Profile::FromBrowserContext(web_contents->GetBrowserContext())));
+-
+   auto controller_client = std::make_unique<SSLErrorControllerClient>(
+       web_contents, ssl_info, cert_error, request_url,
+       std::move(metrics_helper), CreateSettingsPageHelper());
+@@ -185,9 +172,6 @@ ChromeSecurityBlockingPageFactory::Creat
+           web_contents, request_url,
+           overridable ? "ssl_overridable" : "ssl_nonoverridable", overridable));
+ 
+-  LogSafeBrowsingSecuritySensitiveAction(
+-      safe_browsing::SafeBrowsingMetricsCollectorFactory::GetForProfile(
+-          Profile::FromBrowserContext(web_contents->GetBrowserContext())));
+ 
+   auto controller_client = std::make_unique<SSLErrorControllerClient>(
+       web_contents, ssl_info, cert_error, request_url,
+@@ -251,10 +235,6 @@ ChromeSecurityBlockingPageFactory::Creat
+     const std::string& mitm_software_name) {
+   Profile* profile =
+       Profile::FromBrowserContext(web_contents->GetBrowserContext());
+-  LogSafeBrowsingSecuritySensitiveAction(
+-      safe_browsing::SafeBrowsingMetricsCollectorFactory::GetForProfile(
+-          profile));
+-
+   auto page = std::make_unique<MITMSoftwareBlockingPage>(
+       web_contents, cert_error, request_url,
+       /*can_show_enhanced_protection_message=*/true, ssl_info,
+@@ -274,10 +254,6 @@ ChromeSecurityBlockingPageFactory::Creat
+     net::Error cert_error,
+     const GURL& request_url,
+     const net::SSLInfo& ssl_info) {
+-  LogSafeBrowsingSecuritySensitiveAction(
+-      safe_browsing::SafeBrowsingMetricsCollectorFactory::GetForProfile(
+-          Profile::FromBrowserContext(web_contents->GetBrowserContext())));
+-
+   auto page = std::make_unique<BlockedInterceptionBlockingPage>(
+       web_contents, cert_error, request_url,
+       /*can_show_enhanced_protection_message=*/true, ssl_info,
+--- a/chrome/browser/ssl/ssl_error_controller_client.cc
++++ b/chrome/browser/ssl/ssl_error_controller_client.cc
+@@ -80,8 +80,6 @@ void SSLErrorControllerClient::GoBack()
+ 
+ void SSLErrorControllerClient::Proceed() {
+   content::WebContents* const web_contents = this->web_contents();
+-  MaybeTriggerSecurityInterstitialProceededEvent(web_contents, request_url_,
+-                                                 "SSL_ERROR", cert_error_);
+ #if !BUILDFLAG(IS_ANDROID)
+   // Web Apps should not be allowed to run if there is a problem with their
+   // certificate. So, when users click proceed on an interstitial, move the tab
+--- a/chrome/browser/ui/BUILD.gn
++++ b/chrome/browser/ui/BUILD.gn
+@@ -4549,8 +4549,6 @@ static_library("ui") {
+       "views/safe_browsing/password_reuse_modal_warning_dialog.h",
+       "views/safe_browsing/tailored_security_desktop_dialog_manager.cc",
+       "views/safe_browsing/tailored_security_desktop_dialog_manager.h",
+-      "views/safe_browsing/tailored_security_unconsented_modal.cc",
+-      "views/safe_browsing/tailored_security_unconsented_modal.h",
+       "views/screen_sharing_util.cc",
+       "views/screen_sharing_util.h",
+       "views/select_audio_output/select_audio_output_dialog.cc",
+--- a/chrome/browser/ui/safety_hub/abusive_notification_permissions_manager.cc
++++ b/chrome/browser/ui/safety_hub/abusive_notification_permissions_manager.cc
+@@ -108,20 +108,7 @@ safe_browsing::NotificationRevocationSou
+ // suspicious notification.
+ bool HasShowOriginalSuspiciousNotification(HostContentSettingsMap* hcsm,
+                                            GURL url) {
+-  DCHECK(hcsm);
+-  DCHECK(url.is_valid());
+-  base::Value stored_value(hcsm->GetWebsiteSetting(
+-      url, url, ContentSettingsType::SUSPICIOUS_NOTIFICATION_SHOW_ORIGINAL));
+-
+-  if (stored_value.is_none()) {
+     return false;
+-  }
+-  DCHECK(stored_value.is_dict());
+-  DCHECK(stored_value.GetDict().contains(
+-      safe_browsing::kSuspiciousNotificationShowOriginalKey));
+-  return stored_value.GetDict()
+-      .FindBool(safe_browsing::kSuspiciousNotificationShowOriginalKey)
+-      .value_or(false);
+ }
+ 
+ // Return true if the url should be considered for suspicious content
+--- a/chrome/browser/ui/safety_hub/revoked_permissions_service.cc
++++ b/chrome/browser/ui/safety_hub/revoked_permissions_service.cc
+@@ -43,7 +43,6 @@
+ #include "components/permissions/permission_util.h"
+ #include "components/prefs/pref_change_registrar.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safety_check/safety_check.h"
+ #include "content/public/browser/browser_context.h"
+ #include "content/public/browser/browser_thread.h"
+@@ -170,32 +169,6 @@ RevokedPermissionsService::RevokedPermis
+         notification_display_manager =
+             RevokedPermissionsOSNotificationDisplayManagerFactory::
+                 GetForProfile(Profile::FromBrowserContext(browser_context_));
+-    abusive_notification_manager_ =
+-        std::make_unique<AbusiveNotificationPermissionsManager>(
+-#if BUILDFLAG(SAFE_BROWSING_AVAILABLE)
+-            g_browser_process->safe_browsing_service()
+-                ? g_browser_process->safe_browsing_service()->database_manager()
+-                : nullptr,
+-#else
+-          nullptr,
+-#endif
+-            hcsm(), pref_change_registrar_->prefs());
+-
+-  pref_change_registrar_->Add(
+-      prefs::kSafeBrowsingEnabled,
+-      base::BindRepeating(
+-          &RevokedPermissionsService::OnPermissionsAutorevocationControlChanged,
+-          base::Unretained(this)));
+-
+-  if (base::FeatureList::IsEnabled(
+-          features::kSafetyHubDisruptiveNotificationRevocation)) {
+-    disruptive_notification_manager_ =
+-        std::make_unique<DisruptiveNotificationPermissionsManager>(
+-            browser_context, hcsm(),
+-            site_engagement::SiteEngagementServiceFactory::GetForProfile(
+-                browser_context_),
+-            notification_display_manager);
+-  }
+ 
+   unused_site_permissions_manager_ =
+       std::make_unique<UnusedSitePermissionsManager>(browser_context, prefs);
+@@ -609,5 +582,5 @@ bool RevokedPermissionsService::IsUnused
+ }
+ 
+ bool RevokedPermissionsService::IsAbusiveNotificationAutoRevocationEnabled() {
+-  return safe_browsing::IsSafeBrowsingEnabled(*pref_change_registrar_->prefs());
++  return false;
+ }
+--- a/chrome/browser/ui/tab_contents/BUILD.gn
++++ b/chrome/browser/ui/tab_contents/BUILD.gn
+@@ -43,7 +43,6 @@ source_set("impl") {
+   if (is_win || is_mac || is_linux || is_chromeos) {
+     sources += [
+       "chrome_web_contents_menu_helper.cc",
+-      "chrome_web_contents_view_handle_drop.cc",
+     ]
+   }
+ 
+--- a/chrome/browser/ui/toasts/toast_service.cc
++++ b/chrome/browser/ui/toasts/toast_service.cc
+@@ -46,7 +46,6 @@
+ #include "components/plus_addresses/core/browser/grit/plus_addresses_strings.h"
+ #include "components/plus_addresses/core/common/features.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/strings/grit/components_strings.h"
+ #include "components/tabs/public/tab_interface.h"
+ #include "components/translate/core/browser/translate_manager.h"
+@@ -144,57 +143,6 @@ void ToastService::RegisterToasts(
+             .Build());
+   }
+ 
+-  // ESB as a synced setting.
+-  if (base::FeatureList::IsEnabled(safe_browsing::kEsbAsASyncedSetting)) {
+-    toast_registry_->RegisterToast(
+-        ToastId::kSyncEsbOn,
+-        ToastSpecification::Builder(
+-#if BUILDFLAG(GOOGLE_CHROME_BRANDING)
+-            vector_icons::kGshieldIcon,
+-#else
+-            kSecurityIcon,
+-#endif
+-            IDS_SETTINGS_SAFEBROWSING_ENHANCED_ON_TOAST_MESSAGE)
+-            .AddActionButton(
+-                IDS_SETTINGS_SETTINGS,
+-                base::BindRepeating(
+-                    [](BrowserWindowInterface* window) {
+-                      window->OpenGURL(
+-                          chrome::GetSettingsUrl(
+-                              chrome::kSafeBrowsingEnhancedProtectionSubPage),
+-                          WindowOpenDisposition::NEW_FOREGROUND_TAB);
+-                    },
+-                    base::Unretained(browser_window_interface)))
+-            .AddCloseButton()
+-            .Build());
+-    toast_registry_->RegisterToast(
+-        ToastId::kSyncEsbOnWithoutActionButton,
+-        ToastSpecification::Builder(
+-#if BUILDFLAG(GOOGLE_CHROME_BRANDING)
+-            vector_icons::kGshieldIcon,
+-#else
+-            kSecurityIcon,
+-#endif
+-            IDS_SETTINGS_SAFEBROWSING_ENHANCED_ON_TOAST_MESSAGE)
+-            .Build());
+-    toast_registry_->RegisterToast(
+-        ToastId::kSyncEsbOff,
+-        ToastSpecification::Builder(
+-            kInfoIcon, IDS_SETTINGS_SAFEBROWSING_ENHANCED_OFF_TOAST_MESSAGE)
+-            .AddActionButton(
+-                IDS_SETTINGS_SAFEBROWSING_TURN_ON_ENHANCED_TOAST_BUTTON,
+-                base::BindRepeating(
+-                    [](BrowserWindowInterface* window) {
+-                      Profile* profile = window->GetProfile();
+-                      if (profile) {
+-                        profile->GetPrefs()->SetBoolean(
+-                            prefs::kSafeBrowsingEnhanced, true);
+-                      }
+-                    },
+-                    base::Unretained(browser_window_interface)))
+-            .AddCloseButton()
+-            .Build());
+-  }
+ 
+   if (data_sharing::features::IsDataSharingFunctionalityEnabled()) {
+     // Current tab has been removed from the group.
+--- a/chrome/browser/ui/views/tab_contents/chrome_web_contents_view_delegate_views.cc
++++ b/chrome/browser/ui/views/tab_contents/chrome_web_contents_view_delegate_views.cc
+@@ -184,7 +184,7 @@ bool ChromeWebContentsViewDelegateViews:
+ void ChromeWebContentsViewDelegateViews::OnPerformingDrop(
+     const content::DropData& drop_data,
+     DropCompletionCallback callback) {
+-  HandleOnPerformingDrop(web_contents_, drop_data, std::move(callback));
++  if (!callback.is_null()) std::move(callback).Run(std::move(drop_data));
+ }
+ 
+ std::unique_ptr<content::WebContentsViewDelegate> CreateWebContentsViewDelegate(
+--- a/chrome/browser/ui/views/tab_contents/chrome_web_contents_view_delegate_views_mac.mm
++++ b/chrome/browser/ui/views/tab_contents/chrome_web_contents_view_delegate_views_mac.mm
+@@ -167,7 +167,7 @@ bool ChromeWebContentsViewDelegateViewsM
+ void ChromeWebContentsViewDelegateViewsMac::OnPerformingDrop(
+     const content::DropData& drop_data,
+     DropCompletionCallback callback) {
+-  HandleOnPerformingDrop(web_contents_, drop_data, std::move(callback));
++  if (!callback.is_null()) std::move(callback).Run(std::move(drop_data));
+ }
+ 
+ std::unique_ptr<RenderViewContextMenuBase>
+--- a/chrome/browser/ui/webui/downloads/downloads_dom_handler.cc
++++ b/chrome/browser/ui/webui/downloads/downloads_dom_handler.cc
+@@ -188,21 +188,6 @@ void MaybeReportBypassAction(download::D
+ void MaybeTriggerTrustSafetySurvey(download::DownloadItem* file,
+                                    WarningSurface surface,
+                                    WarningAction action) {
+-  CHECK(file);
+-  CHECK(surface == WarningSurface::DOWNLOADS_PAGE ||
+-        surface == WarningSurface::DOWNLOAD_PROMPT);
+-  CHECK(action == WarningAction::PROCEED || action == WarningAction::DISCARD);
+-  if (Profile* profile = Profile::FromBrowserContext(
+-          content::DownloadItemUtils::GetBrowserContext(file));
+-      profile &&
+-      safe_browsing::IsSafeBrowsingSurveysEnabled(*profile->GetPrefs())) {
+-    TrustSafetySentimentService* trust_safety_sentiment_service =
+-        TrustSafetySentimentServiceFactory::GetForProfile(profile);
+-    if (trust_safety_sentiment_service) {
+-      trust_safety_sentiment_service->InteractedWithDownloadWarningUI(surface,
+-                                                                      action);
+-    }
+-  }
+ }
+ 
+ void RecordDownloadsPageValidatedHistogram(download::DownloadItem* item) {
+--- a/chrome/browser/ui/webui/feedback/report_unsafe_site/BUILD.gn
++++ b/chrome/browser/ui/webui/feedback/report_unsafe_site/BUILD.gn
+@@ -26,7 +26,6 @@ static_library("report_unsafe_site") {
+     "//chrome/browser/feedback:feedback_impl",
+     "//chrome/browser/ui/webui/top_chrome",
+     "//chrome/common",
+-    "//components/safe_browsing/content/browser:client_side_detection",
+     "//mojo/public/cpp/bindings",
+     "//ui/views",
+   ]
+--- a/chrome/browser/ui/webui/feedback/report_unsafe_site/report_unsafe_site_handler.cc
++++ b/chrome/browser/ui/webui/feedback/report_unsafe_site/report_unsafe_site_handler.cc
+@@ -5,7 +5,6 @@
+ #include "chrome/browser/ui/webui/feedback/report_unsafe_site/report_unsafe_site_handler.h"
+ 
+ #include "base/strings/utf_string_conversions.h"
+-#include "components/safe_browsing/content/browser/client_side_detection_host.h"
+ #include "components/safe_browsing/content/browser/safe_browsing_tab_observer.h"
+ #include "components/url_formatter/elide_url.h"
+ #include "components/viz/common/frame_sinks/copy_output_result.h"
+@@ -17,16 +16,7 @@
+ namespace {
+ safe_browsing::ClientSideDetectionHost* GetClientSideDetectionHost(
+     content::WebContents* web_contents) {
+-  if (!web_contents) {
+     return nullptr;
+-  }
+-
+-  auto* observer =
+-      safe_browsing::SafeBrowsingTabObserver::FromWebContents(web_contents);
+-  if (!observer) {
+-    return nullptr;
+-  }
+-  return observer->client_side_detection_host();
+ }
+ 
+ }  // anonymous namespace
+@@ -92,8 +82,6 @@ void ReportUnsafeSitePageHandler::SendRe
+   if (!include_screenshot) {
+     screenshot_ = SkBitmap();
+   }
+-  client_side_detection_host->ReportUnsafeSite(screenshot_,
+-                                               std::move(callback));
+ }
+ 
+ void ReportUnsafeSitePageHandler::CloseDialog() {
+--- a/chrome/browser/ui/webui/settings/hats_handler.cc
++++ b/chrome/browser/ui/webui/settings/hats_handler.cc
+@@ -22,14 +22,11 @@
+ #include "components/privacy_sandbox/privacy_sandbox_prefs.h"
+ #include "components/privacy_sandbox/privacy_sandbox_settings.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/version_info/version_info.h"
+ #include "content/public/browser/visibility.h"
+ #include "content/public/browser/web_contents.h"
+ #include "services/metrics/public/cpp/metrics_utils.h"
+ 
+-using safe_browsing::SafeBrowsingState;
+-using safe_browsing::SecuritySettingsBundleSetting;
+ 
+ namespace {
+ 
+@@ -87,56 +84,6 @@ void HatsHandler::RegisterMessages() {
+  */
+ void HatsHandler::HandleSecurityPageHatsRequest(const base::ListValue& args) {
+   AllowJavascript();
+-
+-  // There are 3 argument in the input list.
+-  // The first one is the SecurityPageInteraction that triggered the survey.
+-  // The second one is the safe browsing setting the user was on.
+-  // The third one is the total amount of time a user spent on the security page
+-  // in focus.
+-  CHECK_EQ(3U, args.size());
+-
+-  Profile* profile = Profile::FromWebUI(web_ui());
+-
+-  // Enterprise users consideration.
+-  // If the admin disabled the survey, the survey will not be requested.
+-  if (!safe_browsing::IsSafeBrowsingSurveysEnabled(*profile->GetPrefs())) {
+-    return;
+-  }
+-
+-  // Request HaTS survey.
+-  HatsService* hats_service = HatsServiceFactory::GetForProfile(
+-      profile, /* create_if_necessary = */ true);
+-
+-  // The HaTS service may not be available for the profile, for example if it
+-  // is a guest profile.
+-  if (!hats_service) {
+-    return;
+-  }
+-
+-  // Do not send the survey if the user didn't stay on the page long enough.
+-  if (args[2].GetDouble() <
+-      features::kHappinessTrackingSurveysForSecurityPageTime.Get()
+-          .InMilliseconds()) {
+-    return;
+-  }
+-
+-  auto interaction = static_cast<SecurityPageInteraction>(args[0].GetInt());
+-  if (features::kHappinessTrackingSurveysForSecurityPageRequireInteraction
+-          .Get() &&
+-      interaction == SecurityPageInteraction::NO_INTERACTION) {
+-    return;
+-  }
+-
+-  // Generate the Product Specific bits data from |profile| and |args|.
+-  SurveyStringData product_specific_string_data =
+-      GetSecurityPageProductSpecificStringData(profile, args);
+-
+-  hats_service->LaunchSurvey(
+-      kHatsSurveyTriggerSettingsSecurity,
+-      /*success_callback*/ base::DoNothing(),
+-      /*failure_callback*/ base::DoNothing(),
+-      /*product_specific_bits_data=*/{},
+-      /*product_specific_string_data=*/product_specific_string_data);
+ }
+ 
+ /**
+@@ -154,40 +101,6 @@ void HatsHandler::HandleSecurityPageV2Ha
+ 
+   CHECK_EQ(4U, args.size());
+ 
+-  Profile* profile = Profile::FromWebUI(web_ui());
+-
+-  // Enterprise users consideration.
+-  // If the admin disabled the survey, the survey will not be requested.
+-  if (!safe_browsing::IsSafeBrowsingSurveysEnabled(*profile->GetPrefs())) {
+-    return;
+-  }
+-
+-  // Request HaTS survey.
+-  HatsService* hats_service = HatsServiceFactory::GetForProfile(
+-      profile, /* create_if_necessary = */ true);
+-
+-  // The HaTS service may not be available for the profile, for example if it
+-  // is a guest profile.
+-  if (!hats_service) {
+-    return;
+-  }
+-
+-  // Do not send the survey if the user didn't stay on the page long enough.
+-  if (args[2].GetDouble() <
+-      features::kHappinessTrackingSurveysForSecurityPageTime.Get()
+-          .InMilliseconds()) {
+-    return;
+-  }
+-  // Generate the Product Specific bits data from |profile| and |args|.
+-  SurveyStringData product_specific_string_data =
+-      GetSecurityPageV2ProductSpecificStringData(profile, args);
+-
+-  hats_service->LaunchSurvey(
+-      kHatsSurveyTriggerSettingsSecurityV2,
+-      /*success_callback*/ base::DoNothing(),
+-      /*failure_callback*/ base::DoNothing(),
+-      /*product_specific_bits_data=*/{},
+-      /*product_specific_string_data=*/product_specific_string_data);
+ }
+ 
+ /**
+@@ -201,7 +114,6 @@ SurveyStringData HatsHandler::GetSecurit
+     Profile* profile,
+     const base::ListValue& args) {
+   auto interaction = static_cast<SecurityPageInteraction>(args[0].GetInt());
+-  auto safe_browsing_state = static_cast<SafeBrowsingState>(args[1].GetInt());
+ 
+   std::string security_page_interaction_type = "";
+   std::string safe_browsing_setting_before = "";
+@@ -238,32 +150,9 @@ SurveyStringData HatsHandler::GetSecurit
+     }
+   }
+ 
+-  switch (safe_browsing_state) {
+-    case SafeBrowsingState::ENHANCED_PROTECTION: {
+-      safe_browsing_setting_before = "enhanced_protection";
+-      break;
+-    }
+-    case SafeBrowsingState::STANDARD_PROTECTION: {
+-      safe_browsing_setting_before = "standard_protection";
+-      break;
+-    }
+-    case SafeBrowsingState::NO_SAFE_BROWSING: {
+       safe_browsing_setting_before = "no_protection";
+-      break;
+-    }
+-  }
+ 
+-  bool safe_browsing_enabled =
+-      profile->GetPrefs()->GetBoolean(prefs::kSafeBrowsingEnabled);
+-  bool safe_browsing_enhanced_enabled =
+-      profile->GetPrefs()->GetBoolean(prefs::kSafeBrowsingEnhanced);
+-  if (safe_browsing_enhanced_enabled) {
+-    safe_browsing_setting_current = "enhanced_protection";
+-  } else if (safe_browsing_enabled) {
+-    safe_browsing_setting_current = "standard_protection";
+-  } else {
+     safe_browsing_setting_current = "no_protection";
+-  }
+ 
+   std::string client_channel =
+       std::string(version_info::GetChannelString(chrome::GetChannel()));
+@@ -289,10 +178,6 @@ SurveyStringData HatsHandler::GetSecurit
+     Profile* profile,
+     const base::ListValue& args) {
+   const base::ListValue& interactions = args[0].GetList();
+-  auto safe_browsing_state = static_cast<SafeBrowsingState>(args[1].GetInt());
+-
+-  auto security_settings_bundle_setting =
+-      static_cast<SecuritySettingsBundleSetting>(args[3].GetInt());
+ 
+   std::string security_page_interactions = "";
+   std::set<SecurityPageV2Interaction> interaction_set;
+@@ -391,62 +276,14 @@ SurveyStringData HatsHandler::GetSecurit
+   security_page_interactions = base::JoinString(interaction_strings, ", ");
+ 
+   std::string safe_browsing_state_before = "";
+-  switch (safe_browsing_state) {
+-    case SafeBrowsingState::ENHANCED_PROTECTION: {
+-      safe_browsing_state_before = "enhanced_protection";
+-      break;
+-    }
+-    case SafeBrowsingState::STANDARD_PROTECTION: {
+-      safe_browsing_state_before = "standard_protection";
+-      break;
+-    }
+-    case SafeBrowsingState::NO_SAFE_BROWSING: {
+       safe_browsing_state_before = "no_protection";
+-      break;
+-    }
+-  }
+ 
+   std::string security_settings_bundle_setting_before = "";
+-  switch (security_settings_bundle_setting) {
+-    case SecuritySettingsBundleSetting::ENHANCED: {
+-      security_settings_bundle_setting_before = "enhanced_protection";
+-      break;
+-    }
+-    case SecuritySettingsBundleSetting::STANDARD: {
+-      security_settings_bundle_setting_before = "standard_protection";
+-      break;
+-    }
+-  }
+ 
+   std::string safe_browsing_state_current = "";
+-  bool safe_browsing_enabled =
+-      profile->GetPrefs()->GetBoolean(prefs::kSafeBrowsingEnabled);
+-  bool safe_browsing_enhanced_enabled =
+-      profile->GetPrefs()->GetBoolean(prefs::kSafeBrowsingEnhanced);
+-  if (safe_browsing_enhanced_enabled) {
+-    safe_browsing_state_current = "enhanced_protection";
+-  } else if (safe_browsing_enabled) {
+-    safe_browsing_state_current = "standard_protection";
+-  } else {
+     safe_browsing_state_current = "no_protection";
+-  }
+ 
+   std::string security_settings_bundle_setting_current = "";
+-  int security_settings_bundle_pref =
+-      profile->GetPrefs()->GetInteger(prefs::kSecuritySettingsBundle);
+-  auto current_bundle_setting =
+-      static_cast<SecuritySettingsBundleSetting>(security_settings_bundle_pref);
+-
+-  switch (current_bundle_setting) {
+-    case SecuritySettingsBundleSetting::ENHANCED: {
+-      security_settings_bundle_setting_current = "enhanced_protection";
+-      break;
+-    }
+-    case SecuritySettingsBundleSetting::STANDARD: {
+-      security_settings_bundle_setting_current = "standard_protection";
+-      break;
+-    }
+-  }
+ 
+   std::string client_channel =
+       std::string(version_info::GetChannelString(chrome::GetChannel()));
+--- a/chrome/browser/ui/webui/settings/safety_hub_handler.cc
++++ b/chrome/browser/ui/webui/settings/safety_hub_handler.cc
+@@ -173,10 +173,6 @@ SafetyHubHandler::SafetyHubHandler(Profi
+   prefs_observation_.Observe(ExtensionPrefs::Get(profile_));
+   extension_registry_observation_.Observe(ExtensionRegistry::Get(profile_));
+   pref_change_registrar_.Init(profile_->GetPrefs());
+-  pref_change_registrar_.Add(
+-      prefs::kSafeBrowsingEnhanced,
+-      base::BindRepeating(&SafetyHubHandler::OnSafeBrowsingEnhancedChanged,
+-                          base::Unretained(this)));
+ }
+ SafetyHubHandler::~SafetyHubHandler() = default;
+ 
+@@ -827,14 +823,4 @@ void SafetyHubHandler::OnJavascriptAllow
+ void SafetyHubHandler::OnJavascriptDisallowed() {}
+ 
+ void SafetyHubHandler::OnSafeBrowsingEnhancedChanged() {
+-  if (profile_->GetPrefs()->GetBoolean(prefs::kSafeBrowsingEnhanced) &&
+-      MobilePromoOnDesktopTypeEnabled(
+-          MobilePromoOnDesktopPromoType::kESBPromo)) {
+-    IOSPromoTriggerService* service =
+-        IOSPromoTriggerServiceFactory::GetForProfile(profile_);
+-    if (service) {
+-      service->NotifyPromoShouldBeShown(
+-          desktop_to_mobile_promos::PromoType::kEnhancedBrowsing);
+-    }
+-  }
+ }
+--- a/chrome/browser/ui/webui/settings/search_engines_handler.cc
++++ b/chrome/browser/ui/webui/settings/search_engines_handler.cc
+@@ -382,24 +382,6 @@ void SearchEnginesHandler::RecordSearchH
+     return;
+   }
+ 
+-  auto status = safe_browsing::SearchHijackingDetector::GetPriorHeuristicResult(
+-      profile_->GetPrefs());
+-
+-  bool available =
+-      (status !=
+-       safe_browsing::SearchHijackingDetector::HeuristicResult::kUnknown);
+-
+-  base::UmaHistogramBoolean(
+-      "Settings.SearchEngines.SearchHijackingDetector.HeuristicAvailable",
+-      available);
+-
+-  if (available) {
+-    base::UmaHistogramBoolean(
+-        "Settings.SearchEngines.SearchHijackingDetector.HeuristicMatch",
+-        status ==
+-            safe_browsing::SearchHijackingDetector::HeuristicResult::kMatch);
+-  }
+-
+   has_recorded_hijacking_metric_ = true;
+ }
+ 
+--- a/chrome/browser/ui/webui/settings/security_settings_provider.cc
++++ b/chrome/browser/ui/webui/settings/security_settings_provider.cc
+@@ -11,41 +11,32 @@
+ #include "components/safe_browsing/core/common/features.h"
+ #include "components/content_settings/core/common/features.h"
+ #include "components/safe_browsing/core/common/hashprefix_realtime/hash_realtime_utils.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "content/public/browser/web_ui_data_source.h"
+ 
+-using safe_browsing::SecuritySettingsBundleSetting;
+ 
+ namespace settings {
+ 
+ void AddSecurityData(content::WebUIDataSource* html_source) {
+   html_source->AddBoolean(
+       "enableBundledSecuritySettings",
+-      base::FeatureList::IsEnabled(safe_browsing::kBundledSecuritySettings));
++      false);
+   html_source->AddBoolean(
+       "enableBundledSecuritySettingsSecureDnsV2",
+-      base::FeatureList::IsEnabled(
+-          safe_browsing::kBundledSecuritySettingsSecureDnsV2));
++      false);
+   html_source->AddBoolean("enableHttpsFirstModeNewSettings",
+                           IsBalancedModeAvailable());
+ 
+   html_source->AddInteger("securityStandardBundleSafeBrowsingDefault",
+-                          static_cast<int>(GetDefaultSafeBrowsingState(
+-                              SecuritySettingsBundleSetting::STANDARD)));
++                          0);
+   html_source->AddInteger("securityEnhancedBundleSafeBrowsingDefault",
+-                          static_cast<int>(GetDefaultSafeBrowsingState(
+-                              SecuritySettingsBundleSetting::ENHANCED)));
++                          0);
+ 
+   html_source->AddInteger(
+       "securityStandardBundleJavascriptGuardrailsDefault",
+-      static_cast<int>(content_settings::GeneratedJavascriptOptimizerPref::
+-                           GetDefaultJsOptimizerSetting(
+-                               SecuritySettingsBundleSetting::STANDARD)));
++      static_cast<int>(content_settings::JavascriptOptimizerSetting::kAllowed));
+   html_source->AddInteger(
+       "securityEnhancedBundleJavascriptGuardrailsDefault",
+-      static_cast<int>(content_settings::GeneratedJavascriptOptimizerPref::
+-                           GetDefaultJsOptimizerSetting(
+-                               SecuritySettingsBundleSetting::ENHANCED)));
++      static_cast<int>(content_settings::JavascriptOptimizerSetting::kAllowed));
+ 
+   html_source->AddBoolean("enableHashPrefixRealTimeLookups",
+                           safe_browsing::hash_realtime_utils::
+--- a/chrome/browser/webshare/BUILD.gn
++++ b/chrome/browser/webshare/BUILD.gn
+@@ -137,7 +137,6 @@ if (is_win || is_chromeos || is_mac) {
+       "//chrome/browser",
+       "//chrome/browser/safe_browsing:test_support",
+       "//chrome/test:test_support",
+-      "//components/safe_browsing/content/common:file_type_policies_test_support",
+       "//components/safe_browsing/core/browser/db:test_database_manager",
+       "//content/public/browser",
+       "//content/test:test_support",
+--- a/chrome/common/webui_url_constants.cc
++++ b/chrome/common/webui_url_constants.cc
+@@ -180,7 +180,6 @@ base::span<const base::cstring_view> Chr
+       kChromeUISuggestInternalsHost,
+ #endif
+       kChromeUINTPTilesInternalsHost,
+-      safe_browsing::kChromeUISafeBrowsingHost,
+       kChromeUISyncInternalsHost,
+ #if !BUILDFLAG(IS_ANDROID)
+       kChromeUITabSearchHost,
+--- a/chrome/test/BUILD.gn
++++ b/chrome/test/BUILD.gn
+@@ -3191,7 +3191,6 @@ if (!is_android) {
+       "//components/resources",
+       "//components/safe_browsing:buildflags",
+       "//components/safe_browsing/content/browser",
+-      "//components/safe_browsing/content/browser:client_side_detection_images_cache",
+       "//components/safe_browsing/content/browser:credit_card_form_event",
+       "//components/safe_browsing/content/browser:safe_browsing_service",
+       "//components/safe_browsing/content/browser/password_protection",
+@@ -7462,7 +7461,6 @@ test("unit_tests") {
+     "//components/resources",
+     "//components/safe_browsing:buildflags",
+     "//components/safe_browsing/content/browser",
+-    "//components/safe_browsing/content/browser:client_side_detection_images_cache",
+     "//components/safe_browsing/content/browser:credit_card_form_event",
+     "//components/safe_browsing/content/browser/password_protection",
+     "//components/safe_browsing/content/browser/password_protection:mock_password_protection",
+@@ -10649,14 +10647,6 @@ test("unit_tests") {
+       "//components/enterprise/data_controls/core/browser:test_support",
+     ]
+   }
+-  if ((enterprise_data_controls || enterprise_screenshot_protection) &&
+-      !is_android) {
+-    sources += [
+-      "../browser/enterprise/data_protection/paste_allowed_request_unittest.cc",
+-    ]
+-
+-    deps += [ "//components/enterprise/connectors/core:cloud_content_scanning" ]
+-  }
+ 
+   if (!is_android) {
+     sources +=
+@@ -11515,7 +11505,6 @@ if (!is_android && !is_chromeos_device)
+       "//components/privacy_sandbox:tracking_protection_settings",
+       "//components/reading_list/core",
+       "//components/resources",
+-      "//components/safe_browsing/content/browser:client_side_detection",
+       "//components/safe_browsing/core/common",
+       "//components/safe_browsing/core/common:safe_browsing_policy_handler",
+       "//components/search",
+--- a/components/BUILD.gn
++++ b/components/BUILD.gn
+@@ -404,7 +404,6 @@ test("components_unittests") {
+     deps += [
+       "//components/enterprise:unit_tests",
+       "//components/enterprise/common:unit_tests",
+-      "//components/enterprise/connectors/core:cloud_content_scanning_unittests",
+       "//components/enterprise/connectors/core:unit_tests",
+       "//components/enterprise/data_protection:unit_tests",
+       "//components/enterprise/obfuscation/core:unit_tests",
+--- a/components/device_signals/core/browser/browser_utils.cc
++++ b/components/device_signals/core/browser/browser_utils.cc
+@@ -29,35 +29,6 @@ bool IsURLBlocked(const GURL& url, Polic
+ 
+ namespace device_signals {
+ 
+-safe_browsing::SafeBrowsingState GetSafeBrowsingProtectionLevel(
+-    PrefService* profile_prefs) {
+-  DCHECK(profile_prefs);
+-  bool safe_browsing_enabled =
+-      profile_prefs->GetBoolean(prefs::kSafeBrowsingEnabled);
+-  bool safe_browsing_enhanced_enabled =
+-      profile_prefs->GetBoolean(prefs::kSafeBrowsingEnhanced);
+-
+-  if (safe_browsing_enabled) {
+-    if (safe_browsing_enhanced_enabled) {
+-      return safe_browsing::SafeBrowsingState::ENHANCED_PROTECTION;
+-    } else {
+-      return safe_browsing::SafeBrowsingState::STANDARD_PROTECTION;
+-    }
+-  } else {
+-    return safe_browsing::SafeBrowsingState::NO_SAFE_BROWSING;
+-  }
+-}
+-
+-std::optional<safe_browsing::PasswordProtectionTrigger>
+-GetPasswordProtectionWarningTrigger(PrefService* profile_prefs) {
+-  DCHECK(profile_prefs);
+-  if (!profile_prefs->HasPrefPath(prefs::kPasswordProtectionWarningTrigger)) {
+-    return std::nullopt;
+-  }
+-  return static_cast<safe_browsing::PasswordProtectionTrigger>(
+-      profile_prefs->GetInteger(prefs::kPasswordProtectionWarningTrigger));
+-}
+-
+ bool GetChromeRemoteDesktopAppBlocked(PolicyBlocklistService* service) {
+   DCHECK(service);
+   return IsURLBlocked(GURL("https://remotedesktop.google.com"), service) ||
+--- a/components/device_signals/core/browser/browser_utils.h
++++ b/components/device_signals/core/browser/browser_utils.h
+@@ -22,12 +22,6 @@ namespace device_signals {
+ 
+ bool GetChromeRemoteDesktopAppBlocked(PolicyBlocklistService* service);
+ 
+-std::optional<safe_browsing::PasswordProtectionTrigger>
+-GetPasswordProtectionWarningTrigger(PrefService* profile_prefs);
+-
+-safe_browsing::SafeBrowsingState GetSafeBrowsingProtectionLevel(
+-    PrefService* profile_prefs);
+-
+ std::optional<std::string> TryGetEnrollmentDomain(
+     policy::CloudPolicyManager* manager);
+ 
+--- a/components/device_signals/core/browser/signals_types.h
++++ b/components/device_signals/core/browser/signals_types.h
+@@ -12,7 +12,6 @@
+ #include "base/values.h"
+ #include "build/build_config.h"
+ #include "components/device_signals/core/common/common_types.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ #if BUILDFLAG(IS_WIN)
+ #include "components/device_signals/core/common/win/win_types.h"
+@@ -275,10 +274,7 @@ struct ProfileSignalsResponse : BaseSign
+ 
+   bool built_in_dns_client_enabled;
+   bool chrome_remote_desktop_app_blocked;
+-  std::optional<safe_browsing::PasswordProtectionTrigger>
+-      password_protection_warning_trigger = std::nullopt;
+   std::optional<std::string> profile_enrollment_domain = std::nullopt;
+-  safe_browsing::SafeBrowsingState safe_browsing_protection_level;
+   bool site_isolation_enabled;
+   std::optional<std::string> profile_id = std::nullopt;
+ 
+--- a/components/enterprise/browser/reporting/chrome_profile_request_generator.cc
++++ b/components/enterprise/browser/reporting/chrome_profile_request_generator.cc
+@@ -313,18 +313,12 @@ void ChromeProfileRequestGenerator::OnAg
+         profile_signals.built_in_dns_client_enabled);
+     profile_signals_report->set_chrome_remote_desktop_app_blocked(
+         profile_signals.chrome_remote_desktop_app_blocked);
+-    profile_signals_report->set_password_protection_warning_trigger(
+-        TranslatePasswordProtectionTrigger(
+-            profile_signals.password_protection_warning_trigger));
+     if (profile_signals.profile_enrollment_domain) {
+       profile_signals_report->set_profile_enrollment_domain(
+           profile_signals.profile_enrollment_domain.value());
+     }
+     profile_signals_report->set_realtime_url_check_mode(
+         TranslateRealtimeUrlCheckMode(profile_signals.realtime_url_check_mode));
+-    profile_signals_report->set_safe_browsing_protection_level(
+-        TranslateSafeBrowsingLevel(
+-            profile_signals.safe_browsing_protection_level));
+     profile_signals_report->set_site_isolation_enabled(
+         profile_signals.site_isolation_enabled);
+ 
+--- a/components/enterprise/browser/reporting/report_util.cc
++++ b/components/enterprise/browser/reporting/report_util.cc
+@@ -83,25 +83,6 @@ em::SettingValue TranslateSettingValue(
+   }
+ }
+ 
+-em::ProfileSignalsReport::PasswordProtectionTrigger
+-TranslatePasswordProtectionTrigger(
+-    std::optional<safe_browsing::PasswordProtectionTrigger> trigger) {
+-  if (trigger == std::nullopt) {
+-    return em::ProfileSignalsReport::POLICY_UNSET;
+-  }
+-  switch (trigger.value()) {
+-    case safe_browsing::PasswordProtectionTrigger::PASSWORD_PROTECTION_OFF:
+-      return em::ProfileSignalsReport::PASSWORD_PROTECTION_OFF;
+-    case safe_browsing::PasswordProtectionTrigger::PASSWORD_REUSE:
+-      return em::ProfileSignalsReport::PASSWORD_REUSE;
+-    case safe_browsing::PasswordProtectionTrigger::PHISHING_REUSE:
+-      return em::ProfileSignalsReport::PHISHING_REUSE;
+-    case safe_browsing::PasswordProtectionTrigger::
+-        PASSWORD_PROTECTION_TRIGGER_MAX:
+-      NOTREACHED();
+-  }
+-}
+-
+ em::ProfileSignalsReport::RealtimeUrlCheckMode TranslateRealtimeUrlCheckMode(
+     enterprise_connectors::EnterpriseRealTimeUrlCheckMode mode) {
+   switch (mode) {
+@@ -114,18 +95,6 @@ em::ProfileSignalsReport::RealtimeUrlChe
+   }
+ }
+ 
+-em::ProfileSignalsReport::SafeBrowsingLevel TranslateSafeBrowsingLevel(
+-    safe_browsing::SafeBrowsingState level) {
+-  switch (level) {
+-    case safe_browsing::SafeBrowsingState::NO_SAFE_BROWSING:
+-      return em::ProfileSignalsReport::NO_SAFE_BROWSING;
+-    case safe_browsing::SafeBrowsingState::STANDARD_PROTECTION:
+-      return em::ProfileSignalsReport::STANDARD_PROTECTION;
+-    case safe_browsing::SafeBrowsingState::ENHANCED_PROTECTION:
+-      return em::ProfileSignalsReport::ENHANCED_PROTECTION;
+-  }
+-}
+-
+ #if BUILDFLAG(IS_WIN)
+ std::unique_ptr<em::AntiVirusProduct> TranslateAvProduct(
+     device_signals::AvProduct av_product) {
+--- a/components/enterprise/browser/reporting/report_util.h
++++ b/components/enterprise/browser/reporting/report_util.h
+@@ -33,17 +33,10 @@ std::string ObfuscateFilePath(const std:
+ enterprise_management::SettingValue TranslateSettingValue(
+     device_signals::SettingValue setting_value);
+ 
+-enterprise_management::ProfileSignalsReport::PasswordProtectionTrigger
+-TranslatePasswordProtectionTrigger(
+-    std::optional<safe_browsing::PasswordProtectionTrigger> trigger);
+-
+ enterprise_management::ProfileSignalsReport::RealtimeUrlCheckMode
+ TranslateRealtimeUrlCheckMode(
+     enterprise_connectors::EnterpriseRealTimeUrlCheckMode mode);
+ 
+-enterprise_management::ProfileSignalsReport::SafeBrowsingLevel
+-TranslateSafeBrowsingLevel(safe_browsing::SafeBrowsingState level);
+-
+ #if BUILDFLAG(IS_WIN)
+ std::unique_ptr<enterprise_management::AntiVirusProduct> TranslateAvProduct(
+     device_signals::AvProduct av_product);
+--- a/components/enterprise/buildflags/buildflags.gni
++++ b/components/enterprise/buildflags/buildflags.gni
+@@ -10,11 +10,11 @@ declare_args() {
+   # Indicates support for content analysis against a cloud agent for Enterprise
+   # Connector policies.
+   enterprise_cloud_content_analysis =
+-      is_win || is_mac || is_linux || is_chromeos || is_ios
++      false
+ 
+   # Indicates support for content analysis against a cloud agent for Enterprise
+   # Connector policies.
+-  enterprise_local_content_analysis = is_win || is_mac || is_linux
++  enterprise_local_content_analysis = false
+ 
+   # Indicates support for Data Control rules.
+   enterprise_data_controls =
+--- a/components/enterprise/connectors/core/analysis_service_settings_base.cc
++++ b/components/enterprise/connectors/core/analysis_service_settings_base.cc
+@@ -271,8 +271,6 @@ CloudAnalysisSettings AnalysisServiceSet
+   CHECK(is_cloud_analysis());
+ 
+   CloudAnalysisSettings cloud_settings;
+-  cloud_settings.analysis_url =
+-      GetRegionalizedEndpoint(analysis_config_->region_urls, data_region);
+   // We assume all support_tags structs have the same max file size.
+   cloud_settings.max_file_size =
+       analysis_config_->supported_tags[0].max_file_size;
+--- a/components/enterprise/connectors/core/cloud_content_scanning/files_request_handler_base.cc
++++ b/components/enterprise/connectors/core/cloud_content_scanning/files_request_handler_base.cc
+@@ -213,20 +213,6 @@ void FilesRequestHandlerBase::OnGotFileI
+ void FilesRequestHandlerBase::FinishRequestEarly(
+     std::unique_ptr<BinaryUploadRequest> request,
+     ScanRequestUploadResult result) {
+-#if !BUILDFLAG(IS_IOS)
+-  // We add the request here in case we never actually uploaded anything, so it
+-  // wasn't added in OnGetRequestData
+-  safe_browsing::WebUIContentInfoSingleton::GetInstance()
+-      ->AddToDeepScanRequests(
+-          request->per_profile_request(),
+-          /*access_token*/ "",
+-          /*upload_info*/ ScanRequestUploadResultToString(result),
+-          /*upload_url=*/"", request->content_analysis_request());
+-  safe_browsing::WebUIContentInfoSingleton::GetInstance()
+-      ->AddToDeepScanResponses(
+-          /*token=*/"", ScanRequestUploadResultToString(result),
+-          enterprise_connectors::ContentAnalysisResponse());
+-#endif
+ 
+   BinaryUploadRequest* request_ptr = request.get();
+   if (request->digest().empty() && request->register_on_got_hash_callback_) {
+--- a/components/enterprise/connectors/core/cloud_content_scanning/multipart_uploader_base.cc
++++ b/components/enterprise/connectors/core/cloud_content_scanning/multipart_uploader_base.cc
+@@ -225,10 +225,6 @@ void MultipartUploadRequestBase::SendReq
+   resource_request->url = base_url_;
+   resource_request->method = "POST";
+   SetRequestHeaders(resource_request.get());
+-#if !BUILDFLAG(IS_IOS)
+-  safe_browsing::WebUIContentInfoSingleton::GetInstance()
+-      ->AddHeadersToDeepScanRequests(request_token_, resource_request->headers);
+-#endif
+ 
+   switch (data_source_) {
+     case STRING:
+--- a/components/enterprise/connectors/core/cloud_content_scanning/resumable_uploader_base.cc
++++ b/components/enterprise/connectors/core/cloud_content_scanning/resumable_uploader_base.cc
+@@ -268,10 +268,6 @@ void ResumableUploadRequestBase::SendMet
+   resource_request->url = base_url_;
+   resource_request->method = "POST";
+   SetMetadataRequestHeaders(resource_request.get());
+-#if !BUILDFLAG(IS_IOS)
+-  safe_browsing::WebUIContentInfoSingleton::GetInstance()
+-      ->AddHeadersToDeepScanRequests(request_token_, resource_request->headers);
+-#endif
+ 
+   url_loader_ = network::SimpleURLLoader::Create(std::move(resource_request),
+                                                  traffic_annotation_);
+--- a/components/enterprise/connectors/core/reporting_service_settings.cc
++++ b/components/enterprise/connectors/core/reporting_service_settings.cc
+@@ -45,16 +45,6 @@ ReportingServiceSettings::ReportingServi
+       else
+         DVLOG(1) << "Enabled event name list contains a non string value!";
+     }
+-  } else {
+-    // When the list of enabled event names is not set, we assume all events are
+-    // enabled. This is to support the feature of selecting the "All always on"
+-    // option in the policy UI, which means to always enable all events, even
+-    // when new events may be added in the future. And this is also to support
+-    // existing customer policies that were created before we introduced the
+-    // concept of enabling/disabling events.
+-    for (const char* event : kAllReportingEnabledEvents) {
+-      enabled_event_names_.insert(event);
+-    }
+   }
+ 
+   const base::ListValue* enabled_opt_in_events_value =
+--- a/components/password_manager/core/browser/leak_detection/leak_detection_check_impl.cc
++++ b/components/password_manager/core/browser/leak_detection/leak_detection_check_impl.cc
+@@ -313,12 +313,7 @@ bool LeakDetectionCheck::IsURLBlockedByP
+     const PrefService& prefs,
+     const GURL& form_url,
+     autofill::SavePasswordProgressLogger* logger) {
+-  bool is_blocked = safe_browsing::IsURLAllowlistedByPolicy(form_url, prefs);
+-  if (is_blocked && logger) {
+-    logger->LogMessage(autofill::SavePasswordProgressLogger::
+-                           STRING_LEAK_DETECTION_URL_BLOCKED);
+-  }
+-  return is_blocked;
++  return false;
+ }
+ 
+ }  // namespace password_manager
+--- a/components/safe_browsing/content/common/safe_browsing.mojom
++++ b/components/safe_browsing/content/common/safe_browsing.mojom
+@@ -184,7 +184,6 @@ interface PhishingDetector {
+ 
+ // Interface for setting a phishing model. This is scoped to an entire
+ // RenderProcess.
+-[EnableIf=full_safe_browsing]
+ interface PhishingModelSetter {
+   // A classification model for client-side phishing detection in addition to
+   // the image embedding model. This call sends the model and the image
+--- a/components/safe_browsing/content/common/visual_utils.h
++++ b/components/safe_browsing/content/common/visual_utils.h
+@@ -7,7 +7,6 @@
+ 
+ #include <string>
+ 
+-#include "components/safe_browsing/core/common/proto/client_model.pb.h"
+ #include "components/safe_browsing/core/common/proto/csd.pb.h"
+ #include "third_party/skia/include/core/SkBitmap.h"
+ #include "ui/gfx/geometry/size.h"
+--- a/components/safe_browsing/core/browser/BUILD.gn
++++ b/components/safe_browsing/core/browser/BUILD.gn
+@@ -21,8 +21,6 @@ source_set("browser") {
+     "url_checker_delegate.h",
+     "url_realtime_mechanism.cc",
+     "url_realtime_mechanism.h",
+-    "user_population.cc",
+-    "user_population.h",
+   ]
+ 
+   configs += [ "//build/config/compiler:wexit_time_destructors" ]
+--- a/components/safe_browsing/core/browser/db/hash_prefix_map.h
++++ b/components/safe_browsing/core/browser/db/hash_prefix_map.h
+@@ -11,6 +11,7 @@
+ #include <unordered_map>
+ 
+ #include "base/files/memory_mapped_file.h"
++#include "base/task/sequenced_task_runner.h"
+ #include "components/safe_browsing/core/browser/db/v4_protocol_manager_util.h"
+ #include "components/safe_browsing/core/browser/db/v4_store.pb.h"
+ #include "components/safe_browsing/core/common/proto/webui.pb.h"
+--- a/components/safe_browsing/core/browser/db/sb_protocol_manager_util.cc
++++ b/components/safe_browsing/core/browser/db/sb_protocol_manager_util.cc
+@@ -133,82 +133,56 @@ PlatformType GetCurrentPlatformType() {
+ }
+ 
+ ListIdentifier GetChromeExtMalwareId() {
+-  return base::FeatureList::IsEnabled(safe_browsing::kLocalListsUseSBv5)
+-             ? ListIdentifier(SBThreatType::SB_THREAT_TYPE_EXTENSION)
+-             : ListIdentifier(CHROME_PLATFORM, CHROME_EXTENSION,
++  return ListIdentifier(CHROME_PLATFORM, CHROME_EXTENSION,
+                               MALWARE_THREAT);
+ }
+ 
+ ListIdentifier GetChromeUrlApiId() {
+-  return base::FeatureList::IsEnabled(safe_browsing::kLocalListsUseSBv5)
+-             ? ListIdentifier(SBThreatType::SB_THREAT_TYPE_API_ABUSE)
+-             : ListIdentifier(GetCurrentPlatformType(), URL, API_ABUSE);
++  return ListIdentifier(GetCurrentPlatformType(), URL, API_ABUSE);
+ }
+ 
+ ListIdentifier GetUrlBillingId() {
+-  return base::FeatureList::IsEnabled(safe_browsing::kLocalListsUseSBv5)
+-             ? ListIdentifier(SBThreatType::SB_THREAT_TYPE_BILLING)
+-             : ListIdentifier(GetCurrentPlatformType(), URL, BILLING);
++  return ListIdentifier(GetCurrentPlatformType(), URL, BILLING);
+ }
+ 
+ ListIdentifier GetUrlCsdDownloadAllowlistId() {
+-  return base::FeatureList::IsEnabled(safe_browsing::kLocalListsUseSBv5)
+-             ? ListIdentifier(
+-                   SBThreatType::SB_THREAT_TYPE_CSD_DOWNLOAD_ALLOWLIST)
+-             : ListIdentifier(GetCurrentPlatformType(), URL,
++  return ListIdentifier(GetCurrentPlatformType(), URL,
+                               CSD_DOWNLOAD_ALLOWLIST);
+ }
+ 
+ ListIdentifier GetUrlCsdAllowlistId() {
+-  return base::FeatureList::IsEnabled(safe_browsing::kLocalListsUseSBv5)
+-             ? ListIdentifier(SBThreatType::SB_THREAT_TYPE_CSD_ALLOWLIST)
+-             : ListIdentifier(GetCurrentPlatformType(), URL, CSD_ALLOWLIST);
++  return ListIdentifier(GetCurrentPlatformType(), URL, CSD_ALLOWLIST);
+ }
+ 
+ ListIdentifier GetUrlHighConfidenceAllowlistId() {
+-  return base::FeatureList::IsEnabled(safe_browsing::kLocalListsUseSBv5)
+-             ? ListIdentifier(
+-                   SBThreatType::SB_THREAT_TYPE_HIGH_CONFIDENCE_ALLOWLIST)
+-             : ListIdentifier(GetCurrentPlatformType(), URL,
++  return ListIdentifier(GetCurrentPlatformType(), URL,
+                               HIGH_CONFIDENCE_ALLOWLIST);
+ }
+ 
+ ListIdentifier GetUrlMalwareId() {
+-  return base::FeatureList::IsEnabled(safe_browsing::kLocalListsUseSBv5)
+-             ? ListIdentifier(SBThreatType::SB_THREAT_TYPE_URL_MALWARE)
+-             : ListIdentifier(GetCurrentPlatformType(), URL, MALWARE_THREAT);
++  return ListIdentifier(GetCurrentPlatformType(), URL, MALWARE_THREAT);
+ }
+ 
+ ListIdentifier GetUrlMalBinId() {
+-  return base::FeatureList::IsEnabled(safe_browsing::kLocalListsUseSBv5)
+-             ? ListIdentifier(SBThreatType::SB_THREAT_TYPE_URL_BINARY_MALWARE)
+-             : ListIdentifier(GetCurrentPlatformType(), URL, MALICIOUS_BINARY);
++  return ListIdentifier(GetCurrentPlatformType(), URL, MALICIOUS_BINARY);
+ }
+ 
+ ListIdentifier GetUrlSocEngId() {
+-  return base::FeatureList::IsEnabled(safe_browsing::kLocalListsUseSBv5)
+-             ? ListIdentifier(SBThreatType::SB_THREAT_TYPE_URL_PHISHING)
+-             : ListIdentifier(GetCurrentPlatformType(), URL,
++  return ListIdentifier(GetCurrentPlatformType(), URL,
+                               SOCIAL_ENGINEERING);
+ }
+ 
+ ListIdentifier GetUrlSubresourceFilterId() {
+-  return base::FeatureList::IsEnabled(safe_browsing::kLocalListsUseSBv5)
+-             ? ListIdentifier(SBThreatType::SB_THREAT_TYPE_SUBRESOURCE_FILTER)
+-             : ListIdentifier(GetCurrentPlatformType(), URL,
++  return ListIdentifier(GetCurrentPlatformType(), URL,
+                               SUBRESOURCE_FILTER);
+ }
+ 
+ ListIdentifier GetUrlSuspiciousSiteId() {
+-  return base::FeatureList::IsEnabled(safe_browsing::kLocalListsUseSBv5)
+-             ? ListIdentifier(SBThreatType::SB_THREAT_TYPE_SUSPICIOUS_SITE)
+-             : ListIdentifier(GetCurrentPlatformType(), URL, SUSPICIOUS);
++  return ListIdentifier(GetCurrentPlatformType(), URL, SUSPICIOUS);
+ }
+ 
+ ListIdentifier GetUrlUwsId() {
+-  return base::FeatureList::IsEnabled(safe_browsing::kLocalListsUseSBv5)
+-             ? ListIdentifier(SBThreatType::SB_THREAT_TYPE_URL_UNWANTED)
+-             : ListIdentifier(GetCurrentPlatformType(), URL, UNWANTED_SOFTWARE);
++  return ListIdentifier(GetCurrentPlatformType(), URL, UNWANTED_SOFTWARE);
+ }
+ 
+ std::string GetUmaSuffixForStore(const base::FilePath& file_path) {
+@@ -277,7 +251,6 @@ ListIdentifier::ListIdentifier(PlatformT
+       threat_entry_type_(threat_entry_type),
+       threat_type_(threat_type),
+       uses_v5_api_(false) {
+-  CHECK(!base::FeatureList::IsEnabled(safe_browsing::kLocalListsUseSBv5));
+   DCHECK(PlatformType_IsValid(platform_type));
+   DCHECK(ThreatEntryType_IsValid(threat_entry_type));
+   DCHECK(ThreatType_IsValid(threat_type));
+@@ -290,7 +263,6 @@ ListIdentifier::ListIdentifier(const Lis
+ 
+ ListIdentifier::ListIdentifier(SBThreatType sb_threat_type)
+     : sb_threat_type_(sb_threat_type), uses_v5_api_(true) {
+-  CHECK(base::FeatureList::IsEnabled(safe_browsing::kLocalListsUseSBv5));
+ }
+ 
+ // static
+--- a/components/safe_browsing/core/browser/db/v4_update_protocol_manager.cc
++++ b/components/safe_browsing/core/browser/db/v4_update_protocol_manager.cc
+@@ -29,7 +29,6 @@
+ #include "services/network/public/mojom/url_response_head.mojom.h"
+ 
+ using base::Time;
+-using enum safe_browsing::ExtendedReportingLevel;
+ 
+ namespace {
+ 
+--- a/components/safe_browsing/core/browser/hashprefix_realtime/hash_realtime_service.h
++++ b/components/safe_browsing/core/browser/hashprefix_realtime/hash_realtime_service.h
+@@ -12,6 +12,7 @@
+ #include <string>
+ #include <vector>
+ 
++#include "base/containers/flat_map.h"
+ #include "base/containers/unique_ptr_adapters.h"
+ #include "base/gtest_prod_util.h"
+ #include "base/memory/raw_ptr.h"
+--- a/components/safe_browsing/core/browser/hashprefix_realtime/ohttp_key_service.cc
++++ b/components/safe_browsing/core/browser/hashprefix_realtime/ohttp_key_service.cc
+@@ -18,7 +18,6 @@
+ #include "components/safe_browsing/core/browser/utils/backoff_operator.h"
+ #include "components/safe_browsing/core/common/features.h"
+ #include "components/safe_browsing/core/common/hashprefix_realtime/hash_realtime_utils.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/utils.h"
+ #include "google_apis/google_api_keys.h"
+ #include "net/base/net_errors.h"
+@@ -124,21 +123,7 @@ constexpr net::NetworkTrafficAnnotationT
+ bool IsEnabled(PrefService* pref_service,
+                std::optional<std::string> country,
+                bool are_background_lookups_allowed) {
+-  // If this class has been created, it is already known that the session is not
+-  // off-the-record, so |is_off_the_record| is passed through as false.
+-  safe_browsing::hash_realtime_utils::HashRealTimeSelection
+-      hash_realtime_selection =
+-          safe_browsing::hash_realtime_utils::DetermineHashRealTimeSelection(
+-              /*is_off_the_record=*/false, pref_service,
+-              /*latest_country=*/country, /*log_usage_histograms=*/false,
+-              /*are_background_lookups_allowed=*/
+-              are_background_lookups_allowed);
+-  return hash_realtime_selection ==
+-             safe_browsing::hash_realtime_utils::HashRealTimeSelection::
+-                 kHashRealTimeService ||
+-         hash_realtime_selection ==
+-             safe_browsing::hash_realtime_utils::HashRealTimeSelection::
+-                 kHashRealTimeServiceBackgroundOnly;
++  return false;
+ }
+ 
+ GURL GetKeyFetchingUrl() {
+@@ -507,30 +492,9 @@ void OhttpKeyService::MaybeStartServerTr
+ }
+ 
+ void OhttpKeyService::PopulateKeyFromPref() {
+-  std::string key =
+-      pref_service_->GetString(prefs::kSafeBrowsingHashRealTimeOhttpKey);
+-  base::Time expiration_time = pref_service_->GetTime(
+-      prefs::kSafeBrowsingHashRealTimeOhttpExpirationTime);
+-  std::string key_fetch_url = pref_service_->GetString(
+-      prefs::kSafeBrowsingHashRealTimeOhttpKeyFetchUrl);
+-  if (!key.empty() && expiration_time > base::Time::Now() &&
+-      key_fetch_url == kHashPrefixRealTimeLookupsKeyFetchUrl.Get()) {
+-    std::string decoded_key;
+-    base::Base64Decode(key, &decoded_key);
+-    ohttp_key_ = {decoded_key, expiration_time};
+-  }
+ }
+ 
+ void OhttpKeyService::StoreKeyToPref() {
+-  if (ohttp_key_ && ohttp_key_->expiration > base::Time::Now()) {
+-    std::string base64_encoded_key = base::Base64Encode(ohttp_key_->key);
+-    pref_service_->SetString(prefs::kSafeBrowsingHashRealTimeOhttpKey,
+-                             base64_encoded_key);
+-    pref_service_->SetTime(prefs::kSafeBrowsingHashRealTimeOhttpExpirationTime,
+-                           ohttp_key_->expiration);
+-    pref_service_->SetString(prefs::kSafeBrowsingHashRealTimeOhttpKeyFetchUrl,
+-                             kHashPrefixRealTimeLookupsKeyFetchUrl.Get());
+-  }
+ }
+ 
+ void OhttpKeyService::Shutdown() {
+--- a/components/safe_browsing/core/browser/realtime/chrome_enterprise_url_lookup_service.cc
++++ b/components/safe_browsing/core/browser/realtime/chrome_enterprise_url_lookup_service.cc
+@@ -151,7 +151,7 @@ bool ChromeEnterpriseRealTimeUrlLookupSe
+ 
+ bool ChromeEnterpriseRealTimeUrlLookupService::CanCheckSafeBrowsingDb() const {
+   // Check database if safe browsing is enabled.
+-  return safe_browsing::IsSafeBrowsingEnabled(*pref_service_);
++  return false;
+ }
+ 
+ bool ChromeEnterpriseRealTimeUrlLookupService::
+--- a/components/safe_browsing/core/browser/realtime/url_lookup_service.cc
++++ b/components/safe_browsing/core/browser/realtime/url_lookup_service.cc
+@@ -256,17 +256,6 @@ void RealTimeUrlLookupService::MaybeLogP
+     bool request_had_cookie,
+     bool was_first_request,
+     bool sent_with_token) {
+-  std::string histogram_name = kCookieHistogramPrefix;
+-  base::StrAppend(&histogram_name,
+-                  {was_first_request ? ".FirstRequest" : ".SubsequentRequest"});
+-  base::UmaHistogramBoolean(histogram_name, request_had_cookie);
+-  // `pref_service_` can be null in tests.
+-  // This histogram variant is only logged for signed-out ESB users.
+-  if (!sent_with_token && pref_service_ &&
+-      IsEnhancedProtectionEnabled(*pref_service_)) {
+-    base::StrAppend(&histogram_name, {".SignedOutEsbUser"});
+-    base::UmaHistogramBoolean(histogram_name, request_had_cookie);
+-  }
+ }
+ 
+ void RealTimeUrlLookupService::MaybeFillReferringWebApk(
+--- a/components/safe_browsing/core/browser/realtime/url_lookup_service_base.cc
++++ b/components/safe_browsing/core/browser/realtime/url_lookup_service_base.cc
+@@ -638,22 +638,6 @@ RealTimeUrlLookupServiceBase::GetResourc
+ RTLookupRequest::LlamaForcedTriggerCapability
+ RealTimeUrlLookupServiceBase::MaybeGetLlamaForcedTriggerCapability() const {
+   auto model_type = IntelligentScanModelType::NOT_SUPPORTED;
+-  if (pref_service_ && IsEnhancedProtectionEnabled(*pref_service_) &&
+-      intelligent_scan_delegate_) {
+-    switch (intelligent_scan_delegate_->GetIntelligentScanModelType(
+-        /*log_failed_eligibility_reason=*/false)) {
+-      case IntelligentScanDelegate::ModelType::kNotSupportedOnDevice:
+-      case IntelligentScanDelegate::ModelType::kNotSupportedServerSide:
+-        model_type = IntelligentScanModelType::NOT_SUPPORTED;
+-        break;
+-      case IntelligentScanDelegate::ModelType::kOnDevice:
+-        model_type = IntelligentScanModelType::ON_DEVICE_MODEL;
+-        break;
+-      case IntelligentScanDelegate::ModelType::kServerSide:
+-        model_type = IntelligentScanModelType::SERVER_SIDE_MODEL;
+-        break;
+-    }
+-  }
+   RTLookupRequest::LlamaForcedTriggerCapability capability;
+   capability.set_supported_model_type(model_type);
+   return capability;
+@@ -674,17 +658,6 @@ void RealTimeUrlLookupServiceBase::Start
+   request->set_report_type(is_sampled_report ? RTLookupRequest::SAMPLED_REPORT
+                                              : RTLookupRequest::FULL_REPORT);
+   request->set_frame_type(RTLookupRequest::MAIN_FRAME);
+-  if (referring_app_info && pref_service_ &&
+-      IsEnhancedProtectionEnabled(*pref_service_)) {
+-    safe_browsing::ReferringAppInfo referring_app_info_proto;
+-    referring_app_info_proto.set_referring_app_name(
+-        referring_app_info.value().referring_app_name);
+-    referring_app_info_proto.set_referring_app_source(
+-        referring_app_info.value().referring_app_source);
+-    *request->mutable_referring_app_info() =
+-        std::move(referring_app_info_proto);
+-    MaybeFillReferringWebApk(*referring_app_info, *request);
+-  }
+   *request->mutable_llama_forced_trigger_capability() =
+       MaybeGetLlamaForcedTriggerCapability();
+ 
+--- a/components/safe_browsing/core/browser/safe_browsing_hats_delegate.h
++++ b/components/safe_browsing/core/browser/safe_browsing_hats_delegate.h
+@@ -5,6 +5,8 @@
+ #ifndef COMPONENTS_SAFE_BROWSING_CORE_BROWSER_SAFE_BROWSING_HATS_DELEGATE_H_
+ #define COMPONENTS_SAFE_BROWSING_CORE_BROWSER_SAFE_BROWSING_HATS_DELEGATE_H_
+ 
++#include <map>
++
+ #include "components/safe_browsing/core/browser/db/v4_protocol_manager_util.h"
+ #include "components/safe_browsing/core/common/proto/csd.pb.h"
+ 
+--- a/components/safe_browsing/core/browser/tailored_security_service/tailored_security_service.cc
++++ b/components/safe_browsing/core/browser/tailored_security_service/tailored_security_service.cc
+@@ -410,7 +410,6 @@ void TailoredSecurityService::MaybeNotif
+       RecordEnabledNotificationResult(
+           TailoredSecurityNotificationResult::kHistoryNotSynced);
+     }
+-    SaveRetryState(TailoredSecurityRetryState::NO_RETRY_NEEDED);
+     return;
+   }
+ 
+@@ -420,7 +419,6 @@ void TailoredSecurityService::MaybeNotif
+       RecordEnabledNotificationResult(
+           TailoredSecurityNotificationResult::kSafeBrowsingControlledByPolicy);
+     }
+-    SaveRetryState(TailoredSecurityRetryState::NO_RETRY_NEEDED);
+     return;
+   }
+ 
+@@ -530,25 +528,10 @@ void TailoredSecurityService::Shutdown()
+ }
+ 
+ void TailoredSecurityService::TailoredSecurityTimestampUpdateCallback() {
+-  // TODO(crbug.com/40925236): remove sync flow last user interaction pref.
+-  prefs_->SetInteger(prefs::kTailoredSecuritySyncFlowLastUserInteractionState,
+-                     TailoredSecurityRetryState::UNKNOWN);
+-  prefs_->SetTime(prefs::kTailoredSecuritySyncFlowLastRunTime,
+-                  base::Time::Now());
+-  // If this method fails, then a retry is needed. If it succeeds, the
+-  // ChromeTailoredSecurityService will set this value to NO_RETRY_NEEDED for
+-  // us.
+-  prefs_->SetInteger(prefs::kTailoredSecuritySyncFlowRetryState,
+-                     TailoredSecurityRetryState::RETRY_NEEDED);
+-
+   StartRequest(base::BindOnce(&TailoredSecurityService::MaybeNotifySyncUser,
+                               weak_ptr_factory_.GetWeakPtr()));
+ }
+ 
+-void TailoredSecurityService::SaveRetryState(TailoredSecurityRetryState state) {
+-  prefs_->SetInteger(prefs::kTailoredSecuritySyncFlowRetryState, state);
+-}
+-
+ void TailoredSecurityService::SetCanQuery(bool can_query) {
+   can_query_ = can_query;
+   if (can_query) {
+@@ -568,13 +551,6 @@ bool TailoredSecurityService::IsResponsi
+     return true;
+   }
+ 
+-  bool is_enhanced_enabled = IsEnhancedProtectionEnabled(*prefs);
+-  if (is_enhanced_enabled &&
+-      prefs->GetBoolean(prefs::kEnhancedProtectionEnabledViaTailoredSecurity)) {
+-    // The TailoredSecurityService was responsible for enabling enhanced
+-    // protection and will show its own UI.
+-    return true;
+-  }
+ 
+   return false;
+ }
+--- a/components/safe_browsing/core/browser/tailored_security_service/tailored_security_service.h
++++ b/components/safe_browsing/core/browser/tailored_security_service/tailored_security_service.h
+@@ -24,7 +24,6 @@
+ #include "base/values.h"
+ #include "components/keyed_service/core/keyed_service.h"
+ #include "components/prefs/pref_change_registrar.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "net/traffic_annotation/network_traffic_annotation.h"
+ #include "url/gurl.h"
+ 
+@@ -212,9 +211,6 @@ class TailoredSecurityService : public K
+                            RetryLogicTimestampUpdateCallbackRecordsStartTime);
+   friend class TailoredSecurityTabHelperTest;
+ 
+-  // Saves the supplied `TailoredSecurityRetryState` to preferences.
+-  void SaveRetryState(TailoredSecurityRetryState state);
+-
+   // Stores pointer to `IdentityManager` instance. It must outlive the
+   // `TailoredSecurityService` and can be null during tests.
+   raw_ptr<signin::IdentityManager> identity_manager_;
+--- a/components/safe_browsing/core/browser/verdict_cache_manager.cc
++++ b/components/safe_browsing/core/browser/verdict_cache_manager.cc
+@@ -468,16 +468,6 @@ VerdictCacheManager::VerdictCacheManager
+   // pref_service can be null in tests.
+   if (pref_service) {
+     pref_change_registrar_.Init(pref_service);
+-    pref_change_registrar_.Add(
+-        prefs::kSafeBrowsingEnhanced,
+-        base::BindRepeating(&VerdictCacheManager::CleanUpAllPageLoadTokens,
+-                            weak_factory_.GetWeakPtr(),
+-                            ClearReason::kSafeBrowsingStateChanged));
+-    pref_change_registrar_.Add(
+-        prefs::kSafeBrowsingEnabled,
+-        base::BindRepeating(&VerdictCacheManager::CleanUpAllPageLoadTokens,
+-                            weak_factory_.GetWeakPtr(),
+-                            ClearReason::kSafeBrowsingStateChanged));
+   }
+   // sync_observer_ can be null in some embedders that don't support sync.
+   if (sync_observer_) {
+--- a/components/security_interstitials/content/ssl_blocking_page_base.cc
++++ b/components/security_interstitials/content/ssl_blocking_page_base.cc
+@@ -4,7 +4,6 @@
+ 
+ #include "components/security_interstitials/content/ssl_blocking_page_base.h"
+ 
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/security_interstitials/content/security_interstitial_controller_client.h"
+ #include "components/security_interstitials/core/controller_client.h"
+ #include "components/security_interstitials/core/metrics_helper.h"
+@@ -42,33 +41,7 @@ SSLBlockingPageBase::~SSLBlockingPageBas
+ void SSLBlockingPageBase::OnInterstitialClosing() {}
+ 
+ bool SSLBlockingPageBase::ShouldShowEnhancedProtectionMessage() {
+-  // Only show the enhanced protection message if all the following are true:
+-  // |can_show_enhanced_protection_message_| is set to true AND
+-  // the window is not incognito AND
+-  // Safe Browsing is not managed by policy AND
+-  // the user is not already in enhanced protection mode.
+-  if (!can_show_enhanced_protection_message_) {
+     return false;
+-  }
+-
+-  const bool in_incognito =
+-      web_contents()->GetBrowserContext()->IsOffTheRecord();
+-  const PrefService* pref_service = GetPrefs(web_contents());
+-  bool is_enhanced_protection_enabled =
+-      safe_browsing::IsEnhancedProtectionEnabled(*pref_service);
+-  bool is_safe_browsing_managed =
+-      safe_browsing::IsSafeBrowsingPolicyManaged(*pref_service);
+-
+-  if (in_incognito) {
+-    return false;
+-  }
+-  if (is_enhanced_protection_enabled) {
+-    return false;
+-  }
+-  if (is_safe_browsing_managed) {
+-    return false;
+-  }
+-  return true;
+ }
+ 
+ void SSLBlockingPageBase::PopulateEnhancedProtectionMessage(
+--- a/components/sync_preferences/common_syncable_prefs_database.cc
++++ b/components/sync_preferences/common_syncable_prefs_database.cc
+@@ -411,9 +411,6 @@ constexpr auto kCommonSyncablePrefsAllow
+         {plus_addresses::prefs::kLastPlusAddressFillingTime,
+          {syncable_prefs_ids::kLastPlusAddressFillingTime, syncer::PREFERENCES,
+           PrefSensitivity::kNone, MergeBehavior::kNone}},
+-        {prefs::kSafeBrowsingEnhanced,
+-         {syncable_prefs_ids::kSafeBrowsingEnhanced, syncer::PREFERENCES,
+-          PrefSensitivity::kNone, MergeBehavior::kNone}},
+ #if BUILDFLAG(IS_ANDROID)
+         {autofill::prefs::kFacilitatedPaymentsPix,
+          {syncable_prefs_ids::kFacilitatedPaymentsPix, syncer::PREFERENCES,
+--- a/content/browser/file_system_access/file_system_access_safe_move_helper.cc
++++ b/content/browser/file_system_access/file_system_access_safe_move_helper.cc
+@@ -175,15 +175,8 @@ void FileSystemAccessSafeMoveHelper::Sta
+     return;
+   }
+ 
+-  if (!RequireAfterWriteChecks() || !manager_->permission_context()) {
+     DidAfterWriteCheck(
+         FileSystemAccessPermissionContext::AfterWriteCheckResult::kAllow);
+-    return;
+-  }
+-
+-  ComputeHashForSourceFile(
+-      base::BindOnce(&FileSystemAccessSafeMoveHelper::DoAfterWriteCheck,
+-                     weak_factory_.GetWeakPtr()));
+ }
+ 
+ void FileSystemAccessSafeMoveHelper::ComputeHashForSourceFile(
+@@ -222,45 +215,6 @@ bool FileSystemAccessSafeMoveHelper::Req
+   return dest_url().type() != storage::kFileSystemTypeTemporary;
+ }
+ 
+-void FileSystemAccessSafeMoveHelper::DoAfterWriteCheck(
+-    base::File::Error hash_result,
+-    const std::string& hash,
+-    int64_t size) {
+-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+-
+-  if (hash_result != base::File::FILE_OK) {
+-    // Calculating the hash failed.
+-    std::move(callback_).Run(file_system_access_error::FromStatus(
+-        blink::mojom::FileSystemAccessStatus::kOperationAborted,
+-        "Failed to perform Safe Browsing check."));
+-    return;
+-  }
+-
+-  if (!manager_) {
+-    std::move(callback_).Run(file_system_access_error::FromStatus(
+-        blink::mojom::FileSystemAccessStatus::kOperationAborted));
+-    return;
+-  }
+-
+-  content::GlobalRenderFrameHostId outermost_main_frame_id;
+-  auto* rfh = content::RenderFrameHost::FromID(context_.frame_id);
+-  if (rfh)
+-    outermost_main_frame_id = rfh->GetOutermostMainFrame()->GetGlobalId();
+-
+-  auto item = std::make_unique<FileSystemAccessWriteItem>();
+-  item->target_file_path = dest_url().path();
+-  item->full_path = source_url().path();
+-  item->sha256_hash = hash;
+-  item->size = size;
+-  item->frame_url = context_.url;
+-  item->outermost_main_frame_id = outermost_main_frame_id;
+-  item->has_user_gesture = has_transient_user_activation_;
+-  manager_->permission_context()->PerformAfterWriteChecks(
+-      std::move(item), context_.frame_id,
+-      base::BindOnce(&FileSystemAccessSafeMoveHelper::DidAfterWriteCheck,
+-                     weak_factory_.GetWeakPtr()));
+-}
+-
+ void FileSystemAccessSafeMoveHelper::DidAfterWriteCheck(
+     FileSystemAccessPermissionContext::AfterWriteCheckResult result) {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+--- a/content/browser/file_system_access/file_system_access_safe_move_helper.h
++++ b/content/browser/file_system_access/file_system_access_safe_move_helper.h
+@@ -60,9 +60,6 @@ class CONTENT_EXPORT FileSystemAccessSaf
+  private:
+   SEQUENCE_CHECKER(sequence_checker_);
+ 
+-  void DoAfterWriteCheck(base::File::Error hash_result,
+-                         const std::string& hash,
+-                         int64_t size);
+   void DidAfterWriteCheck(
+       FileSystemAccessPermissionContext::AfterWriteCheckResult result);
+   void DidFileSkipQuarantine(base::File::Error result);
+--- a/extensions/browser/api/declarative_net_request/declarative_net_request_api.cc
++++ b/extensions/browser/api/declarative_net_request/declarative_net_request_api.cc
+@@ -134,13 +134,6 @@ DeclarativeNetRequestUpdateDynamicRulesF
+     return RespondNow(NoArguments());
+   }
+ 
+-  // Collect rules to add in the Extension Telemetry Service.
+-  if (!rules_to_add.empty()) {
+-    ExtensionsBrowserClient::Get()
+-        ->GetSafeBrowsingDelegate()
+-        ->NotifyExtensionApiDeclarativeNetRequest(browser_context(),
+-                                                  extension_id(), rules_to_add);
+-  }
+ 
+   auto* rules_monitor_service =
+       declarative_net_request::RulesMonitorService::Get(browser_context());
+@@ -248,13 +241,6 @@ DeclarativeNetRequestUpdateSessionRulesF
+     return RespondNow(NoArguments());
+   }
+ 
+-  // Collect rules to add in the Extension Telemetry Service.
+-  if (!rules_to_add.empty()) {
+-    ExtensionsBrowserClient::Get()
+-        ->GetSafeBrowsingDelegate()
+-        ->NotifyExtensionApiDeclarativeNetRequest(browser_context(),
+-                                                  extension_id(), rules_to_add);
+-  }
+ 
+   auto* rules_monitor_service =
+       declarative_net_request::RulesMonitorService::Get(browser_context());
+--- a/extensions/browser/api/execute_code_function.cc
++++ b/extensions/browser/api/execute_code_function.cc
+@@ -175,12 +175,6 @@ ExtensionFunction::ResponseAction Execut
+     return RespondNow(Error(std::move(error)));
+ 
+   if (details_->code) {
+-    if (!IsWebView() && extension()) {
+-      ExtensionsBrowserClient::Get()
+-          ->GetSafeBrowsingDelegate()
+-          ->NotifyExtensionApiTabExecuteScript(browser_context(),
+-                                               extension_id(), *details_->code);
+-    }
+ 
+     if (!Execute(*details_->code, &error))
+       return RespondNow(Error(std::move(error)));
+--- a/extensions/browser/api/web_request/extension_web_request_event_router.cc
++++ b/extensions/browser/api/web_request/extension_web_request_event_router.cc
+@@ -1145,14 +1145,6 @@ int WebRequestEventRouter::OnBeforeReque
+           DCHECK(action.redirect_url);
+           OnDNRActionMatched(browser_context, *request, action);
+           *new_url = GetNewUrl(action.redirect_url.value(), browser_context);
+-          // Collect redirect action data for the Extension Telemetry Service.
+-          if (action.type == DNRRequestAction::Type::REDIRECT) {
+-            ExtensionsBrowserClient::Get()
+-                ->GetSafeBrowsingDelegate()
+-                ->NotifyExtensionDeclarativeNetRequestRedirectAction(
+-                    browser_context, action.extension_id, request->url,
+-                    action.redirect_url.value());
+-          }
+           RecordThatNavigationWasInitiatedByExtension(
+               request, browser_context, new_url, action.extension_id);
+           return net::OK;
+--- a/extensions/browser/blocklist.cc
++++ b/extensions/browser/blocklist.cc
+@@ -183,21 +183,8 @@ Blocklist::~Blocklist() = default;
+ void Blocklist::GetBlocklistedIDs(const std::set<ExtensionId>& ids,
+                                   GetBlocklistedIDsCallback callback) {
+   DCHECK_CURRENTLY_ON(BrowserThread::UI);
+-
+-  if (ids.empty() || !GetDatabaseManager().get()) {
+     base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
+         FROM_HERE, base::BindOnce(std::move(callback), BlocklistStateMap()));
+-    return;
+-  }
+-
+-  // Constructing the SafeBrowsingClientImpl begins the process of asking
+-  // safebrowsing for the blocklisted extensions. The set of blocklisted
+-  // extensions returned by SafeBrowsing will then be passed to
+-  // GetBlocklistStateIDs to get the particular BlocklistState for each id.
+-  SafeBrowsingClientImpl::Start(
+-      SafeBrowsingDatabaseManager::Client::GetPassKey(), ids,
+-      base::BindOnce(&Blocklist::GetBlocklistStateForIDs,
+-                     weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
+ }
+ 
+ void Blocklist::GetMalwareIDs(const std::set<ExtensionId>& ids,
+--- a/extensions/browser/blocklist_state_fetcher.cc
++++ b/extensions/browser/blocklist_state_fetcher.cc
+@@ -44,7 +44,6 @@ void BlocklistStateFetcher::Request(cons
+     std::optional<safe_browsing::V4ProtocolConfig> config =
+         ExtensionsBrowserClient::Get()->GetV4ProtocolConfig();
+     if (config) {
+-      SetSafeBrowsingConfig(*config);
+     } else {
+       base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
+           FROM_HERE, base::BindOnce(std::move(callback), BLOCKLISTED_UNKNOWN));
+--- a/extensions/browser/extension_host.cc
++++ b/extensions/browser/extension_host.cc
+@@ -171,11 +171,6 @@ ExtensionHost::ExtensionHost(const Exten
+   ExtensionWebContentsObserver::GetForWebContents(host_contents())->
+       dispatcher()->set_delegate(this);
+ 
+-  // Create password reuse detection manager when new extension web contents are
+-  // created.
+-  ExtensionsBrowserClient::Get()
+-      ->GetSafeBrowsingDelegate()
+-      ->CreatePasswordReuseDetectionManager(host_contents_.get());
+ 
+   ExtensionHostRegistry::Get(browser_context_)->ExtensionHostCreated(this);
+ }
+--- a/extensions/browser/extension_registrar.cc
++++ b/extensions/browser/extension_registrar.cc
+@@ -815,119 +815,27 @@ void ExtensionRegistrar::UnblockAllExten
+ 
+ void ExtensionRegistrar::OnBlocklistStateRemoved(
+     const std::string& extension_id) {
+-  if (blocklist_prefs::IsExtensionBlocklisted(extension_id, extension_prefs_)) {
+-    return;
+-  }
+-
+-  // Clear acknowledged state.
+-  blocklist_prefs::RemoveAcknowledgedBlocklistState(
+-      extension_id, BitMapBlocklistState::BLOCKLISTED_MALWARE,
+-      extension_prefs_);
+-
+-  scoped_refptr<const Extension> extension =
+-      registry_->blocklisted_extensions().GetByID(extension_id);
+-  DCHECK(extension);
+-  registry_->RemoveBlocklisted(extension_id);
+-  AddExtension(extension.get());
+ }
+ 
+ void ExtensionRegistrar::OnBlocklistStateAdded(
+     const std::string& extension_id) {
+-  DCHECK(
+-      blocklist_prefs::IsExtensionBlocklisted(extension_id, extension_prefs_));
+-  // The extension was already acknowledged by the user, it should already be in
+-  // the unloaded state.
+-  if (blocklist_prefs::HasAcknowledgedBlocklistState(
+-          extension_id, BitMapBlocklistState::BLOCKLISTED_MALWARE,
+-          extension_prefs_)) {
+-    DCHECK(registry_->blocklisted_extensions().GetIDs().contains(extension_id));
+-    return;
+-  }
+-
+-  scoped_refptr<const Extension> extension =
+-      registry_->GetInstalledExtension(extension_id);
+-  registry_->AddBlocklisted(extension);
+-  RemoveExtension(extension_id, UnloadedExtensionReason::BLOCKLIST);
+ }
+ 
+ void ExtensionRegistrar::OnGreylistStateRemoved(
+     const std::string& extension_id) {
+-  bool is_on_sb_list = (blocklist_prefs::GetSafeBrowsingExtensionBlocklistState(
+-                            extension_id, extension_prefs_) !=
+-                        BitMapBlocklistState::NOT_BLOCKLISTED);
+-  bool is_on_omaha_list =
+-      blocklist_prefs::HasAnyOmahaGreylistState(extension_id, extension_prefs_);
+-  if (is_on_sb_list || is_on_omaha_list) {
+-    return;
+-  }
+-  // Clear all acknowledged states so the extension will still get disabled if
+-  // it is added to the greylist again.
+-  blocklist_prefs::ClearAcknowledgedGreylistStates(extension_id,
+-                                                   extension_prefs_);
+-  RemoveDisableReasonAndMaybeEnable(extension_id,
+-                                    disable_reason::DISABLE_GREYLIST);
+-
+-  // A user can enable and disable a force-installed extension while it is
+-  // greylisted. If a user disables an extension while greylisted, the
+-  // extension gets a DISABLE_USER_ACTION disable reason assigned to it. So
+-  // remove the DISABLE_USER_ACTION disable reason as well when a
+-  // force-installed extension gets "un-greylisted" to allow the extension
+-  // to be re-enabled.
+-  const Extension* extension = registry_->GetInstalledExtension(extension_id);
+-  if (extension && extension_system_->management_policy()->MustRemainEnabled(
+-                       extension, nullptr)) {
+-    RemoveDisableReasonAndMaybeEnable(extension_id,
+-                                      disable_reason::DISABLE_USER_ACTION);
+-  }
+ }
+ 
+ void ExtensionRegistrar::OnGreylistStateAdded(const std::string& extension_id,
+                                               BitMapBlocklistState new_state) {
+-#if DCHECK_IS_ON()
+-  bool has_new_state_on_sb_list =
+-      (blocklist_prefs::GetSafeBrowsingExtensionBlocklistState(
+-           extension_id, extension_prefs_) == new_state);
+-  bool has_new_state_on_omaha_list = blocklist_prefs::HasOmahaBlocklistState(
+-      extension_id, new_state, extension_prefs_);
+-  DCHECK(has_new_state_on_sb_list || has_new_state_on_omaha_list);
+-#endif
+-  if (blocklist_prefs::HasAcknowledgedBlocklistState(extension_id, new_state,
+-                                                     extension_prefs_)) {
+-    // If the extension is already acknowledged, don't disable it again
+-    // because it can be already re-enabled by the user. This could happen if
+-    // the extension is added to the SafeBrowsing blocklist, and then
+-    // subsequently marked by Omaha. In this case, we don't want to disable the
+-    // extension twice.
+-    return;
+-  }
+-
+-  // Set the current greylist states to acknowledge immediately because the
+-  // extension is disabled silently. Clear the other acknowledged state because
+-  // when the state changes to another greylist state in the future, we'd like
+-  // to disable the extension again.
+-  blocklist_prefs::UpdateCurrentGreylistStatesAsAcknowledged(extension_id,
+-                                                             extension_prefs_);
+-  DisableExtension(extension_id, {disable_reason::DISABLE_GREYLIST});
+ }
+ 
+ void ExtensionRegistrar::BlocklistExtensionForTest(
+     const std::string& extension_id) {
+-  blocklist_prefs::SetSafeBrowsingExtensionBlocklistState(
+-      extension_id, BitMapBlocklistState::BLOCKLISTED_MALWARE,
+-      extension_prefs_);
+-  OnBlocklistStateAdded(extension_id);
+ }
+ 
+ void ExtensionRegistrar::GreylistExtensionForTest(
+     const std::string& extension_id,
+     const BitMapBlocklistState& state) {
+-  blocklist_prefs::SetSafeBrowsingExtensionBlocklistState(extension_id, state,
+-                                                          extension_prefs_);
+-  if (state == BitMapBlocklistState::NOT_BLOCKLISTED) {
+-    OnGreylistStateRemoved(extension_id);
+-  } else {
+-    OnGreylistStateAdded(extension_id, state);
+-  }
+ }
+ 
+ // static
+--- a/extensions/browser/updater/update_service.cc
++++ b/extensions/browser/updater/update_service.cc
+@@ -131,13 +131,6 @@ void UpdateService::OnCrxStateChange(Upd
+       break;
+   }
+ 
+-  if (should_perform_action_on_omaha_attributes) {
+-    base::DictValue attributes = GetExtensionOmahaAttributes(item);
+-    // Note that it's important to perform actions even if |attributes| is
+-    // empty, missing values may default to false and have associated logic.
+-    ExtensionSystem::Get(browser_context_)
+-        ->PerformActionBasedOnOmahaAttributes(item.id, attributes);
+-  }
+ }
+ 
+ UpdateService::UpdateService(

--- a/patches/ungoogled/core/ungoogled-chromium/remove-f1-shortcut.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/remove-f1-shortcut.patch
@@ -1,0 +1,10 @@
+--- a/chrome/browser/ui/accelerator_table.cc
++++ b/chrome/browser/ui/accelerator_table.cc
+@@ -137,7 +137,6 @@ const AcceleratorMapping kAcceleratorMap
+     {ui::VKEY_OEM_PLUS, ui::EF_PLATFORM_ACCELERATOR, IDC_ZOOM_PLUS},
+     {ui::VKEY_ADD, ui::EF_PLATFORM_ACCELERATOR, IDC_ZOOM_PLUS},
+ 
+-    {ui::VKEY_F1, ui::EF_NONE, IDC_HELP_PAGE_VIA_KEYBOARD},
+     {ui::VKEY_F3, ui::EF_NONE, IDC_FIND_NEXT},
+     {ui::VKEY_F3, ui::EF_SHIFT_DOWN, IDC_FIND_PREVIOUS},
+     {ui::VKEY_F4, ui::EF_CONTROL_DOWN, IDC_CLOSE_TAB},

--- a/patches/ungoogled/core/ungoogled-chromium/remove-unused-preferences-fields.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/remove-unused-preferences-fields.patch
@@ -1,0 +1,7153 @@
+# Remove unused Safe Browsing and Sign-in fields from Preferences file
+# TODO: This patch should probably be split up and merged into
+# disable-signin.patch and fix-building-without-safebrowsing.patch
+
+--- a/chrome/browser/ash/login/signin/device_id_browsertest.cc
++++ b/chrome/browser/ash/login/signin/device_id_browsertest.cc
+@@ -32,7 +32,6 @@
+ #include "chrome/test/base/in_process_browser_test.h"
+ #include "chromeos/dbus/constants/dbus_paths.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/user_manager/known_user.h"
+ #include "components/user_manager/user_manager.h"
+ #include "content/public/test/browser_test.h"
+@@ -302,15 +301,6 @@ IN_PROC_BROWSER_TEST_F(DeviceIDTest, PRE
+   SignInOnline(FakeGaiaMixin::kFakeUserEmail, FakeGaiaMixin::kFakeUserPassword,
+                kRefreshToken1, FakeGaiaMixin::kFakeUserGaiaId);
+ 
+-  // Simulate user that has device ID saved only in preferences (pre-M44).
+-  PrefService* prefs =
+-      ProfileHelper::Get()
+-          ->GetProfileByUser(user_manager::UserManager::Get()->GetActiveUser())
+-          ->GetPrefs();
+-  prefs->SetString(
+-      prefs::kGoogleServicesSigninScopedDeviceId,
+-      GetDeviceId(AccountId::FromUserEmail(FakeGaiaMixin::kFakeUserEmail)));
+-
+   // Can't use SetKnownUserDeviceId here, because it forbids changing a device
+   // ID.
+   user_manager::KnownUser known_user(g_browser_process->local_state());
+@@ -339,13 +329,6 @@ IN_PROC_BROWSER_TEST_F(DeviceIDTest, PRE
+   SignInOnline(FakeGaiaMixin::kFakeUserEmail, FakeGaiaMixin::kFakeUserPassword,
+                kRefreshToken1, FakeGaiaMixin::kFakeUserGaiaId);
+ 
+-  PrefService* prefs =
+-      ProfileHelper::Get()
+-          ->GetProfileByUser(user_manager::UserManager::Get()->GetActiveUser())
+-          ->GetPrefs();
+-  EXPECT_TRUE(
+-      prefs->GetString(prefs::kGoogleServicesSigninScopedDeviceId).empty());
+-
+   // Can't use SetKnownUserDeviceId here, because it forbids changing a device
+   // ID.
+   user_manager::KnownUser known_user(g_browser_process->local_state());
+--- a/chrome/browser/browsing_data/chrome_browsing_data_lifetime_manager.cc
++++ b/chrome/browser/browsing_data/chrome_browsing_data_lifetime_manager.cc
+@@ -31,7 +31,6 @@
+ #include "components/keep_alive_registry/keep_alive_types.h"
+ #include "components/keep_alive_registry/scoped_keep_alive.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/sync/service/sync_service.h"
+ #include "components/sync/service/sync_user_settings.h"
+ #include "content/public/browser/browser_context.h"
+@@ -441,40 +440,5 @@ bool ChromeBrowsingDataLifetimeManager::
+     return sync_disabled;
+   }
+ 
+-#if !BUILDFLAG(IS_CHROMEOS)
+-  // Allow clearing data if browser signin is disabled.
+-  if (!profile_->GetPrefs()->GetBoolean(prefs::kSigninAllowed)) {
+-    return true;
+-  }
+-  // If signin will be disabled on next startup, delay the browsing data
+-  // clearing until then.
+-  if (!profile_->GetPrefs()->GetBoolean(prefs::kSigninAllowedOnNextStartup)) {
+-    profile_->GetPrefs()->SetBoolean(
+-        browsing_data::prefs::kClearBrowsingDataOnExitDeletionPending, true);
+-    return false;
+-  }
+-#endif
+-
+-  // Check that sync types have been disabled if neither sync nor browser sign
+-  // in is disabled.
+-  syncer::SyncService* sync_service =
+-      SyncServiceFactory::GetForProfile(profile_);
+-
+-  // If the sync service is not available, data can be safely cleared as it is
+-  // not synced.
+-  if (!sync_service) {
+-    return true;
+-  }
+-
+-  for (syncer::UserSelectableType type : sync_types) {
+-    if (!sync_service->GetUserSettings()->IsTypeManagedByPolicy(type)) {
+-      return false;
+-    } else if (sync_service->GetActiveDataTypes().HasAny(
+-                   syncer::UserSelectableTypeToAllDataTypes(type))) {
+-      // If the sync type is disabled by policy, but the sync service has not
+-      // deactivated the type yet, then data can not be safely cleared yet.
+-      return false;
+-    }
+-  }
+   return true;
+ }
+--- a/chrome/browser/chrome_content_browser_client.cc
++++ b/chrome/browser/chrome_content_browser_client.cc
+@@ -307,7 +307,6 @@
+ #include "components/safe_browsing/core/browser/url_checker_delegate.h"
+ #include "components/safe_browsing/core/common/features.h"
+ #include "components/safe_browsing/core/common/hashprefix_realtime/hash_realtime_utils.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/search_engines/search_engines_switches.h"
+ #include "components/search_engines/template_url_service.h"
+ #include "components/security_state/core/security_state.h"
+--- a/chrome/browser/content_settings/generated_javascript_optimizer_pref.cc
++++ b/chrome/browser/content_settings/generated_javascript_optimizer_pref.cc
+@@ -13,7 +13,6 @@
+ #include "components/content_settings/browser/ui/javascript_optimizer_setting.h"
+ #include "components/content_settings/core/common/features.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ using extensions::api::settings_private::Enforcement;
+ using extensions::api::settings_private::PrefObject;
+--- a/chrome/browser/download/download_browsertest.cc
++++ b/chrome/browser/download/download_browsertest.cc
+@@ -104,7 +104,6 @@
+ #include "components/safe_browsing/content/common/file_type_policies_test_util.h"
+ #include "components/safe_browsing/content/common/proto/download_file_types.pb.h"
+ #include "components/safe_browsing/core/common/proto/csd.pb.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/security_state/core/security_state.h"
+ #include "components/services/quarantine/test_support.h"
+ #include "content/public/browser/browser_task_traits.h"
+--- a/chrome/browser/download/download_ui_model.cc
++++ b/chrome/browser/download/download_ui_model.cc
+@@ -32,7 +32,6 @@
+ #include "components/enterprise/common/proto/connectors.pb.h"
+ #include "components/google/core/common/google_util.h"
+ #include "components/safe_browsing/buildflags.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/safebrowsing_referral_methods.h"
+ #include "components/strings/grit/components_strings.h"
+ #include "net/base/mime_util.h"
+--- a/chrome/browser/download/download_ui_safe_browsing_util.cc
++++ b/chrome/browser/download/download_ui_safe_browsing_util.cc
+@@ -11,7 +11,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/safe_browsing/buildflags.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ #if BUILDFLAG(SAFE_BROWSING_DOWNLOAD_PROTECTION)
+ #include "chrome/browser/browser_process.h"
+--- a/chrome/browser/enterprise/connectors/analysis/content_analysis_delegate.cc
++++ b/chrome/browser/enterprise/connectors/analysis/content_analysis_delegate.cc
+@@ -58,7 +58,6 @@
+ #include "components/safe_browsing/content/browser/web_ui/safe_browsing_ui.h"
+ #include "components/safe_browsing/core/browser/realtime/url_lookup_service_base.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/sessions/content/session_tab_helper.h"
+ #include "components/url_matcher/url_matcher.h"
+ #include "content/public/browser/web_contents.h"
+--- a/chrome/browser/enterprise/connectors/connectors_service.cc
++++ b/chrome/browser/enterprise/connectors/connectors_service.cc
+@@ -232,8 +232,7 @@ std::string ConnectorsService::GetManage
+ 
+   std::optional<policy::PolicyScope> scope = std::nullopt;
+   for (const char* scope_pref :
+-       {enterprise_connectors::kEnterpriseRealTimeUrlCheckScope,
+-        AnalysisConnectorScopePref(AnalysisConnector::FILE_ATTACHED),
++       {AnalysisConnectorScopePref(AnalysisConnector::FILE_ATTACHED),
+         AnalysisConnectorScopePref(AnalysisConnector::FILE_DOWNLOADED),
+         AnalysisConnectorScopePref(AnalysisConnector::BULK_DATA_ENTRY),
+         AnalysisConnectorScopePref(AnalysisConnector::PRINT),
+--- a/chrome/browser/enterprise/profile_management/profile_management_navigation_throttle.cc
++++ b/chrome/browser/enterprise/profile_management/profile_management_navigation_throttle.cc
+@@ -25,7 +25,6 @@
+ #include "chrome/common/chrome_switches.h"
+ #include "components/account_id/account_id.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "content/public/browser/browser_context.h"
+ #include "content/public/browser/navigation_handle.h"
+ #include "content/public/browser/navigation_throttle.h"
+@@ -317,12 +316,6 @@ void ProfileManagementNavigationThrottle
+   std::optional<std::string> management_domain =
+       GetDomainFromAttributeValue(domain);
+   if (management_domain) {
+-    auto* prefs =
+-        Profile::FromBrowserContext(
+-            navigation_handle()->GetWebContents()->GetBrowserContext())
+-            ->GetPrefs();
+-    prefs->SetString(prefs::kSigninInterceptionIDPCookiesUrl,
+-                     navigation_handle()->GetURL().spec());
+     PostNavigateTo(GURL(base::StringPrintf(kGoogleServiceLoginUrl,
+                                            management_domain.value().c_str())));
+     return;
+@@ -344,11 +337,6 @@ void ProfileManagementNavigationThrottle
+     PostNavigateTo(GURL(token_url_for_testing_));
+     return;
+   }
+-  auto* prefs = Profile::FromBrowserContext(
+-                    navigation_handle()->GetWebContents()->GetBrowserContext())
+-                    ->GetPrefs();
+-  prefs->SetString(prefs::kSigninInterceptionIDPCookiesUrl,
+-                   navigation_handle()->GetURL().spec());
+ 
+   auto* interceptor = ProfileTokenWebSigninInterceptorFactory::GetForProfile(
+       Profile::FromBrowserContext(
+--- a/chrome/browser/enterprise/signals/context_info_fetcher.cc
++++ b/chrome/browser/enterprise/signals/context_info_fetcher.cc
+@@ -126,12 +126,6 @@ void ContextInfoFetcher::Fetch(ContextIn
+           ChromePolicyBlocklistServiceFactory::GetForProfile(
+               Profile::FromBrowserContext(browser_context_)));
+ 
+-  Profile* profile = Profile::FromBrowserContext(browser_context_);
+-  info.safe_browsing_protection_level =
+-      device_signals::GetSafeBrowsingProtectionLevel(profile->GetPrefs());
+-  info.password_protection_warning_trigger =
+-      device_signals::GetPasswordProtectionWarningTrigger(profile->GetPrefs());
+-  info.enterprise_profile_id = GetEnterpriseProfileId(profile);
+ 
+ #if BUILDFLAG(IS_WIN)
+   base::ThreadPool::CreateCOMSTATaskRunner({base::MayBlock()})
+--- a/chrome/browser/enterprise/signals/context_info_fetcher.h
++++ b/chrome/browser/enterprise/signals/context_info_fetcher.h
+@@ -15,7 +15,6 @@
+ #include "components/device_signals/core/common/common_types.h"
+ #include "components/enterprise/buildflags/buildflags.h"
+ #include "components/enterprise/connectors/core/common.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ namespace content {
+ class BrowserContext;
+@@ -43,11 +42,8 @@ struct ContextInfo {
+   std::vector<std::string> on_print_providers;
+   std::vector<std::string> on_security_event_providers;
+   std::string browser_version;
+-  safe_browsing::SafeBrowsingState safe_browsing_protection_level;
+   bool site_isolation_enabled;
+   bool built_in_dns_client_enabled;
+-  std::optional<safe_browsing::PasswordProtectionTrigger>
+-      password_protection_warning_trigger;
+   bool chrome_remote_desktop_app_blocked;
+   device_signals::SettingValue os_firewall;
+   std::vector<std::string> system_dns_servers;
+--- a/chrome/browser/enterprise/signin/managed_profile_creation_controller.cc
++++ b/chrome/browser/enterprise/signin/managed_profile_creation_controller.cc
+@@ -32,7 +32,6 @@
+ #include "components/policy/core/browser/signin/user_cloud_signin_restriction_policy_fetcher.h"
+ #include "components/policy/core/common/policy_utils.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/accounts_mutator.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ 
+@@ -139,55 +138,6 @@ void ManagedProfileCreationController::O
+ }
+ 
+ void ManagedProfileCreationController::FetchProfileSeparationPolicies() {
+-  // We should not fetch the policies twice.
+-  CHECK(!policies_received_);
+-  CHECK(!account_level_signin_restriction_policy_fetcher_);
+-
+-  auto policy_fetch_callback = base::BindOnce(
+-      &ManagedProfileCreationController::OnProfileSeparationPoliciesReceived,
+-      weak_ptr_factory_.GetWeakPtr());
+-
+-  if (profile_separation_policies_for_testing_.has_value()) {
+-    CHECK_IS_TEST();
+-    policy::ProfileSeparationPolicies profile_separation_policies =
+-        std::exchange(profile_separation_policies_for_testing_, std::nullopt)
+-            .value();
+-    std::move(policy_fetch_callback)
+-        .Run(std::move(profile_separation_policies));
+-    return;
+-  }
+-
+-  // If we cannot make network calls, we will not be able to fetch the
+-  // account level policies.
+-  if (!g_browser_process->system_network_context_manager()) {
+-    std::move(policy_fetch_callback).Run(policy::ProfileSeparationPolicies());
+-    return;
+-  }
+-
+-  CHECK(source_profile_);
+-  account_level_signin_restriction_policy_fetcher_ =
+-      std::make_unique<policy::UserCloudSigninRestrictionPolicyFetcher>(
+-          g_browser_process->browser_policy_connector(),
+-          g_browser_process->system_network_context_manager()
+-              ->GetSharedURLLoaderFactory());
+-  account_level_signin_restriction_policy_fetcher_
+-      ->GetManagedAccountsSigninRestriction(
+-          GetIdentityManager(), account_info_.account_id,
+-          std::move(policy_fetch_callback),
+-          policy::utils::IsPolicyTestingEnabled(source_profile_->GetPrefs(),
+-                                                chrome::GetChannel())
+-              ? source_profile_->GetPrefs()
+-                    ->GetDefaultPrefValue(
+-                        prefs::kUserCloudSigninPolicyResponseFromPolicyTestPage)
+-                    ->GetString()
+-              : std::string());
+-
+-  policy_fetch_timeout_.Start(
+-      FROM_HERE, base::Seconds(5),
+-      base::BindOnce(&ManagedProfileCreationController::
+-                         OnProfileSeparationPoliciesReceived,
+-                     weak_ptr_factory_.GetWeakPtr(),
+-                     policy::ProfileSeparationPolicies()));
+ }
+ 
+ void ManagedProfileCreationController::OnProfileSeparationPoliciesReceived(
+@@ -211,7 +161,6 @@ void ManagedProfileCreationController::O
+   account_level_signin_restriction_policy_fetcher_.reset();
+ 
+   // If the user is not allowed to sign in, we should not show the disclaimer.
+-  if (!source_profile_->GetPrefs()->GetBoolean(prefs::kSigninAllowed)) {
+     // If the profile creation is required by policy, we should sign the user
+     // out since they cannot sign in to Chrome.
+     if (profile_creation_required_by_policy_) {
+@@ -220,9 +169,6 @@ void ManagedProfileCreationController::O
+       std::move(callback_).Run(base::ok(nullptr),
+                                profile_creation_required_by_policy_);
+     }
+-    return;
+-  }
+-  ShowManagementDisclaimer();
+ }
+ 
+ void ManagedProfileCreationController::ShowManagementDisclaimer() {
+--- a/chrome/browser/enterprise/signin/oidc_authentication_signin_interceptor.cc
++++ b/chrome/browser/enterprise/signin/oidc_authentication_signin_interceptor.cc
+@@ -50,7 +50,6 @@
+ #include "components/policy/core/common/cloud/user_cloud_policy_manager.h"
+ #include "components/policy/core/common/policy_logger.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/primary_account_mutator.h"
+ #include "content/public/browser/storage_partition.h"
+ #include "content/public/browser/web_contents.h"
+@@ -439,8 +438,7 @@ void OidcAuthenticationSigninInterceptor
+ 
+   // TODO(b/355270189): The interaction between OIDC profiles and BrowserSignin
+   // policy should be finalized, this check only prevents Chrome from crashing.
+-  if (dasher_based_ &&
+-      !profile_->GetPrefs()->GetBoolean(prefs::kSigninAllowedOnNextStartup)) {
++  if (dasher_based_) {
+     LOG_POLICY(ERROR, OIDC_ENROLLMENT)
+         << "Google-synced OIDC profile can't be created because browser sign"
+            "in is disabled.";
+--- a/chrome/browser/enterprise/signin/oidc_managed_profile_creation_delegate.cc
++++ b/chrome/browser/enterprise/signin/oidc_managed_profile_creation_delegate.cc
+@@ -9,7 +9,6 @@
+ #include "chrome/browser/enterprise/signin/enterprise_signin_prefs.h"
+ #include "chrome/browser/profiles/profile_attributes_storage.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ 
+ OidcManagedProfileCreationDelegate::OidcManagedProfileCreationDelegate() =
+     default;
+@@ -55,8 +54,6 @@ void OidcManagedProfileCreationDelegate:
+ 
+ void OidcManagedProfileCreationDelegate::CheckManagedProfileStatus(
+     Profile* new_profile) {
+-  CHECK_EQ(new_profile->GetPrefs()->GetBoolean(prefs::kSigninAllowed),
+-           dasher_based_);
+ }
+ 
+ void OidcManagedProfileCreationDelegate::OnManagedProfileInitialized(
+--- a/chrome/browser/enterprise/signin/profile_management_disclaimer_service.cc
++++ b/chrome/browser/enterprise/signin/profile_management_disclaimer_service.cc
+@@ -39,7 +39,6 @@
+ #include "components/policy/core/browser/signin/user_cloud_signin_restriction_policy_fetcher.h"
+ #include "components/policy/core/common/policy_utils.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_prefs.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+--- a/chrome/browser/enterprise/signin/token_managed_profile_creation_delegate.cc
++++ b/chrome/browser/enterprise/signin/token_managed_profile_creation_delegate.cc
+@@ -7,7 +7,6 @@
+ #include "chrome/browser/profiles/profile_attributes_storage.h"
+ #include "chrome/browser/signin/signin_util.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ 
+ TokenManagedProfileCreationDelegate::TokenManagedProfileCreationDelegate() =
+     default;
+@@ -29,7 +28,6 @@ void TokenManagedProfileCreationDelegate
+ 
+ void TokenManagedProfileCreationDelegate::CheckManagedProfileStatus(
+     Profile* new_profile) {
+-  DCHECK(!new_profile->GetPrefs()->GetBoolean(prefs::kSigninAllowed));
+ }
+ 
+ void TokenManagedProfileCreationDelegate::OnManagedProfileInitialized(
+--- a/chrome/browser/extensions/api/enterprise_reporting_private/enterprise_reporting_private_api.cc
++++ b/chrome/browser/extensions/api/enterprise_reporting_private/enterprise_reporting_private_api.cc
+@@ -103,44 +103,10 @@ api::enterprise_reporting_private::Conte
+   info.built_in_dns_client_enabled = signals.built_in_dns_client_enabled;
+   info.enterprise_profile_id = signals.enterprise_profile_id;
+ 
+-  switch (signals.safe_browsing_protection_level) {
+-    case safe_browsing::SafeBrowsingState::NO_SAFE_BROWSING:
+       info.safe_browsing_protection_level = extensions::api::
+           enterprise_reporting_private::SafeBrowsingLevel::kDisabled;
+-      break;
+-    case safe_browsing::SafeBrowsingState::STANDARD_PROTECTION:
+-      info.safe_browsing_protection_level = extensions::api::
+-          enterprise_reporting_private::SafeBrowsingLevel::kStandard;
+-      break;
+-    case safe_browsing::SafeBrowsingState::ENHANCED_PROTECTION:
+-      info.safe_browsing_protection_level = extensions::api::
+-          enterprise_reporting_private::SafeBrowsingLevel::kEnhanced;
+-      break;
+-  }
+-  if (!signals.password_protection_warning_trigger.has_value()) {
+     info.password_protection_warning_trigger = extensions::api::
+         enterprise_reporting_private::PasswordProtectionTrigger::kPolicyUnset;
+-  } else {
+-    switch (signals.password_protection_warning_trigger.value()) {
+-      case safe_browsing::PASSWORD_PROTECTION_OFF:
+-        info.password_protection_warning_trigger =
+-            extensions::api::enterprise_reporting_private::
+-                PasswordProtectionTrigger::kPasswordProtectionOff;
+-        break;
+-      case safe_browsing::PASSWORD_REUSE:
+-        info.password_protection_warning_trigger =
+-            extensions::api::enterprise_reporting_private::
+-                PasswordProtectionTrigger::kPasswordReuse;
+-        break;
+-      case safe_browsing::PHISHING_REUSE:
+-        info.password_protection_warning_trigger =
+-            extensions::api::enterprise_reporting_private::
+-                PasswordProtectionTrigger::kPhishingReuse;
+-        break;
+-      case safe_browsing::PASSWORD_PROTECTION_TRIGGER_MAX:
+-        NOTREACHED();
+-    }
+-  }
+ 
+   return info;
+ }
+--- a/chrome/browser/extensions/api/identity/identity_apitest.cc
++++ b/chrome/browser/extensions/api/identity/identity_apitest.cc
+@@ -64,7 +64,6 @@
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/list_accounts_test_utils.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/accounts_mutator.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+--- a/chrome/browser/extensions/api/identity/identity_get_auth_token_function.cc
++++ b/chrome/browser/extensions/api/identity/identity_get_auth_token_function.cc
+@@ -30,7 +30,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/oauth_consumer_id.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/access_token_info.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+@@ -70,7 +69,7 @@ namespace extensions {
+ namespace {
+ 
+ bool IsBrowserSigninAllowed(Profile* profile) {
+-  return profile->GetPrefs()->GetBoolean(prefs::kSigninAllowed);
++  return false;
+ }
+ 
+ std::string_view GetOAuth2MintTokenFlowVersion() {
+--- a/chrome/browser/extensions/api/preference/preference_api.cc
++++ b/chrome/browser/extensions/api/preference/preference_api.cc
+@@ -27,7 +27,6 @@
+ #include "components/content_settings/core/common/pref_names.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/privacy_sandbox/privacy_sandbox_features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "extensions/browser/api/content_settings/content_settings_service.h"
+ #include "extensions/browser/extension_function_registry.h"
+ #include "extensions/browser/extension_pref_value_map.h"
+@@ -453,17 +452,6 @@ ExtensionFunction::ResponseAction SetPre
+         base::Value(browser_pref_value->GetBool()));
+   }
+ 
+-  // Whenever an extension takes control of the |kSafeBrowsingEnabled|
+-  // preference, it must also set |kSafeBrowsingEnhanced| to false.
+-  // See crbug.com/40681445 for more background.
+-  //
+-  // TODO(crbug.com/40681445): Consider extending
+-  // chrome.privacy.services.safeBrowsingEnabled to a three-state enum.
+-  if (prefs::kSafeBrowsingEnabled == browser_pref) {
+-    prefs_helper->SetExtensionControlledPref(extension_id(),
+-                                             prefs::kSafeBrowsingEnhanced,
+-                                             scope, base::Value(false));
+-  }
+ 
+   prefs_helper->SetExtensionControlledPref(extension_id(), browser_pref, scope,
+                                            browser_pref_value->Clone());
+@@ -514,16 +502,6 @@ ExtensionFunction::ResponseAction ClearP
+   prefs_helper->RemoveExtensionControlledPref(extension_id(), browser_pref,
+                                               scope);
+ 
+-  // Whenever an extension clears the |kSafeBrowsingEnabled| preference,
+-  // it must also clear |kSafeBrowsingEnhanced|. See crbug.com/40681445 for
+-  // more background.
+-  //
+-  // TODO(crbug.com/40681445): Consider extending
+-  // chrome.privacy.services.safeBrowsingEnabled to a three-state enum.
+-  if (prefs::kSafeBrowsingEnabled == browser_pref) {
+-    prefs_helper->RemoveExtensionControlledPref(
+-        extension_id(), prefs::kSafeBrowsingEnhanced, scope);
+-  }
+   return RespondNow(NoArguments());
+ }
+ 
+--- a/chrome/browser/extensions/api/preference/preference_apitest.cc
++++ b/chrome/browser/extensions/api/preference/preference_apitest.cc
+@@ -31,7 +31,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/privacy_sandbox/privacy_sandbox_features.h"
+ #include "components/privacy_sandbox/privacy_sandbox_prefs.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/translate/core/browser/translate_pref_names.h"
+ #include "content/public/test/browser_test.h"
+ #include "content/public/test/test_devtools_protocol_client.h"
+@@ -87,7 +86,6 @@ class ExtensionPreferenceApiTest : publi
+               prefs->GetInteger(prefetch::prefs::kNetworkPredictionOptions));
+     EXPECT_TRUE(
+         prefs->GetBoolean(password_manager::prefs::kCredentialsEnableService));
+-    EXPECT_TRUE(prefs->GetBoolean(prefs::kSafeBrowsingEnabled));
+     EXPECT_TRUE(prefs->GetBoolean(prefs::kSearchSuggestEnabled));
+     VerifyPrefValueAndControlledState(prefs::kPrivacySandboxM1TopicsEnabled,
+                                       base::Value(false),
+@@ -125,7 +123,6 @@ class ExtensionPreferenceApiTest : publi
+               prefs->GetInteger(prefetch::prefs::kNetworkPredictionOptions));
+     EXPECT_FALSE(
+         prefs->GetBoolean(password_manager::prefs::kCredentialsEnableService));
+-    EXPECT_FALSE(prefs->GetBoolean(prefs::kSafeBrowsingEnabled));
+     EXPECT_FALSE(prefs->GetBoolean(prefs::kSearchSuggestEnabled));
+     VerifyPrefValueAndControlledState(prefs::kPrivacySandboxM1TopicsEnabled,
+                                       base::Value(true),
+@@ -210,7 +207,6 @@ IN_PROC_BROWSER_TEST_F(ExtensionPreferen
+       prefetch::prefs::kNetworkPredictionOptions,
+       static_cast<int>(prefetch::NetworkPredictionOptions::kDisabled));
+   prefs->SetBoolean(password_manager::prefs::kCredentialsEnableService, false);
+-  prefs->SetBoolean(prefs::kSafeBrowsingEnabled, false);
+   prefs->SetBoolean(prefs::kSearchSuggestEnabled, false);
+   prefs->SetString(prefs::kWebRTCIPHandlingPolicy,
+                    blink::kWebRTCIPHandlingDefaultPublicInterfaceOnly);
+--- a/chrome/browser/extensions/api/safe_browsing_private/safe_browsing_private_event_router.cc
++++ b/chrome/browser/extensions/api/safe_browsing_private/safe_browsing_private_event_router.cc
+@@ -18,7 +18,6 @@
+ #include "chrome/common/extensions/api/safe_browsing_private.h"
+ #include "components/enterprise/connectors/core/common.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/url_matcher/url_matcher.h"
+ #include "components/url_matcher/url_util.h"
+ #include "content/public/browser/browser_context.h"
+--- a/chrome/browser/extensions/api/safe_browsing_private/safe_browsing_private_event_router_unittest.cc
++++ b/chrome/browser/extensions/api/safe_browsing_private/safe_browsing_private_event_router_unittest.cc
+@@ -22,7 +22,6 @@
+ #include "chrome/test/base/testing_browser_process.h"
+ #include "chrome/test/base/testing_profile.h"
+ #include "chrome/test/base/testing_profile_manager.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/signin/public/identity_manager/identity_test_environment.h"
+ #include "content/public/test/browser_task_environment.h"
+ #include "extensions/browser/test_event_router.h"
+--- a/chrome/browser/extensions/api/settings_private/prefs_util.cc
++++ b/chrome/browser/extensions/api/settings_private/prefs_util.cc
+@@ -59,10 +59,8 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/privacy_sandbox/privacy_sandbox_prefs.h"
+ #include "components/proxy_config/proxy_config_pref_names.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/saved_tab_groups/public/pref_names.h"
+ #include "components/search_engines/default_search_manager.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/spellcheck/browser/pref_names.h"
+ #include "components/supervised_user/core/common/pref_names.h"
+ #include "components/themes/pref_names.h"
+@@ -386,8 +384,6 @@ const PrefsUtil::TypedPrefMap& PrefsUtil
+       settings_api::PrefType::kNumber;
+ 
+   // Privacy page
+-  (*s_allowlist)[::prefs::kSigninAllowedOnNextStartup] =
+-      settings_api::PrefType::kBoolean;
+   (*s_allowlist)[::prefs::kDnsOverHttpsMode] = settings_api::PrefType::kString;
+   (*s_allowlist)[::prefs::kDnsOverHttpsTemplates] =
+       settings_api::PrefType::kString;
+@@ -413,16 +409,6 @@ const PrefsUtil::TypedPrefMap& PrefsUtil
+       settings_api::PrefType::kBoolean;
+ 
+   // Security page
+-  (*s_allowlist)[::kGeneratedPasswordLeakDetectionPref] =
+-      settings_api::PrefType::kBoolean;
+-  (*s_allowlist)[::prefs::kSafeBrowsingEnabled] =
+-      settings_api::PrefType::kBoolean;
+-  (*s_allowlist)[::prefs::kSafeBrowsingEnhanced] =
+-      settings_api::PrefType::kBoolean;
+-  (*s_allowlist)[::prefs::kSafeBrowsingScoutReportingEnabled] =
+-      settings_api::PrefType::kBoolean;
+-  (*s_allowlist)[::safe_browsing::kGeneratedSafeBrowsingPref] =
+-      settings_api::PrefType::kNumber;
+   (*s_allowlist)[::prefs::kHttpsOnlyModeEnabled] =
+       settings_api::PrefType::kBoolean;
+   (*s_allowlist)[::kGeneratedHttpsFirstModePref] =
+--- a/chrome/browser/extensions/api/webstore_private/webstore_private_apitest.cc
++++ b/chrome/browser/extensions/api/webstore_private/webstore_private_apitest.cc
+@@ -1176,9 +1176,6 @@ IN_PROC_BROWSER_TEST_F(ExtensionWebstore
+ IN_PROC_BROWSER_TEST_F(ExtensionWebstorePrivateGetReferrerChainApiTest,
+                        GetReferrerChainForNonSafeBrowsingUser) {
+   PrefService* pref_service = profile()->GetPrefs();
+-  EXPECT_TRUE(pref_service->GetBoolean(prefs::kSafeBrowsingEnabled));
+-  // Disable SafeBrowsing.
+-  pref_service->SetBoolean(prefs::kSafeBrowsingEnabled, false);
+ 
+   GURL page_url = GetTestServerURLWithReferrers("empty_referrer_chain.html");
+   ASSERT_TRUE(OpenTestURL(page_url));
+--- a/chrome/browser/extensions/extension_service.cc
++++ b/chrome/browser/extensions/extension_service.cc
+@@ -69,7 +69,6 @@
+ #include "chrome/common/url_constants.h"
+ #include "components/crx_file/id_util.h"
+ #include "components/policy/core/common/policy_pref_names.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/supervised_user/core/browser/supervised_user_preferences.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "content/public/browser/render_process_host.h"
+--- a/chrome/browser/extensions/installed_loader.cc
++++ b/chrome/browser/extensions/installed_loader.cc
+@@ -34,7 +34,6 @@
+ #include "chrome/common/extensions/manifest_handlers/settings_overrides_handler.h"
+ #include "chrome/common/pref_names.h"
+ #include "chrome/common/webui_url_constants.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "content/public/common/url_constants.h"
+ #include "extensions/browser/allowlist_state.h"
+@@ -1003,12 +1002,6 @@ void InstalledLoader::RecordExtensionsMe
+                               enabled_not_allowlisted_count);
+   base::UmaHistogramCounts100("Extensions.NotAllowlistedDisabled2",
+                               disabled_not_allowlisted_count);
+-  if (safe_browsing::IsEnhancedProtectionEnabled(*profile->GetPrefs())) {
+-    base::UmaHistogramCounts100("Extensions.NotAllowlistedEnabledAndEsbUser2",
+-                                enabled_not_allowlisted_count);
+-    base::UmaHistogramCounts100("Extensions.NotAllowlistedDisabledAndEsbUser2",
+-                                disabled_not_allowlisted_count);
+-  }
+ }
+ 
+ int InstalledLoader::GetCreationFlags(const ExtensionInfo* info) {
+--- a/chrome/browser/extensions/pref_mapping.cc
++++ b/chrome/browser/extensions/pref_mapping.cc
+@@ -20,7 +20,6 @@
+ #include "components/password_manager/core/common/password_manager_pref_names.h"
+ #include "components/privacy_sandbox/privacy_sandbox_prefs.h"
+ #include "components/proxy_config/proxy_config_pref_names.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/spellcheck/browser/pref_names.h"
+ #include "components/translate/core/browser/translate_pref_names.h"
+ #include "extensions/buildflags/buildflags.h"
+@@ -66,11 +65,6 @@ const PrefMappingEntry kMappings[] = {
+      APIPermissionID::kPrivacy},
+     {"doNotTrackEnabled", prefs::kEnableDoNotTrack, APIPermissionID::kPrivacy,
+      APIPermissionID::kPrivacy},
+-    {"safeBrowsingEnabled", prefs::kSafeBrowsingEnabled,
+-     APIPermissionID::kPrivacy, APIPermissionID::kPrivacy},
+-    {"safeBrowsingExtendedReportingEnabled",
+-     prefs::kSafeBrowsingScoutReportingEnabled, APIPermissionID::kPrivacy,
+-     APIPermissionID::kPrivacy},
+     {"searchSuggestEnabled", prefs::kSearchSuggestEnabled,
+      APIPermissionID::kPrivacy, APIPermissionID::kPrivacy},
+     {"spellingServiceEnabled", spellcheck::prefs::kSpellCheckUseSpellingService,
+--- a/chrome/browser/net/profile_network_context_service.cc
++++ b/chrome/browser/net/profile_network_context_service.cc
+@@ -74,7 +74,6 @@
+ #include "components/prefs/pref_registry_simple.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/privacy_sandbox/privacy_sandbox_prefs.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "content/public/browser/browser_context.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "content/public/browser/first_party_sets_handler.h"
+@@ -1461,15 +1460,8 @@ void ProfileNetworkContextService::Confi
+ 
+   network_context_params->enable_certificate_reporting = true;
+ 
+-  SCTReportingService* sct_reporting_service =
+-      SCTReportingServiceFactory::GetForBrowserContext(profile_);
+-  if (sct_reporting_service) {
+-    network_context_params->sct_auditing_mode =
+-        sct_reporting_service->GetReportingMode();
+-  } else {
+     network_context_params->sct_auditing_mode =
+         network::mojom::SCTAuditingMode::kDisabled;
+-  }
+ 
+   network_context_params->ct_policy = GetCTPolicy();
+   cert_verifier_creation_params->ct_policy = GetCTPolicy();
+--- a/chrome/browser/notifications/platform_notification_service_impl.cc
++++ b/chrome/browser/notifications/platform_notification_service_impl.cc
+@@ -46,7 +46,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/safe_browsing/buildflags.h"
+ #include "components/safe_browsing/content/browser/notification_content_detection/notification_content_detection_constants.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "content/public/browser/platform_notification_context.h"
+ #include "content/public/browser/storage_partition.h"
+@@ -817,25 +816,7 @@ void PlatformNotificationServiceImpl::Lo
+ 
+ bool PlatformNotificationServiceImpl::
+     AreSuspiciousNotificationsAllowlistedByUser(const GURL& origin) {
+-  auto* hcsm = HostContentSettingsMapFactory::GetForProfile(profile_);
+-  if (!hcsm || !origin.is_valid()) {
+     return false;
+-  }
+-  content_settings::SettingInfo info;
+-  base::Value stored_value(hcsm->GetWebsiteSetting(
+-      origin, origin,
+-      ContentSettingsType::ARE_SUSPICIOUS_NOTIFICATIONS_ALLOWLISTED_BY_USER,
+-      &info));
+-  if (stored_value.is_none()) {
+-    return false;
+-  }
+-  if (!stored_value.is_dict() || !stored_value.GetDict().contains(
+-                                     safe_browsing::kIsAllowlistedByUserKey)) {
+-    return false;
+-  }
+-  return stored_value.GetDict()
+-      .FindBool(safe_browsing::kIsAllowlistedByUserKey)
+-      .value_or(false);
+ }
+ 
+ void PlatformNotificationServiceImpl::DidUpdatePersistentMetadata(
+--- a/chrome/browser/password_manager/generated_password_leak_detection_pref.cc
++++ b/chrome/browser/password_manager/generated_password_leak_detection_pref.cc
+@@ -15,7 +15,6 @@
+ #include "components/password_manager/core/common/password_manager_pref_names.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ 
+ namespace {
+@@ -42,16 +41,6 @@ GeneratedPasswordLeakDetectionPref::Gene
+       base::BindRepeating(
+           &GeneratedPasswordLeakDetectionPref::OnSourcePreferencesChanged,
+           base::Unretained(this)));
+-  user_prefs_registrar_.Add(
+-      prefs::kSafeBrowsingEnabled,
+-      base::BindRepeating(
+-          &GeneratedPasswordLeakDetectionPref::OnSourcePreferencesChanged,
+-          base::Unretained(this)));
+-  user_prefs_registrar_.Add(
+-      prefs::kSafeBrowsingEnhanced,
+-      base::BindRepeating(
+-          &GeneratedPasswordLeakDetectionPref::OnSourcePreferencesChanged,
+-          base::Unretained(this)));
+ 
+   if (auto* identity_manager = IdentityManagerFactory::GetForProfile(profile)) {
+     identity_manager_observer_.Observe(identity_manager);
+--- a/chrome/browser/policy/browser_signin_policy_handler.cc
++++ b/chrome/browser/policy/browser_signin_policy_handler.cc
+@@ -15,7 +15,6 @@
+ #include "components/policy/core/common/policy_map.h"
+ #include "components/policy/policy_constants.h"
+ #include "components/prefs/pref_value_map.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ 
+ namespace policy {
+ 
+@@ -30,50 +29,6 @@ BrowserSigninPolicyHandler::~BrowserSign
+ 
+ void BrowserSigninPolicyHandler::ApplyPolicySettings(const PolicyMap& policies,
+                                                      PrefValueMap* prefs) {
+-#if BUILDFLAG(IS_WIN)
+-  // Browser sign in policies shouldn't be enforced on gcpw signin
+-  // mode as gcpw is invoked in windows login UI screen.
+-  // Also note that GCPW launches chrome in incognito mode using a
+-  // special user's logon_token. So the end user won't have access
+-  // to this session after user logs in via GCPW.
+-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+-          ::credential_provider::kGcpwSigninSwitch))
+-    return;
+-#endif
+-
+-  const base::Value* value =
+-      policies.GetValue(policy_name(), base::Value::Type::INTEGER);
+-  switch (static_cast<BrowserSigninMode>(value->GetInt())) {
+-    case BrowserSigninMode::kForced:
+-#if !BUILDFLAG(IS_CHROMEOS)
+-      prefs->SetValue(prefs::kForceBrowserSignin, base::Value(true));
+-#endif
+-      [[fallthrough]];
+-    case BrowserSigninMode::kEnabled:
+-      prefs->SetValue(
+-#if BUILDFLAG(IS_ANDROID)
+-          // The new kSigninAllowedOnNextStartup pref is only used on Desktop.
+-          // Keep the old kSigninAllowed pref for Android until the policy is
+-          // fully deprecated in M71 and can be removed.
+-          prefs::kSigninAllowed,
+-#else
+-          prefs::kSigninAllowedOnNextStartup,
+-#endif
+-          base::Value(true));
+-      break;
+-    case BrowserSigninMode::kDisabled:
+-      prefs->SetValue(
+-#if BUILDFLAG(IS_ANDROID)
+-          // The new kSigninAllowedOnNextStartup pref is only used on Desktop.
+-          // Keep the old kSigninAllowed pref for Android until the policy is
+-          // fully deprecated in M71 and can be removed.
+-          prefs::kSigninAllowed,
+-#else
+-          prefs::kSigninAllowedOnNextStartup,
+-#endif
+-          base::Value(false));
+-      break;
+-  }
+ }
+ 
+ }  // namespace policy
+--- a/chrome/browser/policy/configuration_policy_handler_list_factory.cc
++++ b/chrome/browser/policy/configuration_policy_handler_list_factory.cc
+@@ -119,15 +119,12 @@
+ #include "components/proxy_config/proxy_override_rules_policy_handler.h"
+ #include "components/proxy_config/proxy_policy_handler.h"
+ #include "components/safe_browsing/buildflags.h"
+-#include "components/safe_browsing/core/common/safe_browsing_policy_handler.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/search_engines/enterprise/default_search_policy_handler.h"
+ #include "components/search_engines/search_engines_pref_names.h"
+ #include "components/security_interstitials/core/https_only_mode_policy_handler.h"
+ #include "components/security_interstitials/core/pref_names.h"
+ #include "components/sharing_message/pref_names.h"
+ #include "components/signin/public/base/signin_buildflags.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/spellcheck/spellcheck_buildflags.h"
+ #include "components/sync/base/pref_names.h"
+ #include "components/sync/service/sync_policy_handler.h"
+@@ -325,9 +322,6 @@ const PolicyToPreferenceMapEntry kSimple
+   { key::kForcePermissionPolicyUnloadDefaultEnabled,
+     policy_prefs::kForcePermissionPolicyUnloadDefaultEnabled,
+     base::Value::Type::BOOLEAN},
+-  { key::kDisableSafeBrowsingProceedAnyway,
+-    prefs::kSafeBrowsingProceedAnywayDisabled,
+-    base::Value::Type::BOOLEAN },
+   { key::kDomainReliabilityAllowed,
+     domain_reliability::prefs::kDomainReliabilityAllowedByPolicy,
+     base::Value::Type::BOOLEAN },
+@@ -370,15 +364,6 @@ const PolicyToPreferenceMapEntry kSimple
+     prefs::kOopPrintDriversAllowedByPolicy,
+     base::Value::Type::BOOLEAN },
+ #endif
+-  { key::kSafeBrowsingAllowlistDomains,
+-    prefs::kSafeBrowsingAllowlistDomains,
+-    base::Value::Type::LIST },
+-  { key::kSafeBrowsingEnabled,
+-    prefs::kSafeBrowsingEnabled,
+-    base::Value::Type::BOOLEAN },
+-  { key::kSafeBrowsingProxiedRealTimeChecksAllowed,
+-    prefs::kHashPrefixRealTimeChecksAllowedByPolicy,
+-    base::Value::Type::BOOLEAN },
+   { key::kSavingBrowserHistoryDisabled,
+     prefs::kSavingBrowserHistoryDisabled,
+     base::Value::Type::BOOLEAN },
+@@ -534,9 +519,6 @@ const PolicyToPreferenceMapEntry kSimple
+   { key::kAccessibilityImageLabelsEnabled,
+     prefs::kAccessibilityImageLabelsEnabled,
+     base::Value::Type::BOOLEAN },
+-  { key::kAdvancedProtectionAllowed,
+-    prefs::kAdvancedProtectionAllowed,
+-    base::Value::Type::BOOLEAN },
+   { key::kAllowCrossOriginAuthPrompt,
+     prefs::kAllowCrossOriginAuthPrompt,
+     base::Value::Type::BOOLEAN },
+@@ -741,15 +723,6 @@ const PolicyToPreferenceMapEntry kSimple
+   { key::kPasswordDismissCompromisedAlertEnabled,
+     password_manager::prefs::kPasswordDismissCompromisedAlertEnabled,
+     base::Value::Type::BOOLEAN },
+-  { key::kPasswordProtectionChangePasswordURL,
+-    prefs::kPasswordProtectionChangePasswordURL,
+-    base::Value::Type::STRING },
+-  { key::kPasswordProtectionLoginURLs,
+-    prefs::kPasswordProtectionLoginURLs,
+-    base::Value::Type::LIST },
+-  { key::kPasswordProtectionWarningTrigger,
+-    prefs::kPasswordProtectionWarningTrigger,
+-    base::Value::Type::INTEGER },
+ #if BUILDFLAG(ENABLE_PDF)
+   { key::kPdfLocalFileAccessAllowedForDomains,
+     prefs::kPdfLocalFileAccessAllowedForDomains,
+@@ -913,9 +886,6 @@ const PolicyToPreferenceMapEntry kSimple
+   { key::kAdditionalDnsQueryTypesEnabled,
+     prefs::kAdditionalDnsQueryTypesEnabled,
+     base::Value::Type::BOOLEAN },
+-  { key::kSafeBrowsingExtendedReportingEnabled,
+-    prefs::kSafeBrowsingScoutReportingEnabled,
+-    base::Value::Type::BOOLEAN },
+   { key::kForceGoogleSafeSearch,
+     policy_prefs::kForceGoogleSafeSearch,
+     base::Value::Type::BOOLEAN },
+@@ -988,9 +958,6 @@ const PolicyToPreferenceMapEntry kSimple
+   { key::kRequireOnlineRevocationChecksForLocalAnchors,
+     prefs::kCertRevocationCheckingRequiredLocalAnchors,
+     base::Value::Type::BOOLEAN },
+-  { key::kSafeBrowsingSurveysEnabled,
+-    prefs::kSafeBrowsingSurveysEnabled,
+-    base::Value::Type::BOOLEAN },
+   { key::kPasswordManagerBlocklist,
+     password_manager::prefs::kPasswordManagerBlocklist,
+     base::Value::Type::LIST },
+@@ -1979,9 +1946,6 @@ const PolicyToPreferenceMapEntry kSimple
+   { key::kUnmanagedDeviceSignalsConsentFlowEnabled,
+     device_signals::prefs::kUnmanagedDeviceSignalsConsentFlowEnabled,
+     base::Value::Type::BOOLEAN },
+-  { key::kProfileSeparationDomainExceptionList,
+-    prefs::kProfileSeparationDomainExceptionList,
+-    base::Value::Type::LIST },
+ #endif // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
+ #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
+   { key::kDefaultBrowserSettingEnabled,
+@@ -2046,9 +2010,6 @@ const PolicyToPreferenceMapEntry kSimple
+     prefs::kImportDialogAutofillFormData,
+     base::Value::Type::BOOLEAN },
+ 
+-  { key::kRestrictSigninToPattern,
+-    prefs::kGoogleServicesUsernamePattern,
+-    base::Value::Type::STRING },
+   { key::kHardwareAccelerationModeEnabled,
+     prefs::kHardwareAccelerationModeEnabled,
+     base::Value::Type::BOOLEAN },
+@@ -2333,9 +2294,6 @@ const PolicyToPreferenceMapEntry kSimple
+   { key::kGoogleSearchSidePanelEnabled,
+     prefs::kGoogleSearchSidePanelEnabled,
+     base::Value::Type::BOOLEAN },
+-  { key::kSafeBrowsingDeepScanningEnabled,
+-    prefs::kSafeBrowsingDeepScanningEnabled,
+-    base::Value::Type::BOOLEAN },
+ #endif  // BUILDFLAG(IS_ANDROID)
+   { key::kAllowBackForwardCacheForCacheControlNoStorePageEnabled,
+     policy_prefs::kAllowBackForwardCacheForCacheControlNoStorePageEnabled,
+@@ -2947,28 +2905,6 @@ std::unique_ptr<ConfigurationPolicyHandl
+           key::kBrowserContextAwareAccessSignalsAllowlist,
+           enterprise_connectors::kBrowserContextAwareAccessSignalsAllowlistPref,
+           chrome_schema));
+-  handlers->AddHandler(
+-      std::make_unique<SingleDeprecatedPolicyToMultipleNewPolicyHandler>(
+-          std::make_unique<ManagedAccountRestrictionsPolicyHandler>(
+-              chrome_schema),
+-          std::vector<std::string>{
+-              key::kProfileSeparationSettings,
+-              key::kProfileSeparationDataMigrationSettings,
+-              key::kProfileSeparationDomainExceptionList}));
+-  handlers->AddHandler(std::make_unique<CloudUserOnlyPolicyChecker>(
+-      std::make_unique<SimplePolicyHandler>(key::kProfileSeparationSettings,
+-                                            prefs::kProfileSeparationSettings,
+-                                            base::Value::Type::INTEGER)));
+-
+-  handlers->AddHandler(std::make_unique<SimpleDeprecatingPolicyHandler>(
+-      std::make_unique<SimplePolicyHandler>(
+-          key::kEnterpriseProfileCreationKeepBrowsingData,
+-          prefs::kEnterpriseProfileCreationKeepBrowsingData,
+-          base::Value::Type::BOOLEAN),
+-      std::make_unique<SimplePolicyHandler>(
+-          key::kProfileSeparationDataMigrationSettings,
+-          prefs::kProfileSeparationDataMigrationSettings,
+-          base::Value::Type::INTEGER)));
+   handlers->AddHandler(std::make_unique<IntRangePolicyHandler>(
+       key::kProfileReauthPrompt, enterprise_signin::prefs::kProfileReauthPrompt,
+       static_cast<int>(enterprise_signin::ProfileReauthPrompt::kDoNotPrompt),
+@@ -3039,9 +2975,6 @@ std::unique_ptr<ConfigurationPolicyHandl
+       signin_legacy_policies;
+ #if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_WIN) || \
+     BUILDFLAG(IS_LINUX)
+-  signin_legacy_policies.push_back(std::make_unique<SimplePolicyHandler>(
+-      key::kForceBrowserSignin, prefs::kForceBrowserSignin,
+-      base::Value::Type::BOOLEAN));
+ 
+   handlers->AddHandler(std::make_unique<CloudUserOnlyPolicyChecker>(
+       std::make_unique<SimplePolicyHandler>(
+@@ -3062,17 +2995,6 @@ std::unique_ptr<ConfigurationPolicyHandl
+           enterprise_reporting::kSecuritySignalsClientCertificatesSelectors,
+           base::Value::Type::LIST)));
+ #endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
+-  signin_legacy_policies.push_back(std::make_unique<SimplePolicyHandler>(
+-      key::kSigninAllowed,
+-#if BUILDFLAG(IS_ANDROID)
+-      // The new kSigninAllowedOnNextStartup pref is only used on Desktop.
+-      // Keep the old kSigninAllowed pref for Android until the policy is
+-      // fully deprecated in M71 and can be removed.
+-      prefs::kSigninAllowed,
+-#else   // BUILDFLAG(IS_ANDROID)
+-      prefs::kSigninAllowedOnNextStartup,
+-#endif  // BUILDFLAG(IS_ANDROID)
+-      base::Value::Type::BOOLEAN));
+   handlers->AddHandler(std::make_unique<LegacyPoliciesDeprecatingPolicyHandler>(
+       std::move(signin_legacy_policies),
+       std::make_unique<BrowserSigninPolicyHandler>(chrome_schema)));
+--- a/chrome/browser/prefs/browser_prefs.cc
++++ b/chrome/browser/prefs/browser_prefs.cc
+@@ -170,7 +170,6 @@
+ #include "components/proxy_config/pref_proxy_config_tracker_impl.h"
+ #include "components/regional_capabilities/regional_capabilities_prefs.h"
+ #include "components/safe_browsing/buildflags.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safety_check/safety_check_prefs.h"
+ #include "components/saved_tab_groups/public/pref_names.h"
+ #include "components/search_engines/search_engine_choice/search_engine_choice_service.h"
+@@ -182,7 +181,6 @@
+ #include "components/sessions/core/session_id_generator.h"
+ #include "components/sharing_message/sharing_sync_preference.h"
+ #include "components/signin/core/browser/active_primary_accounts_metrics_recorder.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_prefs.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/site_engagement/content/site_engagement_service.h"
+@@ -1463,7 +1461,6 @@ void RegisterLocalState(PrefRegistrySimp
+   PushMessagingServiceImpl::RegisterPrefs(registry);
+ #endif
+   RegisterScreenshotPrefs(registry);
+-  safe_browsing::RegisterLocalStatePrefs(registry);
+   search_engines::SearchEngineChoiceService::RegisterLocalStatePrefs(registry);
+   secure_origin_allowlist::RegisterPrefs(registry);
+   segmentation_platform::SegmentationPlatformService::RegisterLocalStatePrefs(
+@@ -1818,7 +1815,6 @@ void RegisterProfilePrefs(user_prefs::Pr
+ #if BUILDFLAG(SAFE_BROWSING_AVAILABLE)
+   safe_browsing::file_type::RegisterProfilePrefs(registry);
+ #endif
+-  safe_browsing::RegisterProfilePrefs(registry);
+   safety_check::prefs::RegisterProfilePrefs(registry);
+   SearchPrefetchService::RegisterProfilePrefs(registry);
+   blocked_content::SafeBrowsingTriggeredPopupBlocker::RegisterProfilePrefs(
+--- a/chrome/browser/prefs/chrome_command_line_pref_store.cc
++++ b/chrome/browser/prefs/chrome_command_line_pref_store.cc
+@@ -24,7 +24,6 @@
+ #include "components/language/core/browser/pref_names.h"
+ #include "components/proxy_config/proxy_config_dictionary.h"
+ #include "components/proxy_config/proxy_config_pref_names.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/safebrowsing_switches.h"
+ #include "components/sync/base/pref_names.h"
+ #include "content/public/common/content_switches.h"
+@@ -82,8 +81,6 @@ const CommandLinePrefStore::BooleanSwitc
+         {switches::kAllowCrossOriginAuthPrompt,
+          prefs::kAllowCrossOriginAuthPrompt, true},
+         {switches::kDisablePrintPreview, prefs::kPrintPreviewDisabled, true},
+-        {safe_browsing::switches::kSbEnableEnhancedProtection,
+-         prefs::kSafeBrowsingEnhanced, true},
+ #if BUILDFLAG(IS_CHROMEOS)
+         {ash::switches::kEnableTouchpadThreeFingerClick,
+          ash::prefs::kEnableTouchpadThreeFingerClick, true},
+--- a/chrome/browser/prefs/chrome_pref_service_factory.cc
++++ b/chrome/browser/prefs/chrome_pref_service_factory.cc
+@@ -55,10 +55,8 @@
+ #include "components/prefs/pref_store.h"
+ #include "components/prefs/pref_value_store.h"
+ #include "components/prefs/wrap_with_prefix_pref_store.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/search_engines/default_search_manager.h"
+ #include "components/search_engines/search_engines_pref_names.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/supervised_user/core/browser/device_parental_controls.h"
+ #include "components/supervised_user/core/browser/supervised_user_pref_store.h"
+@@ -131,9 +129,6 @@ const auto kTrackedPrefs = std::to_array
+     {5, extensions::pref_names::kExtensions, EnforcementLevel::NO_ENFORCEMENT,
+      PrefTrackingStrategy::SPLIT, ValueType::IMPERSONAL},
+ #endif
+-    {6, prefs::kGoogleServicesLastSyncingUsername,
+-     EnforcementLevel::ENFORCE_ON_LOAD, PrefTrackingStrategy::ATOMIC,
+-     ValueType::PERSONAL},
+     {7, prefs::kSearchProviderOverrides, EnforcementLevel::ENFORCE_ON_LOAD,
+      PrefTrackingStrategy::ATOMIC, ValueType::IMPERSONAL},
+ #if !BUILDFLAG(IS_ANDROID)
+@@ -157,19 +152,12 @@ const auto kTrackedPrefs = std::to_array
+      PrefTrackingStrategy::ATOMIC, ValueType::IMPERSONAL},
+     // kSyncRemainingRollbackTries is deprecated and will be removed a few
+     // releases after M50.
+-    {18, prefs::kSafeBrowsingIncidentsSent, EnforcementLevel::ENFORCE_ON_LOAD,
+-     PrefTrackingStrategy::ATOMIC, ValueType::IMPERSONAL},
+-    {23, prefs::kGoogleServicesAccountId, EnforcementLevel::ENFORCE_ON_LOAD,
+-     PrefTrackingStrategy::ATOMIC, ValueType::PERSONAL},
+     {29, prefs::kMediaStorageIdSalt, EnforcementLevel::ENFORCE_ON_LOAD,
+      PrefTrackingStrategy::ATOMIC, ValueType::IMPERSONAL},
+ #if BUILDFLAG(IS_WIN)
+     {32, prefs::kMediaCdmOriginData, EnforcementLevel::ENFORCE_ON_LOAD,
+      PrefTrackingStrategy::ATOMIC, ValueType::IMPERSONAL},
+ #endif  // BUILDFLAG(IS_WIN)
+-    {33, prefs::kGoogleServicesLastSignedInUsername,
+-     EnforcementLevel::ENFORCE_ON_LOAD, PrefTrackingStrategy::ATOMIC,
+-     ValueType::PERSONAL},
+     {34, enterprise_signin::prefs::kPolicyRecoveryToken,
+      EnforcementLevel::ENFORCE_ON_LOAD, PrefTrackingStrategy::ATOMIC,
+      ValueType::IMPERSONAL},
+--- a/chrome/browser/prefs/pref_functional_browsertest.cc
++++ b/chrome/browser/prefs/pref_functional_browsertest.cc
+@@ -27,7 +27,6 @@
+ #include "components/content_settings/core/common/content_settings_types.h"
+ #include "components/content_settings/core/common/pref_names.h"
+ #include "components/embedder_support/pref_names.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/sync_preferences/pref_service_syncable.h"
+ #include "content/public/browser/web_contents.h"
+ #include "content/public/test/browser_test.h"
+@@ -226,9 +225,6 @@ IN_PROC_BROWSER_TEST_F(PrefsFunctionalTe
+   prefetch::SetPreloadPagesState(prefs,
+                                  prefetch::PreloadPagesState::kNoPreloading);
+ 
+-  EXPECT_TRUE(prefs->GetBoolean(prefs::kSafeBrowsingEnabled));
+-  prefs->SetBoolean(prefs::kSafeBrowsingEnabled, false);
+-
+   EXPECT_TRUE(prefs->GetBoolean(embedder_support::kAlternateErrorPagesEnabled));
+   prefs->SetBoolean(embedder_support::kAlternateErrorPagesEnabled, false);
+ 
+@@ -242,7 +238,6 @@ IN_PROC_BROWSER_TEST_F(PrefsFunctionalTe
+ 
+   EXPECT_EQ(prefetch::PreloadPagesState::kNoPreloading,
+             prefetch::GetPreloadPagesState(*prefs));
+-  EXPECT_FALSE(prefs->GetBoolean(prefs::kSafeBrowsingEnabled));
+   EXPECT_FALSE(
+       prefs->GetBoolean(embedder_support::kAlternateErrorPagesEnabled));
+   EXPECT_FALSE(prefs->GetBoolean(prefs::kSearchSuggestEnabled));
+--- a/chrome/browser/profiles/gaia_info_update_service.cc
++++ b/chrome/browser/profiles/gaia_info_update_service.cc
+@@ -21,7 +21,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/public/base/avatar_icon_util.h"
+ #include "components/signin/public/base/consent_level.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_prefs.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/signin/public/identity_manager/accounts_in_cookie_jar_info.h"
+--- a/chrome/browser/profiles/gaia_info_update_service_unittest.cc
++++ b/chrome/browser/profiles/gaia_info_update_service_unittest.cc
+@@ -36,7 +36,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/profile_metrics/state.h"
+ #include "components/signin/public/base/consent_level.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_prefs.h"
+ #include "components/signin/public/identity_manager/account_capabilities_test_mutator.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+--- a/chrome/browser/profiles/profile_attributes_entry.cc
++++ b/chrome/browser/profiles/profile_attributes_entry.cc
+@@ -25,7 +25,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/prefs/scoped_user_pref_update.h"
+ #include "components/profile_metrics/state.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/signin/public/identity_manager/signin_constants.h"
+@@ -516,7 +515,7 @@ bool ProfileAttributesEntry::IsUsingDefa
+ }
+ 
+ bool ProfileAttributesEntry::IsSignedInWithCredentialProvider() const {
+-  return GetBool(prefs::kSignedInWithCredentialProvider);
++  return false;
+ }
+ 
+ bool ProfileAttributesEntry::IsDasherlessManagement() const {
+@@ -745,7 +744,6 @@ void ProfileAttributesEntry::SetLastDown
+ }
+ 
+ void ProfileAttributesEntry::SetSignedInWithCredentialProvider(bool value) {
+-  SetBool(prefs::kSignedInWithCredentialProvider, value);
+ }
+ 
+ void ProfileAttributesEntry::SetDasherlessManagement(bool value) {
+--- a/chrome/browser/profiles/profile_attributes_storage.cc
++++ b/chrome/browser/profiles/profile_attributes_storage.cc
+@@ -42,7 +42,6 @@
+ #include "components/prefs/scoped_user_pref_update.h"
+ #include "components/profile_metrics/state.h"
+ #include "components/signin/public/base/persistent_repeating_timer.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_managed_status_finder.h"
+ #include "content/public/browser/browser_task_traits.h"
+@@ -394,9 +393,7 @@ void ProfileAttributesStorage::AddProfil
+                    params.profile_name,
+                    /*include_check_for_legacy_profile_name*/ false))
+           // Assume newly created profiles use a default avatar.
+-          .Set(ProfileAttributesEntry::kIsUsingDefaultAvatarKey, true)
+-          .Set(prefs::kSignedInWithCredentialProvider,
+-               params.is_signed_in_with_credential_provider);
++          .Set(ProfileAttributesEntry::kIsUsingDefaultAvatarKey, true);
+ 
+   if (params.account_id.HasAccountIdKey()) {
+     info.Set(ProfileAttributesEntry::kAccountIdKey,
+--- a/chrome/browser/profiles/profile_impl.cc
++++ b/chrome/browser/profiles/profile_impl.cc
+@@ -154,7 +154,6 @@
+ #include "components/profile_metrics/browser_profile_type.h"
+ #include "components/safe_search_api/safe_search_util.h"
+ #include "components/security_interstitials/content/stateful_ssl_host_state_delegate.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/site_isolation/site_isolation_policy.h"
+@@ -1109,7 +1108,6 @@ void ProfileImpl::OnLocaleReady(CreateMo
+ #if !BUILDFLAG(IS_ANDROID)
+   CHECK(!ThemeServiceFactory::GetForProfileIfExists(this));
+ #endif  // !BUILDFLAG(IS_ANDROID)
+-  browser_sync::MaybeMigrateSyncingUserToSignedIn(GetPath(), GetPrefs());
+ 
+ #if BUILDFLAG(IS_CHROMEOS)
+   // If this is a kiosk profile, reset some of its prefs which should not
+--- a/chrome/browser/profiles/profile_manager.cc
++++ b/chrome/browser/profiles/profile_manager.cc
+@@ -93,7 +93,6 @@
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_buildflags.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/signin/public/identity_manager/primary_account_mutator.h"
+ #include "components/signin/public/identity_manager/tribool.h"
+@@ -2052,8 +2051,7 @@ void ProfileManager::AddProfileToStorage
+       entry->SetAuthInfo(account_info.gaia, username,
+                          is_consented_primary_account);
+ 
+-      entry->SetSignedInWithCredentialProvider(profile->GetPrefs()->GetBoolean(
+-          prefs::kSignedInWithCredentialProvider));
++      entry->SetSignedInWithCredentialProvider(false);
+ 
+ #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_CHROMEOS)
+       // Sign out if force-sign-in policy is enabled and profile is not signed
+@@ -2102,14 +2100,13 @@ void ProfileManager::AddProfileToStorage
+ 
+   init_params.is_ephemeral = IsForceEphemeralProfilesEnabled(profile);
+   init_params.is_signed_in_with_credential_provider =
+-      profile->GetPrefs()->GetBoolean(prefs::kSignedInWithCredentialProvider);
++      false;
+ 
+   storage.AddProfile(std::move(init_params));
+ }
+ 
+ void ProfileManager::SetNonPersonalProfilePrefs(Profile* profile) {
+   PrefService* prefs = profile->GetPrefs();
+-  prefs->SetBoolean(prefs::kSigninAllowed, false);
+   prefs->SetBoolean(bookmarks::prefs::kEditBookmarksEnabled, false);
+   prefs->SetBoolean(bookmarks::prefs::kShowBookmarkBar, false);
+   prefs->ClearPref(DefaultSearchManager::kDefaultSearchProviderDataPrefName);
+--- a/chrome/browser/profiles/profile_window.cc
++++ b/chrome/browser/profiles/profile_window.cc
+@@ -42,7 +42,6 @@
+ #include "chrome/common/pref_names.h"
+ #include "chrome/common/url_constants.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/webui/flags/pref_service_flags_storage.h"
+--- a/chrome/browser/profiles/profiles_state.cc
++++ b/chrome/browser/profiles/profiles_state.cc
+@@ -51,7 +51,6 @@
+ 
+ #include "chrome/browser/profiles/gaia_info_update_service.h"
+ #include "chrome/browser/profiles/gaia_info_update_service_factory.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #endif
+ 
+ namespace profiles {
+--- a/chrome/browser/resources/settings/privacy_page/security/security_page.html
++++ b/chrome/browser/resources/settings/privacy_page/security/security_page.html
+@@ -73,126 +73,6 @@
+   <settings-subpage page-title="$i18n{securityPageTitle}"
+       learn-more-url="$i18n{safeBrowsingHelpCenterURL}"
+       route-path$="[[routePath]]">
+-    <div id="safeBrowsingSection">
+-      <h2 class="cr-title-text">$i18n{safeBrowsingSectionLabel}</h2>
+-      <settings-radio-group id="safeBrowsingRadioGroup" no-set-pref
+-          pref="{{prefs.generated.safe_browsing}}"
+-          selectable-elements="cr-radio-button, settings-collapse-radio-button"
+-          on-change="onSafeBrowsingRadioChange_">
+-        <settings-collapse-radio-button id="safeBrowsingEnhanced"
+-            name="[[safeBrowsingSettingEnum_.ENHANCED]]"
+-            pref="[[prefs.generated.safe_browsing]]"
+-            label="$i18n{safeBrowsingEnhanced}"
+-            sub-label="$i18n{safeBrowsingEnhancedDescUpdated}"
+-            indicator-aria-label="$i18n{controlledSettingPolicy}"
+-            expand-aria-label="$i18n{safeBrowsingEnhancedExpandA11yLabel}"
+-            on-expand-clicked="onEnhancedProtectionExpandButtonClicked_"
+-            no-automatic-collapse>
+-          <div slot="collapse">
+-            <div id="enhancedProtectionDescContainer"
+-                class="settings-columned-section">
+-              <div class="column">
+-                <h3 class="description-header">
+-                  $i18n{columnHeadingWhenOn}
+-                </h3>
+-                <ul class="icon-bulleted-list">
+-                  <li>
+-                    <cr-icon icon="settings20:data" aria-hidden="true">
+-                    </cr-icon>
+-                    <div class="secondary">
+-                      $i18n{safeBrowsingEnhancedWhenOnBulOne}
+-                    </div>
+-                  </li>
+-                  <li>
+-                    <cr-icon icon="settings20:download" aria-hidden="true">
+-                    </cr-icon>
+-                    <div class="secondary">
+-                      $i18n{safeBrowsingEnhancedWhenOnBulTwo}
+-                    </div>
+-                  </li>
+-                  <li>
+-                    <cr-icon icon="settings20:gshield" aria-hidden="true">
+-                    </cr-icon>
+-                    <div class="secondary">
+-                      $i18n{safeBrowsingEnhancedWhenOnBulThree}
+-                    </div>
+-                  </li>
+-                  <li>
+-                    <cr-icon icon="settings:language" aria-hidden="true">
+-                    </cr-icon>
+-                    <div class="secondary">
+-                      $i18n{safeBrowsingEnhancedWhenOnBulFour}
+-                    </div>
+-                  </li>
+-                </ul>
+-              </div>
+-              <div class="column">
+-                <h3 class="description-header">
+-                  $i18n{columnHeadingConsider}
+-                </h3>
+-                <ul class="icon-bulleted-list">
+-                  <li>
+-                    <cr-icon icon="settings20:link"></cr-icon>
+-                    <div class="cr-secondary-text">
+-                      $i18n{safeBrowsingEnhancedThingsToConsiderBulOne}
+-                    </div>
+-                  </li>
+-                  <li>
+-                    <cr-icon icon="settings20:account-circle"></cr-icon>
+-                    <div class="cr-secondary-text">
+-                      $i18n{safeBrowsingEnhancedThingsToConsiderBulTwo}
+-                    </div>
+-                  </li>
+-                  <li>
+-                    <cr-icon icon="settings:performance"></cr-icon>
+-                    <div class="cr-secondary-text">
+-                      $i18n{safeBrowsingEnhancedThingsToConsiderBulThree}
+-                    </div>
+-                  </li>
+-                </ul>
+-              </div>
+-            </div>
+-            <div id="learnMoreLabelContainer">
+-              <div class="cr-secondary-text">
+-                $i18nRaw{safeBrowsingEnhancedLearnMoreLabel}
+-              </div>
+-            </div>
+-          </div>
+-        </settings-collapse-radio-button>
+-        <settings-collapse-radio-button id="safeBrowsingStandard"
+-            no-collapse="[[hideExtendedReportingRadioButton_]]"
+-            name="[[safeBrowsingSettingEnum_.STANDARD]]"
+-            pref="[[prefs.generated.safe_browsing]]"
+-            label="$i18n{safeBrowsingStandard}"
+-            sub-label="[[getSafeBrowsingStandardSubLabel_(
+-                        enableHashPrefixRealTimeLookups_)]]"
+-            indicator-aria-label="$i18n{controlledSettingPolicy}"
+-            expand-aria-label="$i18n{safeBrowsingStandardExpandA11yLabel}"
+-            info-opened="{{infoOpened_}}"
+-            on-expand-clicked="onStandardProtectionExpandButtonClicked_"
+-            no-automatic-collapse>
+-          <div slot="noSelectionCollapse">
+-            <template is="dom-if" if="[[!hideExtendedReportingRadioButton_]]">
+-              <settings-toggle-button id="safeBrowsingReportingToggle"
+-                pref="{{prefs.safebrowsing.scout_reporting_enabled}}"
+-                label="$i18n{safeBrowsingStandardReportingLabel}"
+-                sub-label="$i18n{safeBrowsingEnableExtendedReportingDesc}"
+-                on-change="onSafeBrowsingExtendedReportingChange_"
+-                disabled="[[getDisabledExtendedSafeBrowsing_(
+-                              prefs.generated.safe_browsing.*)]]">
+-              </settings-toggle-button>
+-            </template>
+-          </div>
+-        </settings-collapse-radio-button>
+-        <settings-collapse-radio-button id="safeBrowsingDisabled" no-collapse
+-            name="[[safeBrowsingSettingEnum_.DISABLED]]"
+-            pref="[[prefs.generated.safe_browsing]]"
+-            label="$i18n{safeBrowsingNone}"
+-            sub-label="$i18n{safeBrowsingNoneDesc}"
+-            indicator-aria-label="$i18n{controlledSettingPolicy}">
+-        </settings-collapse-radio-button>
+-      </settings-radio-group>
+-    </div>
+     <template is="dom-if" if="[[enableHttpsFirstModeNewSettings_]]" restamp>
+       <div id="secureConnectionsSection">
+         <h2 class="cr-title-text">$i18n{secureConnectionsSectionTitle}</h2>
+@@ -298,12 +178,4 @@
+         on-click="onAdvancedProtectionProgramLinkClick_"
+         external>
+     </cr-link-row>
+-    <template is="dom-if" if="[[showDisableSafebrowsingDialog_]]" restamp>
+-      <settings-simple-confirmation-dialog
+-          title-text="$i18n{safeBrowsingDisableDialog}"
+-          body-text="$i18n{safeBrowsingDisableDialogDesc}"
+-          confirm-text="$i18n{safeBrowsingDisableDialogConfirm}"
+-          on-close="onDisableSafebrowsingDialogClose_">
+-      </settings-simple-confirmation-dialog>
+-    </template>
+   </settings-subpage>
+--- a/chrome/browser/resources/settings/privacy_page/security/security_page.ts
++++ b/chrome/browser/resources/settings/privacy_page/security/security_page.ts
+@@ -246,17 +246,6 @@ export class SettingsSecurityPageElement
+     super.ready();
+ 
+     CrSettingsPrefs.initialized.then(() => {
+-      // Expand initial pref value manually because automatic
+-      // expanding is disabled.
+-      const prefValue = this.getPref('generated.safe_browsing').value;
+-      if (prefValue === SafeBrowsingSetting.ENHANCED) {
+-        this.$.safeBrowsingEnhanced.expanded = true;
+-      } else if (prefValue === SafeBrowsingSetting.STANDARD) {
+-        this.$.safeBrowsingStandard.expanded = true;
+-      }
+-
+-      this.safeBrowsingStateOnOpen_ = prefValue;
+-
+       // The HTTPS-First Mode generated pref should never be set to
+       // ENABLED_BALANCED if the feature flag is not enabled.
+       if (!loadTimeData.getBoolean('enableHttpsFirstModeNewSettings')) {
+@@ -266,10 +255,6 @@ export class SettingsSecurityPageElement
+       }
+     });
+ 
+-    this.registerHelpBubble(
+-        'kEnhancedProtectionSettingElementId',
+-        this.$.safeBrowsingEnhanced.getBubbleAnchor(), {anchorPaddingTop: 10});
+-
+     // Initialize the last focus time on page load.
+     this.lastFocusTime_ = HatsBrowserProxyImpl.getInstance().now();
+ 
+@@ -409,8 +394,7 @@ export class SettingsSecurityPageElement
+   }
+ 
+   private getDisabledExtendedSafeBrowsing_(): boolean {
+-    return this.getPref('generated.safe_browsing').value !==
+-        SafeBrowsingSetting.STANDARD;
++    return true;
+   }
+ 
+   private getSafeBrowsingStandardSubLabel_(): string {
+@@ -422,19 +406,6 @@ export class SettingsSecurityPageElement
+ 
+   private getPasswordsLeakToggleSubLabel_(): string {
+     let subLabel = this.i18n('passwordsLeakDetectionGeneralDescription');
+-    // If the backing password leak detection preference is enabled, but the
+-    // generated preference is off and user control is disabled, then additional
+-    // text explaining that the feature will be enabled if the user signs in is
+-    // added.
+-    if (this.prefs !== undefined) {
+-      const generatedPref = this.getPref('generated.password_leak_detection');
+-      if (this.getPref('profile.password_manager_leak_detection').value &&
+-          !generatedPref.value && generatedPref.userControlDisabled) {
+-        subLabel +=
+-            ' ' +  // Whitespace is a valid sentence separator w.r.t. i18n.
+-            this.i18n('passwordsLeakDetectionSignedOutEnabledDescription');
+-      }
+-    }
+     return subLabel;
+   }
+ 
+--- a/chrome/browser/resources/settings/site_settings/site_settings_page.ts
++++ b/chrome/browser/resources/settings/site_settings/site_settings_page.ts
+@@ -61,7 +61,7 @@ function getCategoryItemMap(): Map<Conte
+       enabledLabel: 'siteSettingsAdsAllowed',
+       disabledLabel: 'siteSettingsAdsBlocked',
+       shouldShow: () =>
+-          loadTimeData.getBoolean('enableSafeBrowsingSubresourceFilter'),
++          false,
+     },
+     {
+       route: routes.SITE_SETTINGS_AUTO_VERIFY,
+--- a/chrome/browser/safe_browsing/advanced_protection_status_manager_desktop.cc
++++ b/chrome/browser/safe_browsing/advanced_protection_status_manager_desktop.cc
+@@ -15,7 +15,6 @@
+ #include "chrome/browser/signin/identity_manager_factory.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/safebrowsing_switches.h"
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+@@ -71,9 +70,7 @@ void AdvancedProtectionStatusManagerDesk
+   RecordStartupUma(is_under_advanced_protection_);
+   NotifyObserversStatusChanged();
+ 
+-  if (pref_service_->HasPrefPath(prefs::kAdvancedProtectionLastRefreshInUs)) {
+-    last_refreshed_ = base::Time::FromDeltaSinceWindowsEpoch(base::Microseconds(
+-        pref_service_->GetInt64(prefs::kAdvancedProtectionLastRefreshInUs)));
++  if (false) {
+     if (is_under_advanced_protection_) {
+       ScheduleNextRefresh();
+     }
+@@ -95,16 +92,7 @@ AdvancedProtectionStatusManagerDesktop::
+     ~AdvancedProtectionStatusManagerDesktop() = default;
+ 
+ bool AdvancedProtectionStatusManagerDesktop::IsUnderAdvancedProtection() const {
+-  if (!pref_service_->GetBoolean(prefs::kAdvancedProtectionAllowed)) {
+     return false;
+-  }
+-
+-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+-          switches::kForceTreatUserAsAdvancedProtection)) {
+-    return true;
+-  }
+-
+-  return is_under_advanced_protection_;
+ }
+ 
+ void AdvancedProtectionStatusManagerDesktop::
+@@ -260,10 +248,6 @@ void AdvancedProtectionStatusManagerDesk
+ }
+ 
+ void AdvancedProtectionStatusManagerDesktop::UpdateLastRefreshTime() {
+-  last_refreshed_ = base::Time::Now();
+-  pref_service_->SetInt64(
+-      prefs::kAdvancedProtectionLastRefreshInUs,
+-      last_refreshed_.ToDeltaSinceWindowsEpoch().InMicroseconds());
+ }
+ 
+ bool AdvancedProtectionStatusManagerDesktop::IsUnconsentedPrimaryAccount(
+--- a/chrome/browser/safe_browsing/advanced_protection_status_manager_unittest.cc
++++ b/chrome/browser/safe_browsing/advanced_protection_status_manager_unittest.cc
+@@ -8,7 +8,6 @@
+ #include "base/test/task_environment.h"
+ #include "build/build_config.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/safebrowsing_switches.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/signin/public/identity_manager/identity_test_environment.h"
+--- a/chrome/browser/safe_browsing/android/services_delegate_android.h
++++ b/chrome/browser/safe_browsing/android/services_delegate_android.h
+@@ -6,7 +6,6 @@
+ #define CHROME_BROWSER_SAFE_BROWSING_ANDROID_SERVICES_DELEGATE_ANDROID_H_
+ 
+ #include "chrome/browser/safe_browsing/services_delegate.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ namespace safe_browsing {
+ 
+--- a/chrome/browser/safe_browsing/chrome_password_protection_service.cc
++++ b/chrome/browser/safe_browsing/chrome_password_protection_service.cc
+@@ -76,7 +76,6 @@
+ #include "components/safe_browsing/core/browser/verdict_cache_manager.h"
+ #include "components/safe_browsing/core/common/features.h"
+ #include "components/safe_browsing/core/common/proto/csd.pb.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/safebrowsing_constants.h"
+ #include "components/safe_browsing/core/common/utils.h"
+ #include "components/security_interstitials/core/unsafe_resource.h"
+@@ -1417,14 +1416,6 @@ bool ChromePasswordProtectionService::Ha
+ }
+ 
+ void ChromePasswordProtectionService::OnWarningTriggerChanged() {
+-  const base::Value& pref_value = pref_change_registrar_->prefs()->GetValue(
+-      prefs::kPasswordProtectionWarningTrigger);
+-  // If password protection is not turned off, do nothing.
+-  if (static_cast<PasswordProtectionTrigger>(pref_value.GetInt()) !=
+-      PASSWORD_PROTECTION_OFF) {
+-    return;
+-  }
+-
+   // Clears captured enterprise password hashes or GSuite sync password hashes.
+   password_manager::PasswordReuseManager* reuse_manager =
+       GetPasswordReuseManager();
+@@ -1600,7 +1591,7 @@ PrefService* ChromePasswordProtectionSer
+ }
+ 
+ bool ChromePasswordProtectionService::IsSafeBrowsingEnabled() {
+-  return ::safe_browsing::IsSafeBrowsingEnabled(*GetPrefs());
++  return false;
+ }
+ 
+ bool ChromePasswordProtectionService::IsExtendedReporting() {
+@@ -1620,54 +1611,7 @@ bool ChromePasswordProtectionService::Is
+ bool ChromePasswordProtectionService::IsPingingEnabled(
+     LoginReputationClientRequest::TriggerType trigger_type,
+     ReusedPasswordAccountType password_type) {
+-  if (!IsSafeBrowsingEnabled()) {
+     return false;
+-  }
+-  bool extended_reporting_enabled = IsExtendedReporting();
+-  if (trigger_type == LoginReputationClientRequest::PASSWORD_REUSE_EVENT ||
+-      trigger_type ==
+-          LoginReputationClientRequest::ONE_TIME_PASSWORD_FIELD_DETECTED) {
+-    // Don't send a ping if the password protection setting is off
+-    if (GetPasswordProtectionWarningTriggerPref(password_type) ==
+-        PASSWORD_PROTECTION_OFF) {
+-      return false;
+-    }
+-    // Don't send a ping if in password alert mode.
+-    if (IsInPasswordAlertMode(password_type)) {
+-      return false;
+-    }
+-    // If the account type is UNKNOWN (i.e. AccountInfo fields could not be
+-    // retrieved from server) and it's not an OTP ping, a phishy verdict will
+-    // not be acted on. Therefore any ping sent would be a pure telemetry ping.
+-    // Such pings should be gated by SBER.
+-    if (password_type.account_type() == ReusedPasswordAccountType::UNKNOWN &&
+-        trigger_type !=
+-            LoginReputationClientRequest::ONE_TIME_PASSWORD_FIELD_DETECTED) {
+-      return extended_reporting_enabled;
+-    }
+-
+-// Only saved password reuse, GAIA password reuse, and OTP field detection can
+-// result in enforcement for Android users. Therefore, other types of password
+-// reuse events should be gated by Safe Browsing extended reporting because
+-// phishy verdicts won't be enforced making the pings telemetry-only.
+-#if BUILDFLAG(IS_ANDROID)
+-    if (password_type.account_type() ==
+-            ReusedPasswordAccountType::SAVED_PASSWORD ||
+-        password_type.account_type() == ReusedPasswordAccountType::GMAIL ||
+-        trigger_type ==
+-            LoginReputationClientRequest::ONE_TIME_PASSWORD_FIELD_DETECTED) {
+-      return true;
+-    }
+-
+-    return extended_reporting_enabled;
+-#else
+-    return true;
+-#endif
+-  }
+-  // Since it's possible that on-focus pings could trigger for many visited
+-  // pages, don't send the ping when a SBER user is in Incognito to reduce data
+-  // sent to Google.
+-  return !IsIncognito() && extended_reporting_enabled;
+ }
+ 
+ RequestOutcome ChromePasswordProtectionService::GetPingNotSentReason(
+@@ -1910,23 +1854,6 @@ MaybeCreateCommitDeferringCondition(
+              : nullptr;
+ }
+ 
+-PasswordProtectionTrigger
+-ChromePasswordProtectionService::GetPasswordProtectionWarningTriggerPref(
+-    ReusedPasswordAccountType password_type) const {
+-  bool is_policy_managed = profile_->GetPrefs()->HasPrefPath(
+-      prefs::kPasswordProtectionWarningTrigger);
+-  PasswordProtectionTrigger trigger_level =
+-      static_cast<PasswordProtectionTrigger>(profile_->GetPrefs()->GetInteger(
+-          prefs::kPasswordProtectionWarningTrigger));
+-  if (is_policy_managed && trigger_level == PASSWORD_PROTECTION_OFF) {
+-    return PASSWORD_PROTECTION_OFF;
+-  }
+-  if (password_type.account_type() == ReusedPasswordAccountType::GMAIL) {
+-    return PHISHING_REUSE;
+-  }
+-  return is_policy_managed ? trigger_level : PHISHING_REUSE;
+-}
+-
+ bool ChromePasswordProtectionService::IsURLAllowlistedForPasswordEntry(
+     const GURL& url) const {
+   if (!profile_)
+--- a/chrome/browser/safe_browsing/chrome_password_protection_service.h
++++ b/chrome/browser/safe_browsing/chrome_password_protection_service.h
+@@ -226,13 +226,6 @@ class ChromePasswordProtectionService
+   bool UserClickedThroughSBInterstitial(
+       PasswordProtectionRequest* request) override;
+ 
+-  // If |prefs::kPasswordProtectionWarningTrigger| is not managed by enterprise
+-  // policy, this function should always return PHISHING_REUSE. Otherwise,
+-  // returns the specified pref value adjusted for the given username's account
+-  // type.
+-  PasswordProtectionTrigger GetPasswordProtectionWarningTriggerPref(
+-      ReusedPasswordAccountType password_type) const override;
+-
+   // If |url| matches Safe Browsing allowlist domains, password protection
+   // change password URL, or password protection login URLs in the enterprise
+   // policy.
+--- a/chrome/browser/safe_browsing/chrome_password_protection_service_browsertest.cc
++++ b/chrome/browser/safe_browsing/chrome_password_protection_service_browsertest.cc
+@@ -44,7 +44,6 @@
+ #include "components/safe_browsing/content/browser/password_protection/password_protection_request_content.h"
+ #include "components/safe_browsing/content/browser/password_protection/password_protection_test_util.h"
+ #include "components/safe_browsing/core/browser/password_protection/metrics_util.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/security_state/content/security_state_tab_helper.h"
+ #include "components/security_state/core/security_state.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+--- a/chrome/browser/safe_browsing/chrome_password_protection_service_sync_browsertest.cc
++++ b/chrome/browser/safe_browsing/chrome_password_protection_service_sync_browsertest.cc
+@@ -27,10 +27,8 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/prefs/scoped_user_pref_update.h"
+ #include "components/safe_browsing/content/browser/password_protection/password_protection_request_content.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/security_state/content/security_state_tab_helper.h"
+ #include "components/security_state/core/security_state.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/signin/public/identity_manager/identity_test_utils.h"
+ #include "components/sync/service/sync_service.h"
+--- a/chrome/browser/safe_browsing/download_protection/check_client_download_request.cc
++++ b/chrome/browser/safe_browsing/download_protection/check_client_download_request.cc
+@@ -36,7 +36,6 @@
+ #include "components/safe_browsing/content/common/file_type_policies.h"
+ #include "components/safe_browsing/core/common/features.h"
+ #include "components/safe_browsing/core/common/proto/csd.pb.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/utils.h"
+ #include "components/url_matcher/url_matcher.h"
+ #include "content/public/browser/browser_context.h"
+--- a/chrome/browser/safe_browsing/download_protection/check_client_download_request_base.cc
++++ b/chrome/browser/safe_browsing/download_protection/check_client_download_request_base.cc
+@@ -25,7 +25,6 @@
+ #include "components/safe_browsing/content/browser/web_ui/web_ui_content_info_singleton.h"
+ #include "components/safe_browsing/content/common/file_type_policies.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/utils.h"
+ #include "content/public/browser/browser_context.h"
+ #include "content/public/browser/browser_task_traits.h"
+--- a/chrome/browser/safe_browsing/download_protection/download_protection_service_unittest.cc
++++ b/chrome/browser/safe_browsing/download_protection/download_protection_service_unittest.cc
+@@ -101,7 +101,6 @@
+ #include "components/safe_browsing/core/browser/db/v4_protocol_manager_util.h"
+ #include "components/safe_browsing/core/common/features.h"
+ #include "components/safe_browsing/core/common/proto/csd.pb.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/safebrowsing_switches.h"
+ #include "components/signin/public/identity_manager/identity_test_environment.h"
+ #include "content/public/browser/browser_task_traits.h"
+--- a/chrome/browser/safe_browsing/incident_reporting/extension_data_collection_unittest.cc
++++ b/chrome/browser/safe_browsing/incident_reporting/extension_data_collection_unittest.cc
+@@ -20,7 +20,6 @@
+ #include "chrome/test/base/testing_profile.h"
+ #include "chrome/test/base/testing_profile_manager.h"
+ #include "components/safe_browsing/core/common/proto/csd.pb.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/sync_preferences/testing_pref_service_syncable.h"
+ #include "content/public/test/browser_task_environment.h"
+ #include "content/public/test/test_utils.h"
+--- a/chrome/browser/safe_browsing/incident_reporting/incident_reporting_service.cc
++++ b/chrome/browser/safe_browsing/incident_reporting/incident_reporting_service.cc
+@@ -40,7 +40,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/safe_browsing/core/common/features.h"
+ #include "components/safe_browsing/core/common/proto/csd.pb.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "content/public/browser/download_item_utils.h"
+ #include "services/network/public/cpp/shared_url_loader_factory.h"
+--- a/chrome/browser/safe_browsing/incident_reporting/incident_reporting_service_unittest.cc
++++ b/chrome/browser/safe_browsing/incident_reporting/incident_reporting_service_unittest.cc
+@@ -34,7 +34,6 @@
+ #include "chrome/test/base/testing_profile.h"
+ #include "chrome/test/base/testing_profile_manager.h"
+ #include "components/safe_browsing/core/common/proto/csd.pb.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/sync_preferences/testing_pref_service_syncable.h"
+ #include "content/public/test/browser_task_environment.h"
+ #include "extensions/browser/quota_service.h"
+--- a/chrome/browser/safe_browsing/incident_reporting/last_download_finder_unittest.cc
++++ b/chrome/browser/safe_browsing/incident_reporting/last_download_finder_unittest.cc
+@@ -42,7 +42,6 @@
+ #include "components/history/core/browser/history_database_params.h"
+ #include "components/history/core/browser/history_service.h"
+ #include "components/safe_browsing/core/common/proto/csd.pb.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/sync_preferences/testing_pref_service_syncable.h"
+ #include "content/public/browser/download_manager.h"
+ #include "content/public/test/browser_task_environment.h"
+--- a/chrome/browser/safe_browsing/incident_reporting/state_store.cc
++++ b/chrome/browser/safe_browsing/incident_reporting/state_store.cc
+@@ -13,7 +13,6 @@
+ #include "chrome/browser/safe_browsing/incident_reporting/incident.h"
+ #include "chrome/browser/safe_browsing/incident_reporting/platform_state_store.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ namespace safe_browsing {
+ 
+--- a/chrome/browser/safe_browsing/incident_reporting/state_store_unittest.cc
++++ b/chrome/browser/safe_browsing/incident_reporting/state_store_unittest.cc
+@@ -22,7 +22,6 @@
+ #include "chrome/test/base/testing_profile_manager.h"
+ #include "components/pref_registry/pref_registry_syncable.h"
+ #include "components/prefs/in_memory_pref_store.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/sync_preferences/pref_service_syncable.h"
+ #include "components/sync_preferences/pref_service_syncable_factory.h"
+ #include "content/public/test/browser_task_environment.h"
+--- a/chrome/browser/safe_browsing/metrics/safe_browsing_metrics_provider.cc
++++ b/chrome/browser/safe_browsing/metrics/safe_browsing_metrics_provider.cc
+@@ -7,7 +7,6 @@
+ #include "base/metrics/histogram_functions.h"
+ #include "chrome/browser/profiles/profile.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ namespace safe_browsing {
+ 
+--- a/chrome/browser/safe_browsing/safe_browsing_blocking_page_test.cc
++++ b/chrome/browser/safe_browsing/safe_browsing_blocking_page_test.cc
+@@ -93,7 +93,6 @@
+ #include "components/safe_browsing/core/browser/verdict_cache_manager.h"
+ #include "components/safe_browsing/core/common/features.h"
+ #include "components/safe_browsing/core/common/hashprefix_realtime/hash_realtime_utils.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/web_ui_constants.h"
+ #include "components/security_interstitials/content/security_interstitial_controller_client.h"
+ #include "components/security_interstitials/content/security_interstitial_tab_helper.h"
+--- a/chrome/browser/safe_browsing/safe_browsing_service.cc
++++ b/chrome/browser/safe_browsing/safe_browsing_service.cc
+@@ -338,7 +338,6 @@ bool SafeBrowsingServiceImpl::IsUserElig
+ 
+ SafeBrowsingServiceImpl::SafeBrowsingServiceImpl()
+     : services_delegate_(ServicesDelegate::Create(this)),
+-      estimated_extended_reporting_by_prefs_(SBER_LEVEL_OFF),
+       shutdown_(false),
+       enabled_(false),
+       enabled_by_prefs_(false) {}
+@@ -480,9 +479,6 @@ TriggerManager* SafeBrowsingServiceImpl:
+ 
+ PasswordProtectionService*
+ SafeBrowsingServiceImpl::GetPasswordProtectionService(Profile* profile) const {
+-  if (IsSafeBrowsingEnabled(*profile->GetPrefs())) {
+-    return ChromePasswordProtectionServiceFactory::GetForProfile(profile);
+-  }
+   return nullptr;
+ }
+ 
+@@ -583,9 +579,6 @@ void SafeBrowsingServiceImpl::OnProfileA
+   std::unique_ptr<PrefChangeRegistrar> registrar =
+       std::make_unique<PrefChangeRegistrar>();
+   registrar->Init(pref_service);
+-  registrar->Add(prefs::kSafeBrowsingEnabled,
+-                 base::BindRepeating(&SafeBrowsingServiceImpl::RefreshState,
+-                                     base::Unretained(this)));
+   // ClientSideDetectionService will need to be refresh the models
+   // renderers have if extended-reporting changes.
+   registrar->Add(prefs::kSafeBrowsingScoutReportingEnabled,
+@@ -629,14 +622,6 @@ void SafeBrowsingServiceImpl::OnProfileA
+                           NoCachedPopulationReason::kChangeMbbPref));
+   user_population_prefs_[pref_service] = std::move(user_population_registrar);
+ 
+-  // Record the current pref state for standard protection.
+-  UMA_HISTOGRAM_BOOLEAN(kSafeBrowsingEnabledHistogramName,
+-                        pref_service->GetBoolean(prefs::kSafeBrowsingEnabled));
+-  // Record the current pref state for enhanced protection. Enhanced protection
+-  // is a subset of the standard protection. Thus, |kSafeBrowsingEnabled| count
+-  // should always be more than the count of enhanced protection.
+-  UMA_HISTOGRAM_BOOLEAN("SafeBrowsing.Pref.Enhanced",
+-                        pref_service->GetBoolean(prefs::kSafeBrowsingEnhanced));
+ 
+   // Record the current enhanced protection pref state and JS Optimizer setting
+   // for regular profiles only
+@@ -798,18 +783,6 @@ void SafeBrowsingServiceImpl::RefreshSta
+ 
+   // Check if any profile requires the service to be active.
+   enabled_by_prefs_ = false;
+-  estimated_extended_reporting_by_prefs_ = SBER_LEVEL_OFF;
+-  for (const auto& pref : prefs_map_) {
+-    if (IsSafeBrowsingEnabled(*pref.first)) {
+-      enabled_by_prefs_ = true;
+-
+-      ExtendedReportingLevel erl =
+-          safe_browsing::GetExtendedReportingLevel(*pref.first);
+-      if (erl != SBER_LEVEL_OFF) {
+-        estimated_extended_reporting_by_prefs_ = erl;
+-      }
+-    }
+-  }
+ 
+   if (enabled_by_prefs_) {
+     Start();
+--- a/chrome/browser/safe_browsing/safe_browsing_service.h
++++ b/chrome/browser/safe_browsing/safe_browsing_service.h
+@@ -28,7 +28,6 @@
+ #include "components/safe_browsing/content/browser/safe_browsing_service_interface.h"
+ #include "components/safe_browsing/core/browser/db/util.h"
+ #include "components/safe_browsing/core/common/proto/csd.pb.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "content/public/browser/browser_context.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "services/network/public/cpp/shared_url_loader_factory.h"
+@@ -108,15 +107,6 @@ class SafeBrowsingServiceImpl : public S
+   // Called on the main thread to let us know that the io_thread is going away.
+   void ShutDown();
+ 
+-  // NOTE(vakh): This is not the most reliable way to find out if extended
+-  // reporting has been enabled. That's why it starts with estimated_. It
+-  // returns true if any of the profiles have extended reporting enabled. It may
+-  // be called on any thread. That can lead to a race condition, but that's
+-  // acceptable.
+-  ExtendedReportingLevel estimated_extended_reporting_by_prefs() const {
+-    return estimated_extended_reporting_by_prefs_;
+-  }
+-
+   // Get current enabled status. Must be called on IO thread.
+   bool enabled() const {
+     DCHECK_CURRENTLY_ON(content::BrowserThread::IO);
+@@ -401,10 +391,6 @@ class SafeBrowsingServiceImpl : public S
+ 
+   std::unique_ptr<ProxyConfigMonitor> proxy_config_monitor_;
+ 
+-  // Whether SafeBrowsing Extended Reporting is enabled by the current set of
+-  // profiles. Updated on the UI thread.
+-  ExtendedReportingLevel estimated_extended_reporting_by_prefs_;
+-
+   // Whether the service has been shutdown.
+   bool shutdown_;
+ 
+--- a/chrome/browser/safe_browsing/telemetry/android/android_telemetry_service.cc
++++ b/chrome/browser/safe_browsing/telemetry/android/android_telemetry_service.cc
+@@ -30,7 +30,6 @@
+ #include "components/safe_browsing/core/browser/db/database_manager.h"
+ #include "components/safe_browsing/core/browser/ping_manager.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "content/public/browser/browser_task_traits.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "content/public/browser/download_item_utils.h"
+@@ -137,11 +136,9 @@ bool AndroidTelemetryService::CanSendPin
+     return false;
+   }
+ 
+-  if (!IsSafeBrowsingEnabled(*GetPrefs())) {
+-    RecordApkDownloadTelemetryOutcome(
+-        ApkDownloadTelemetryOutcome::NOT_SENT_SAFE_BROWSING_NOT_ENABLED);
+-    return false;
+-  }
++  RecordApkDownloadTelemetryOutcome(
++      ApkDownloadTelemetryOutcome::NOT_SENT_SAFE_BROWSING_NOT_ENABLED);
++  return false;
+ 
+   if (profile_->IsOffTheRecord()) {
+     RecordApkDownloadTelemetryOutcome(
+--- a/chrome/browser/safe_browsing/telemetry/android/android_telemetry_service_unittest.cc
++++ b/chrome/browser/safe_browsing/telemetry/android/android_telemetry_service_unittest.cc
+@@ -21,7 +21,6 @@
+ #include "components/safe_browsing/android/safe_browsing_api_handler_bridge.h"
+ #include "components/safe_browsing/android/safe_browsing_api_handler_util.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "content/public/browser/browser_task_traits.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "content/public/browser/download_item_utils.h"
+--- a/chrome/browser/safe_browsing/url_checker_delegate_impl.cc
++++ b/chrome/browser/safe_browsing/url_checker_delegate_impl.cc
+@@ -23,7 +23,6 @@
+ #include "components/safe_browsing/core/browser/db/database_manager.h"
+ #include "components/safe_browsing/core/browser/db/v4_protocol_manager_util.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "content/public/browser/browser_task_traits.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "content/public/browser/navigation_entry.h"
+--- a/chrome/browser/signin/account_consistency_mode_manager.cc
++++ b/chrome/browser/signin/account_consistency_mode_manager.cc
+@@ -24,7 +24,6 @@
+ #include "components/pref_registry/pref_registry_syncable.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/public/base/signin_buildflags.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "google_apis/google_api_keys.h"
+ 
+ #if BUILDFLAG(IS_CHROMEOS)
+@@ -95,13 +94,9 @@ signin::AccountConsistencyMethod Compute
+ #if BUILDFLAG(ENABLE_MIRROR)
+   return AccountConsistencyMethod::kMirror;
+ #elif BUILDFLAG(ENABLE_DICE_SUPPORT)
+-  if (!profile->GetPrefs()->GetBoolean(prefs::kSigninAllowed)) {
+     VLOG(1) << "Desktop Identity Consistency disabled as sign-in to Chrome "
+                "is not allowed";
+     return AccountConsistencyMethod::kDisabled;
+-  }
+-
+-  return AccountConsistencyMethod::kDice;
+ #else
+   NOTREACHED();
+ #endif
+@@ -119,21 +114,6 @@ AccountConsistencyModeManager::AccountCo
+                           ->GetProfileAttributesStorage()
+                           .GetProfileAttributesWithPath(profile_->GetPath())
+                     : nullptr;
+-  PrefService* prefs = profile_->GetPrefs();
+-  // Propagate settings changes from the previous launch to the signin-allowed
+-  // pref.
+-  bool signin_allowed = IsDiceSignInAllowed(entry) &&
+-                        prefs->GetBoolean(prefs::kSigninAllowedOnNextStartup);
+-
+-  // Disable sign-in if experimental-ai is enabled, regardless of channel.
+-  auto* command_line = base::CommandLine::ForCurrentProcess();
+-  if (command_line->HasSwitch(::switches::kExperimentalAiStableChannel)) {
+-    signin_allowed = false;
+-  }
+-
+-  prefs->SetBoolean(prefs::kSigninAllowed, signin_allowed);
+-
+-  UMA_HISTOGRAM_BOOLEAN("Signin.SigninAllowed", signin_allowed);
+ #endif
+ 
+   account_consistency_ = ComputeAccountConsistencyMethod(profile_);
+@@ -146,7 +126,6 @@ AccountConsistencyModeManager::~AccountC
+ // static
+ void AccountConsistencyModeManager::RegisterProfilePrefs(
+     user_prefs::PrefRegistrySyncable* registry) {
+-  registry->RegisterBooleanPref(prefs::kSigninAllowedOnNextStartup, true);
+ }
+ 
+ // static
+--- a/chrome/browser/signin/account_consistency_mode_manager_unittest.cc
++++ b/chrome/browser/signin/account_consistency_mode_manager_unittest.cc
+@@ -19,7 +19,6 @@
+ #include "components/prefs/testing_pref_store.h"
+ #include "components/signin/public/base/account_consistency_method.h"
+ #include "components/signin/public/base/signin_buildflags.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/sync_preferences/testing_pref_service_syncable.h"
+ #include "content/public/test/browser_task_environment.h"
+ #include "testing/gtest/include/gtest/gtest.h"
+--- a/chrome/browser/signin/accounts_policy_manager.cc
++++ b/chrome/browser/signin/accounts_policy_manager.cc
+@@ -41,7 +41,6 @@
+ #include "components/profile_metrics/browser_profile_type.h"
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/signin/public/identity_manager/accounts_mutator.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+@@ -212,25 +211,11 @@ void AccountsPolicyManager::Initialize()
+   EnsurePrimaryAccountAllowedForProfile(
+       profile_, signin_metrics::ProfileSignout::kSigninNotAllowedOnProfileInit);
+ 
+-  signin_allowed_.Init(
+-      prefs::kSigninAllowed, profile_->GetPrefs(),
+-      base::BindRepeating(&AccountsPolicyManager::OnSigninAllowedPrefChanged,
+-                          weak_pointer_factory_.GetWeakPtr()));
+-
+   local_state_pref_registrar_.Init(g_browser_process->local_state());
+-  local_state_pref_registrar_.Add(
+-      prefs::kGoogleServicesUsernamePattern,
+-      base::BindRepeating(
+-          &AccountsPolicyManager::OnGoogleServicesUsernamePatternChanged,
+-          weak_pointer_factory_.GetWeakPtr()));
+ 
+   auto* identity_manager = IdentityManagerFactory::GetForProfile(profile_);
+   identity_manager_observation_.Observe(identity_manager);
+   profile_pref_change_registrar_.Init(profile_->GetPrefs());
+-  profile_pref_change_registrar_.Add(
+-      prefs::kProfileSeparationDomainExceptionList,
+-      base::BindRepeating(&AccountsPolicyManager::RemoveUnallowedAccounts,
+-                          weak_pointer_factory_.GetWeakPtr()));
+   if (identity_manager->AreRefreshTokensLoaded()) {
+     OnRefreshTokensLoaded();
+   }
+@@ -239,7 +224,6 @@ void AccountsPolicyManager::Initialize()
+ void AccountsPolicyManager::Shutdown() {
+   profile_pref_change_registrar_.RemoveAll();
+   local_state_pref_registrar_.RemoveAll();
+-  signin_allowed_.Destroy();
+ }
+ 
+ void AccountsPolicyManager::OnGoogleServicesUsernamePatternChanged() {
+@@ -319,9 +303,7 @@ void AccountsPolicyManager::EnsurePrimar
+           << ", ProfileSignoutSource="
+           << static_cast<int>(clear_primary_account_source)
+           << ", signin.allowed preference="
+-          << profile->GetPrefs()->GetBoolean(prefs::kSigninAllowed)
+           << " (managed="
+-          << profile->GetPrefs()->IsManagedPreference(prefs::kSigninAllowed)
+           << "), SigninLevel=" << signin_level << ", ProfileType="
+           << static_cast<int>(profile_metrics::GetBrowserProfileType(profile));
+       LOG(WARNING) << base::debug::StackTrace().ToString();
+--- a/chrome/browser/signin/accounts_policy_manager.h
++++ b/chrome/browser/signin/accounts_policy_manager.h
+@@ -67,9 +67,6 @@ class AccountsPolicyManager : public Key
+ 
+   raw_ptr<Profile> profile_;
+ 
+-  // Helper object to listen for changes to the signin allowed preference.
+-  BooleanPrefMember signin_allowed_;
+-
+   // Helper object to listen for changes to signin preferences stored in non-
+   // profile-specific local prefs (like kGoogleServicesUsernamePattern).
+   PrefChangeRegistrar local_state_pref_registrar_;
+--- a/chrome/browser/signin/bound_session_credentials/bound_session_cookie_refresh_service_factory.cc
++++ b/chrome/browser/signin/bound_session_credentials/bound_session_cookie_refresh_service_factory.cc
+@@ -20,7 +20,6 @@
+ #include "chrome/browser/signin/bound_session_credentials/unexportable_key_service_factory.h"
+ #include "components/pref_registry/pref_registry_syncable.h"
+ #include "components/signin/public/base/account_consistency_method.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "content/public/browser/network_service_instance.h"
+ 
+@@ -111,7 +110,4 @@ BoundSessionCookieRefreshServiceFactory:
+ void BoundSessionCookieRefreshServiceFactory::RegisterProfilePrefs(
+     user_prefs::PrefRegistrySyncable* registry) {
+   BoundSessionParamsStorage::RegisterProfilePrefs(registry);
+-  // Default value for this pref doesn't matter since it is only used when
+-  // explicitly set.
+-  registry->RegisterBooleanPref(prefs::kBoundSessionCredentialsEnabled, false);
+ }
+--- a/chrome/browser/signin/chrome_device_id_helper.cc
++++ b/chrome/browser/signin/chrome_device_id_helper.cc
+@@ -18,7 +18,6 @@
+ #include "chrome/browser/ash/profiles/profile_helper.h"
+ #include "chrome/browser/browser_process.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/user_manager/known_user.h"
+ #include "components/user_manager/user_manager.h"
+@@ -87,21 +86,11 @@ void MigrateSigninScopedDeviceId(Profile
+   user_manager::KnownUser known_user(g_browser_process->local_state());
+   const AccountId account_id = user->GetAccountId();
+   if (known_user.GetDeviceId(account_id).empty()) {
+-    const std::string legacy_device_id = profile->GetPrefs()->GetString(
+-        prefs::kGoogleServicesSigninScopedDeviceId);
+-    if (!legacy_device_id.empty()) {
+-      // Need to move device ID from the old location to the new one, if it has
+-      // not been done yet.
+-      known_user.SetDeviceId(account_id, legacy_device_id);
+-    } else {
+-      known_user.SetDeviceId(
+-          account_id, GenerateSigninScopedDeviceId(
+-                          user_manager::UserManager::Get()
+-                              ->IsUserNonCryptohomeDataEphemeral(account_id)));
+-    }
++    known_user.SetDeviceId(
++        account_id, GenerateSigninScopedDeviceId(
++                        user_manager::UserManager::Get()
++                            ->IsUserNonCryptohomeDataEphemeral(account_id)));
+   }
+-  profile->GetPrefs()->SetString(prefs::kGoogleServicesSigninScopedDeviceId,
+-                                 std::string());
+ }
+ 
+ #endif  // BUILDFLAG(IS_CHROMEOS)
+--- a/chrome/browser/signin/chrome_signin_client.cc
++++ b/chrome/browser/signin/chrome_signin_client.cc
+@@ -50,7 +50,6 @@
+ #include "components/signin/public/base/signin_buildflags.h"
+ #include "components/signin/public/base/signin_client.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_prefs.h"
+ #include "components/signin/public/identity_manager/access_token_info.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+--- a/chrome/browser/signin/chromeos_mirror_account_consistency_browsertest.cc
++++ b/chrome/browser/signin/chromeos_mirror_account_consistency_browsertest.cc
+@@ -17,7 +17,6 @@
+ #include "components/policy/core/common/policy_pref_names.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/core/browser/signin_header_helper.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/identity_test_utils.h"
+ #include "components/supervised_user/core/browser/supervised_user_preferences.h"
+ #include "components/user_manager/user.h"
+--- a/chrome/browser/signin/dice_browsertest.cc
++++ b/chrome/browser/signin/dice_browsertest.cc
+@@ -86,7 +86,6 @@
+ #include "components/signin/public/base/signin_buildflags.h"
+ #include "components/signin/public/base/signin_client.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_prefs.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_capabilities_test_mutator.h"
+--- a/chrome/browser/signin/dice_signed_in_profile_creator.cc
++++ b/chrome/browser/signin/dice_signed_in_profile_creator.cc
+@@ -20,7 +20,6 @@
+ #include "chrome/browser/signin/identity_manager_factory.h"
+ #include "chrome/browser/signin/signin_util.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/accounts_mutator.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "content/public/browser/storage_partition.h"
+--- a/chrome/browser/signin/dice_web_signin_interceptor.cc
++++ b/chrome/browser/signin/dice_web_signin_interceptor.cc
+@@ -82,7 +82,6 @@
+ #include "components/search_engines/template_url_service.h"
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_prefs.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_capabilities.h"
+@@ -421,16 +420,8 @@ void DiceWebSigninInterceptor::RegisterP
+   registry->RegisterBooleanPref(prefs::kSigninInterceptionEnabled, true);
+   registry->RegisterStringPref(prefs::kManagedAccountsSigninRestriction,
+                                std::string());
+-  registry->RegisterStringPref(prefs::kSigninInterceptionIDPCookiesUrl,
+-                               std::string());
+   registry->RegisterBooleanPref(
+       prefs::kManagedAccountsSigninRestrictionScopeMachine, false);
+-  registry->RegisterIntegerPref(prefs::kProfileSeparationSettings, 0);
+-  registry->RegisterIntegerPref(prefs::kProfileSeparationDataMigrationSettings,
+-                                1);
+-  registry->RegisterListPref(prefs::kProfileSeparationDomainExceptionList);
+-  registry->RegisterStringPref(
+-      prefs::kUserCloudSigninPolicyResponseFromPolicyTestPage, std::string());
+ }
+ 
+ std::optional<SigninInterceptionHeuristicOutcome>
+@@ -1570,16 +1561,6 @@ void DiceWebSigninInterceptor::
+           g_browser_process->browser_policy_connector(),
+           g_browser_process->system_network_context_manager()
+               ->GetSharedURLLoaderFactory());
+-  state_->account_level_signin_restriction_policy_fetcher_
+-      ->GetManagedAccountsSigninRestriction(
+-          identity_manager_, account_info.account_id, std::move(callback),
+-          policy::utils::IsPolicyTestingEnabled(profile_->GetPrefs(),
+-                                                chrome::GetChannel())
+-              ? profile_->GetPrefs()
+-                    ->GetDefaultPrefValue(
+-                        prefs::kUserCloudSigninPolicyResponseFromPolicyTestPage)
+-                    ->GetString()
+-              : std::string());
+ }
+ 
+ void DiceWebSigninInterceptor::
+--- a/chrome/browser/signin/header_modification_delegate_impl.cc
++++ b/chrome/browser/signin/header_modification_delegate_impl.cc
+@@ -17,7 +17,6 @@
+ #include "chrome/browser/sync/sync_service_factory.h"
+ #include "components/policy/core/common/policy_pref_names.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+@@ -228,7 +227,7 @@ void HeaderModificationDelegateImpl::Pro
+       // the sync feature is enabled, which in particular triggers a
+       // confirmation web page on signout.
+       sync_service && sync_service->IsSyncFeatureEnabled(),
+-      prefs->GetString(prefs::kGoogleServicesSigninScopedDeviceId),
++      std::string(),
+ #endif
+       cookie_settings_.get());
+ }
+--- a/chrome/browser/signin/mirror_browsertest.cc
++++ b/chrome/browser/signin/mirror_browsertest.cc
+@@ -32,7 +32,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/core/browser/dice_header_helper.h"
+ #include "components/signin/core/browser/signin_header_helper.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "content/public/common/content_client.h"
+ #include "content/public/test/browser_test.h"
+ #include "google_apis/gaia/gaia_urls.h"
+--- a/chrome/browser/signin/signin_promo.cc
++++ b/chrome/browser/signin/signin_promo.cc
+@@ -21,7 +21,6 @@
+ #include "components/pref_registry/pref_registry_syncable.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/sync/base/features.h"
+ #include "content/public/browser/browser_context.h"
+@@ -221,12 +220,6 @@ void RegisterProfilePrefs(
+ 
+   // Signin promo limits experiment prefs.
+   registry->RegisterIntegerPref(
+-      prefs::kAddressSignInPromoShownCountPerProfileForLimitsExperiment, 0);
+-  registry->RegisterIntegerPref(
+-      prefs::kBookmarkSignInPromoShownCountPerProfileForLimitsExperiment, 0);
+-  registry->RegisterIntegerPref(
+-      prefs::kPasswordSignInPromoShownCountPerProfileForLimitsExperiment, 0);
+-  registry->RegisterIntegerPref(
+       prefs::kAddressSignInPromoDismissCountPerProfileForLimitsExperiment, 0);
+   registry->RegisterIntegerPref(
+       prefs::kPasswordSignInPromoDismissCountPerProfileForLimitsExperiment, 0);
+--- a/chrome/browser/signin/signin_promo_util.cc
++++ b/chrome/browser/signin/signin_promo_util.cc
+@@ -27,7 +27,6 @@
+ #include "components/prefs/scoped_user_pref_update.h"
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/signin/public/identity_manager/primary_account_mutator.h"
+@@ -317,21 +316,7 @@ bool IsAllowedByPromoFrequency(Profile&
+ }
+ 
+ bool WasPreviouslySyncingWithPrimaryAccount(Profile* profile) {
+-  const GaiaId last_syncing_gaia_id(
+-      profile->GetPrefs()->GetString(prefs::kGoogleServicesLastSyncingGaiaId));
+-  if (last_syncing_gaia_id.empty()) {
+     return false;
+-  }
+-
+-  const GaiaId primary_account_gaia_id =
+-      IdentityManagerFactory::GetForProfile(profile)
+-          ->GetPrimaryAccountInfo(ConsentLevel::kSignin)
+-          .gaia;
+-  if (primary_account_gaia_id.empty()) {
+-    return false;
+-  }
+-
+-  return last_syncing_gaia_id == primary_account_gaia_id;
+ }
+ 
+ ProfileMenuAvatarButtonPromoInfo
+@@ -424,49 +409,19 @@ bool PromoTypeHasSyncableData(SignInProm
+ }
+ 
+ int GetAddressPromoShownCount(Profile& profile, const GaiaId& gaia_id) {
+-  if (!gaia_id.empty()) {
+-    return SigninPrefs(*profile.GetPrefs())
+-        .GetAddressSigninPromoImpressionCount(gaia_id);
+-  }
+-
+-  return profile.GetPrefs()->GetInteger(
+-      base::FeatureList::IsEnabled(switches::kSigninPromoLimitsExperiment)
+-          ? prefs::kAddressSignInPromoShownCountPerProfileForLimitsExperiment
+-          : prefs::kAddressSignInPromoShownCountPerProfile);
++  return 0;
+ }
+ 
+ int GetPasswordPromoShownCount(Profile& profile, const GaiaId& gaia_id) {
+-  if (!gaia_id.empty()) {
+-    return SigninPrefs(*profile.GetPrefs())
+-        .GetPasswordSigninPromoImpressionCount(gaia_id);
+-  }
+-
+-  return profile.GetPrefs()->GetInteger(
+-      base::FeatureList::IsEnabled(switches::kSigninPromoLimitsExperiment)
+-          ? prefs::kPasswordSignInPromoShownCountPerProfileForLimitsExperiment
+-          : prefs::kPasswordSignInPromoShownCountPerProfile);
++  return 0;
+ }
+ 
+ int GetSearchAIModePromoShownCount(Profile& profile, const GaiaId& gaia_id) {
+-  if (!gaia_id.empty()) {
+-    return SigninPrefs(*profile.GetPrefs())
+-        .GetSearchAIModeSigninPromoImpressionCount(gaia_id);
+-  }
+-
+-  return profile.GetPrefs()->GetInteger(
+-      prefs::kSearchAIModeSignInPromoShownCountPerProfile);
++  return 0;
+ }
+ 
+ int GetBookmarkPromoShownCount(Profile& profile, const GaiaId& gaia_id) {
+-  if (!gaia_id.empty()) {
+-    return SigninPrefs(*profile.GetPrefs())
+-        .GetBookmarkSigninPromoImpressionCount(gaia_id);
+-  }
+-
+-  return profile.GetPrefs()->GetInteger(
+-      base::FeatureList::IsEnabled(switches::kSigninPromoLimitsExperiment)
+-          ? prefs::kBookmarkSignInPromoShownCountPerProfileForLimitsExperiment
+-          : prefs::kBookmarkSignInPromoShownCountPerProfile);
++  return 0;
+ }
+ 
+ int GetContextualPromoDismissCountPerSignedOutProfile(Profile& profile,
+@@ -613,60 +568,7 @@ bool CanShowPromoForSyncableDataType(Sig
+ // Needs additional checks depending on the type of the promo.
+ // `profile` is the profile of the tab the promo would be shown on.
+ bool ShouldShowSignInPromoCommon(Profile& profile, SignInPromoType type) {
+-  if (profile.IsOffTheRecord()) {
+-    return false;
+-  }
+-
+-  // Don't bother if we don't have any kind of network connection.
+-  if (net::NetworkChangeNotifier::IsOffline()) {
+     return false;
+-  }
+-
+-  // Consider original profile even if an off-the-record profile was
+-  // passed to this method as sign-in state is only defined for the
+-  // primary profile.
+-  Profile* original_profile = profile.GetOriginalProfile();
+-
+-  // Don't show for supervised child profiles.
+-  if (original_profile->IsChild()) {
+-    return false;
+-  }
+-
+-  signin::IdentityManager* identity_manager =
+-      IdentityManagerFactory::GetForProfile(original_profile);
+-  AccountInfo promo_account =
+-      signin_ui_util::GetSingleAccountForPromos(identity_manager);
+-
+-  // Don't show if sign in can't be offered (ex: signin disallowed).
+-  if (!CanOfferSignin(original_profile, promo_account.gaia, promo_account.email,
+-                      /*allow_account_from_other_profile=*/true)
+-           .IsOk()) {
+-    return false;
+-  }
+-
+-  if (PromoTypeHasSyncableData(type) &&
+-      !CanShowPromoForSyncableDataType(type, profile)) {
+-    return false;
+-  }
+-
+-  SignedInState signed_in_state = signin_util::GetSignedInState(
+-      IdentityManagerFactory::GetForProfile(&profile));
+-
+-  switch (signed_in_state) {
+-    case signin_util::SignedInState::kSignedIn:
+-    case signin_util::SignedInState::kSyncing:
+-    case signin_util::SignedInState::kSyncPaused:
+-      // Don't show the promo if the user is already signed in or syncing.
+-      return false;
+-    case signin_util::SignedInState::kSignInPending:
+-      // Always show the promo in sign in pending state.
+-      return true;
+-    case signin_util::SignedInState::kSignedOut:
+-    case signin_util::SignedInState::kWebOnlySignedIn:
+-      break;
+-  }
+-
+-  return ShouldShowPromoBasedOnImpressionOrDismissalCount(profile, type);
+ }
+ 
+ #endif  // BUILDFLAG(ENABLE_DICE_SUPPORT)
+@@ -676,32 +578,7 @@ bool ShouldShowSignInPromoCommon(Profile
+ #if BUILDFLAG(ENABLE_EXTENSIONS)
+ bool ShouldShowExtensionSignInPromo(Profile& profile,
+                                     const extensions::Extension& extension) {
+-#if BUILDFLAG(ENABLE_DICE_SUPPORT)
+-  if (!extensions::sync_util::ShouldSync(&profile, &extension)) {
+-    return false;
+-  }
+-
+-  if (!base::FeatureList::IsEnabled(syncer::kUnoPhase2FollowUp)) {
+-    // `ShouldShowSignInPromoCommon()` does not check if extensions are syncing
+-    // in transport mode. That's why `IsSyncingExtensionsEnabled()` is added so
+-    // the sign in promo is not shown in that case.
+-    if (extensions::sync_util::IsSyncingExtensionsEnabled(&profile)) {
+-      return false;
+-    }
+-
+-    if (const signin::IdentityManager* identity_manager =
+-            IdentityManagerFactory::GetForProfile(&profile);
+-        identity_manager->HasPrimaryAccount(signin::ConsentLevel::kSignin)) {
+-      // The promo is not shown to users that have explicitly signed in through
+-      // the browser (even if extensions are not syncing).
+-      return false;
+-    }
+-  }
+-
+-  return ShouldShowSignInPromoCommon(profile, SignInPromoType::kExtension);
+-#else
+   return false;
+-#endif  // BUILDFLAG(ENABLE_DICE_SUPPORT)
+ }
+ #endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+ 
+@@ -740,30 +617,7 @@ bool ShouldShowSearchAIModeSignInPromo(P
+ }
+ 
+ bool ShouldShowBookmarkSignInPromo(Profile& profile) {
+-#if BUILDFLAG(ENABLE_DICE_SUPPORT)
+-  if (!ShouldShowSignInPromoCommon(profile, SignInPromoType::kBookmark)) {
+-    return false;
+-  }
+-
+-  // At this point, both the identity manager and sync service should not be
+-  // null.
+-  IdentityManager* identity_manager =
+-      IdentityManagerFactory::GetForProfile(&profile);
+-  syncer::SyncService* sync_service =
+-      SyncServiceFactory::GetForProfile(&profile);
+-  CHECK(identity_manager);
+-  CHECK(sync_service);
+-
+-  // If the user is in sign in pending state, the promo should only be shown if
+-  // they already have account storage for bookmarks enabled.
+-  // Uno Phase 2 Follow up: Always display the promotion.
+-  return base::FeatureList::IsEnabled(syncer::kUnoPhase2FollowUp) ||
+-         !signin_util::IsSigninPending(identity_manager) ||
+-         sync_service->GetUserSettings()->GetSelectedTypes().Has(
+-             syncer::UserSelectableType::kBookmarks);
+-#else
+   return false;
+-#endif  // BUILDFLAG(ENABLE_DICE_SUPPORT)
+ }
+ 
+ bool IsBubbleSigninPromo(signin_metrics::AccessPoint access_point) {
+@@ -824,83 +678,6 @@ SignInPromoType GetSignInPromoTypeFromAc
+ #if BUILDFLAG(ENABLE_DICE_SUPPORT)
+ void RecordSignInPromoShown(signin_metrics::AccessPoint access_point,
+                             Profile* profile) {
+-  CHECK(profile);
+-  CHECK(!profile->IsOffTheRecord());
+-
+-  AccountInfo account = signin_ui_util::GetSingleAccountForPromos(
+-      IdentityManagerFactory::GetForProfile(profile));
+-  SignInPromoType promo_type = GetSignInPromoTypeFromAccessPoint(access_point);
+-
+-  // Record the pref per profile if there is no account present.
+-  if (account.gaia.empty()) {
+-    const char* pref_name;
+-    switch (promo_type) {
+-      case SignInPromoType::kPassword:
+-        pref_name =
+-            base::FeatureList::IsEnabled(switches::kSigninPromoLimitsExperiment)
+-                ? prefs::
+-                      kPasswordSignInPromoShownCountPerProfileForLimitsExperiment
+-                : prefs::kPasswordSignInPromoShownCountPerProfile;
+-        break;
+-      case SignInPromoType::kAddress:
+-        pref_name =
+-            base::FeatureList::IsEnabled(switches::kSigninPromoLimitsExperiment)
+-                ? prefs::
+-                      kAddressSignInPromoShownCountPerProfileForLimitsExperiment
+-                : prefs::kAddressSignInPromoShownCountPerProfile;
+-        break;
+-      case SignInPromoType::kSearchAIMode:
+-        pref_name = prefs::kSearchAIModeSignInPromoShownCountPerProfile;
+-        profile->GetPrefs()->SetTime(
+-            prefs::kSearchAIModeSignInPromoLastImpressionTimestampPerProfile,
+-            base::Time::Now());
+-        break;
+-      case SignInPromoType::kBookmark:
+-        if (!base::FeatureList::IsEnabled(syncer::kUnoPhase2FollowUp)) {
+-          return;
+-        }
+-        pref_name =
+-            base::FeatureList::IsEnabled(switches::kSigninPromoLimitsExperiment)
+-                ? prefs::
+-                      kBookmarkSignInPromoShownCountPerProfileForLimitsExperiment
+-                : prefs::kBookmarkSignInPromoShownCountPerProfile;
+-        break;
+-      case SignInPromoType::kExtension:
+-        return;
+-    }
+-
+-    int show_count = profile->GetPrefs()->GetInteger(pref_name);
+-    profile->GetPrefs()->SetInteger(pref_name, show_count + 1);
+-    return;
+-  }
+-
+-  // Record the pref for the account that was used for the promo, either because
+-  // it is signed into the web or in sign in pending state.
+-  switch (promo_type) {
+-    case SignInPromoType::kPassword:
+-      SigninPrefs(*profile->GetPrefs())
+-          .IncrementPasswordSigninPromoImpressionCount(account.gaia);
+-      return;
+-    case SignInPromoType::kAddress:
+-      SigninPrefs(*profile->GetPrefs())
+-          .IncrementAddressSigninPromoImpressionCount(account.gaia);
+-      return;
+-    case SignInPromoType::kSearchAIMode:
+-      SigninPrefs(*profile->GetPrefs())
+-          .IncrementSearchAIModeSigninPromoImpressionCount(account.gaia);
+-      SigninPrefs(*profile->GetPrefs())
+-          .SetSearchAIModeSigninPromoLastImpressionTime(account.gaia,
+-                                                        base::Time::Now());
+-      return;
+-    case SignInPromoType::kBookmark:
+-      if (base::FeatureList::IsEnabled(syncer::kUnoPhase2FollowUp)) {
+-        SigninPrefs(*profile->GetPrefs())
+-            .IncrementBookmarkSigninPromoImpressionCount(account.gaia);
+-      }
+-      return;
+-    case SignInPromoType::kExtension:
+-      return;
+-  }
+ }
+ 
+ bool ShouldUseAutofillSignInPromoLimits(signin::SignInPromoType promo_type) {
+--- a/chrome/browser/signin/signin_ui_util.cc
++++ b/chrome/browser/signin/signin_ui_util.cc
+@@ -42,7 +42,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/signin/public/identity_manager/accounts_in_cookie_jar_info.h"
+--- a/chrome/browser/signin/signin_util.cc
++++ b/chrome/browser/signin/signin_util.cc
+@@ -33,7 +33,6 @@
+ #include "components/policy/core/browser/signin/profile_separation_policies.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/core/browser/account_reconcilor.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_managed_status_finder.h"
+ #include "components/signin/public/identity_manager/accounts_mutator.h"
+@@ -89,8 +88,7 @@ ScopedForceSigninSetterForTesting::~Scop
+ CookiesMover::CookiesMover(base::WeakPtr<Profile> source_profile,
+                            base::WeakPtr<Profile> destination_profile,
+                            base::OnceCallback<void()> callback)
+-    : url_(source_profile->GetPrefs()->GetString(
+-          prefs::kSigninInterceptionIDPCookiesUrl)),
++    : url_(std::string()),
+       source_profile_(std::move(source_profile)),
+       destination_profile_(std::move(destination_profile)),
+       callback_(std::move(callback)) {
+@@ -100,25 +98,7 @@ CookiesMover::CookiesMover(base::WeakPtr
+ CookiesMover::~CookiesMover() = default;
+ 
+ void CookiesMover::StartMovingCookies() {
+-#if BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
+-  bool allow_cookies_to_be_moved = base::FeatureList::IsEnabled(
+-      profile_management::features::kThirdPartyProfileManagement);
+-#else
+-  bool allow_cookies_to_be_moved = false;
+-#endif
+-  if (!allow_cookies_to_be_moved || url_.is_empty() || !url_.is_valid()) {
+     std::move(callback_).Run();
+-    return;
+-  }
+-
+-  source_profile_->GetPrefs()->ClearPref(
+-      prefs::kSigninInterceptionIDPCookiesUrl);
+-  source_profile_->GetDefaultStoragePartition()
+-      ->GetCookieManagerForBrowserProcess()
+-      ->GetCookieList(url_, net::CookieOptions::MakeAllInclusive(),
+-                      net::CookiePartitionKeyCollection::Todo(),
+-                      base::BindOnce(&CookiesMover::OnCookiesReceived,
+-                                     weak_pointer_factory_.GetWeakPtr()));
+ }
+ 
+ void CookiesMover::OnCookiesReceived(
+@@ -259,16 +239,7 @@ bool ProfileSeparationAllowsKeepingUnman
+ bool IsAccountExemptedFromEnterpriseProfileSeparation(
+     Profile* profile,
+     const std::string& email) {
+-  if (profile->GetPrefs()
+-          ->FindPreference(prefs::kProfileSeparationDomainExceptionList)
+-          ->IsDefaultValue()) {
+     return true;
+-  }
+-
+-  const std::string domain = gaia::ExtractDomainName(email);
+-  const auto& allowed_domains = profile->GetPrefs()->GetList(
+-      prefs::kProfileSeparationDomainExceptionList);
+-  return allowed_domains.contains(domain);
+ }
+ #endif  // !BUILDFLAG(IS_CHROMEOS)
+ 
+@@ -568,57 +539,7 @@ bool IsValidAccessPointForHistoryOptinSc
+ }
+ 
+ bool ShouldShowAvatarSyncPromo(Profile* profile) {
+-  CHECK(switches::IsAvatarSyncPromoFeatureEnabled());
+-
+-  // Do not show the promo for users that are not signed in. (E.g. Signed out,
+-  // Signin Pending or already syncing).
+-  if (GetSignedInState(IdentityManagerFactory::GetForProfile(profile)) !=
+-      signin_util::SignedInState::kSignedIn) {
+-    return false;
+-  }
+-
+-  // SyncService should be usable.
+-  syncer::SyncService* sync_service =
+-      SyncServiceFactory::GetForProfile(profile);
+-  if (!sync_service) {
+-    return false;
+-  }
+-  if (sync_service->HasDisableReason(
+-          syncer::SyncService::DISABLE_REASON_ENTERPRISE_POLICY)) {
+-    return false;
+-  }
+-
+-  signin::IdentityManager* identity_manager =
+-      IdentityManagerFactory::GetForProfile(profile);
+-  CHECK(identity_manager->AreRefreshTokensLoaded());
+-  AccountInfo account_info = identity_manager->FindExtendedAccountInfo(
+-      identity_manager->GetPrimaryAccountInfo(signin::ConsentLevel::kSignin));
+-  // Do not show the promo for non signed in accounts, or managed accounts.
+-  if (account_info.IsEmpty() ||
+-      account_info.IsManaged() != signin::Tribool::kFalse) {
+     return false;
+-  }
+-
+-  // Do not show the promo if there was a previously syncing account that does
+-  // not match the currently signed in one.
+-  PrefService* pref_service = profile->GetPrefs();
+-  GaiaId previously_syncing_gaia_id =
+-      GaiaId(pref_service->GetString(prefs::kGoogleServicesLastSyncingGaiaId));
+-  if (IsCrossAccountError(profile, account_info.gaia)) {
+-    return false;
+-  }
+-
+-  // Do not show the promo for users that have been signed for a short period of
+-  // time.
+-  const base::Time last_changed = base::Time::FromSecondsSinceUnixEpoch(
+-      pref_service->GetDouble(prefs::kGaiaCookieChangedTime));
+-  if (last_changed.is_null() ||
+-      (base::Time::Now() - last_changed <
+-       switches::GetAvatarSyncPromoFeatureMinimumCookeAgeParam())) {
+-    return false;
+-  }
+-
+-  return true;
+ }
+ 
+ void ShowErrorDialogWithMessage(Browser* browser, int error_message_id) {
+--- a/chrome/browser/signin/signin_util_win.cc
++++ b/chrome/browser/signin/signin_util_win.cc
+@@ -42,7 +42,6 @@
+ #include "components/signin/core/browser/about_signin_internals.h"
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/accounts_mutator.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/signin/public/identity_manager/primary_account_mutator.h"
+@@ -211,9 +210,6 @@ void ImportCredentialsFromProvider(Profi
+                                        account_id, profile));
+     }
+   }
+-
+-  // Mark this profile as having been signed in with the credential provider.
+-  profile->GetPrefs()->SetBoolean(prefs::kSignedInWithCredentialProvider, true);
+ }
+ 
+ // Extracts the |cred_provider_gaia_id| and |cred_provider_email| for the user
+@@ -390,18 +386,7 @@ bool ReauthWithCredentialProviderIfPossi
+   //  - The profile is marked as having been signed in with a system credential.
+   //  - The profile is already signed in.
+   //  - The profile is in an auth error state.
+-  auto* identity_manager = IdentityManagerFactory::GetForProfile(profile);
+-  if (!(profile->GetPrefs()->GetBoolean(
+-            prefs::kSignedInWithCredentialProvider) &&
+-        identity_manager->HasPrimaryAccount(GetConsentLevel()) &&
+-        identity_manager->HasAccountWithRefreshTokenInPersistentErrorState(
+-            identity_manager->GetPrimaryAccountId(GetConsentLevel())))) {
+     return false;
+-  }
+-
+-  const GaiaId gaia_id =
+-      identity_manager->GetPrimaryAccountInfo(GetConsentLevel()).gaia;
+-  return TrySigninWithCredentialProvider(profile, gaia_id, /*is_reauth=*/true);
+ }
+ 
+ }  // namespace signin_util
+--- a/chrome/browser/signin/signin_util_win_browsertest.cc
++++ b/chrome/browser/signin/signin_util_win_browsertest.cc
+@@ -45,7 +45,6 @@
+ #include "components/keep_alive_registry/keep_alive_types.h"
+ #include "components/keep_alive_registry/scoped_keep_alive.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/signin/public/identity_manager/identity_test_utils.h"
+ #include "components/signin/public/identity_manager/primary_account_mutator.h"
+--- a/chrome/browser/site_protection/site_familiarity_utils.cc
++++ b/chrome/browser/site_protection/site_familiarity_utils.cc
+@@ -12,7 +12,6 @@
+ #include "components/content_settings/core/common/features.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/search_engines/template_url_service.h"
+ #include "content/public/browser/render_frame_host.h"
+ #include "content/public/browser/render_process_host.h"
+--- a/chrome/browser/ssl/sct_reporting_service.cc
++++ b/chrome/browser/ssl/sct_reporting_service.cc
+@@ -18,7 +18,6 @@
+ #include "chrome/common/chrome_features.h"
+ #include "chrome/common/pref_names.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "content/public/browser/network_service_instance.h"
+ #include "content/public/browser/storage_partition.h"
+ #include "google_apis/google_api_keys.h"
+@@ -215,22 +214,6 @@ SCTReportingService::SCTReportingService
+ SCTReportingService::~SCTReportingService() = default;
+ 
+ network::mojom::SCTAuditingMode SCTReportingService::GetReportingMode() {
+-  bool is_sct_auditing_enabled = false;
+-#if !BUILDFLAG(IS_ANDROID)
+-  is_sct_auditing_enabled =
+-      SystemNetworkContextManager::IsCertificateTransparencyEnabled();
+-#endif
+-  if (profile_->IsOffTheRecord() || !is_sct_auditing_enabled) {
+-    return network::mojom::SCTAuditingMode::kDisabled;
+-  }
+-  if (safe_browsing::IsSafeBrowsingEnabled(*pref_service_)) {
+-    if (safe_browsing::IsExtendedReportingEnabled(*pref_service_)) {
+-      return network::mojom::SCTAuditingMode::kEnhancedSafeBrowsingReporting;
+-    }
+-    if (base::FeatureList::IsEnabled(features::kSCTAuditingHashdance)) {
+-      return network::mojom::SCTAuditingMode::kHashdance;
+-    }
+-  }
+   return network::mojom::SCTAuditingMode::kDisabled;
+ }
+ 
+--- a/chrome/browser/ssl/ssl_browsertest.cc
++++ b/chrome/browser/ssl/ssl_browsertest.cc
+@@ -99,7 +99,6 @@
+ #include "components/policy/policy_constants.h"
+ #include "components/prefs/testing_pref_service.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/security_interstitials/content/bad_clock_blocking_page.h"
+ #include "components/security_interstitials/content/captive_portal_blocking_page.h"
+ #include "components/security_interstitials/content/common_name_mismatch_handler.h"
+--- a/chrome/browser/ssl/ssl_error_controller_client.cc
++++ b/chrome/browser/ssl/ssl_error_controller_client.cc
+@@ -20,7 +20,6 @@
+ #include "chrome/browser/ssl/stateful_ssl_host_state_delegate_factory.h"
+ #include "chrome/common/pref_names.h"
+ #include "chrome/common/url_constants.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/security_interstitials/content/content_metrics_helper.h"
+ #include "components/security_interstitials/content/settings_page_helper.h"
+ #include "components/security_interstitials/content/stateful_ssl_host_state_delegate.h"
+--- a/chrome/browser/ui/autofill/payments/save_card_bubble_controller_impl.cc
++++ b/chrome/browser/ui/autofill/payments/save_card_bubble_controller_impl.cc
+@@ -49,7 +49,6 @@
+ #include "components/autofill/core/common/autofill_constants.h"
+ #include "components/autofill/core/common/autofill_payments_features.h"
+ #include "components/signin/public/base/signin_buildflags.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/strings/grit/components_strings.h"
+ #include "components/sync/service/sync_service.h"
+--- a/chrome/browser/ui/browser_command_controller.cc
++++ b/chrome/browser/ui/browser_command_controller.cc
+@@ -115,7 +115,6 @@
+ #include "components/sessions/core/tab_restore_service.h"
+ #include "components/signin/public/base/signin_buildflags.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/translate/core/browser/translate_manager.h"
+ #include "content/public/browser/navigation_controller.h"
+--- a/chrome/browser/ui/browser_command_controller_unittest.cc
++++ b/chrome/browser/ui/browser_command_controller_unittest.cc
+@@ -37,7 +37,6 @@
+ #include "components/input/native_web_keyboard_event.h"
+ #include "components/performance_manager/public/features.h"
+ #include "components/policy/core/common/policy_pref_names.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "content/public/test/web_contents_tester.h"
+ #include "extensions/buildflags/buildflags.h"
+ #include "ui/events/keycodes/dom/dom_code.h"
+--- a/chrome/browser/ui/chrome_pages.cc
++++ b/chrome/browser/ui/chrome_pages.cc
+@@ -82,7 +82,6 @@
+ #if !BUILDFLAG(IS_ANDROID)
+ #include "base/metrics/histogram_functions.h"
+ #include "chrome/browser/signin/identity_manager_factory.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #endif
+ 
+--- a/chrome/browser/ui/extensions/extension_post_install_dialog_model.cc
++++ b/chrome/browser/ui/extensions/extension_post_install_dialog_model.cc
+@@ -14,7 +14,6 @@
+ #include "chrome/grit/branded_strings.h"
+ #include "chrome/grit/generated_resources.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "extensions/buildflags/buildflags.h"
+ #include "extensions/common/api/extension_action/action_info.h"
+ #include "extensions/common/command.h"
+--- a/chrome/browser/ui/hats/trust_safety_sentiment_service.cc
++++ b/chrome/browser/ui/hats/trust_safety_sentiment_service.cc
+@@ -30,8 +30,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/privacy_sandbox/privacy_sandbox_prefs.h"
+ #include "components/safe_browsing/core/browser/db/v4_protocol_manager_util.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/unified_consent/pref_names.h"
+ #include "components/version_info/channel.h"
+ 
+@@ -77,9 +75,6 @@ bool HasNonDefaultPrivacySetting(Profile
+   auto* prefs = profile->GetPrefs();
+ 
+   std::vector<std::string> prefs_to_check = {
+-      prefs::kSafeBrowsingEnabled,
+-      prefs::kSafeBrowsingEnhanced,
+-      prefs::kSafeBrowsingScoutReportingEnabled,
+       prefs::kEnableDoNotTrack,
+       password_manager::prefs::kPasswordLeakDetectionEnabled,
+       prefs::kCookieControlsMode,
+@@ -97,13 +92,9 @@ bool HasNonDefaultPrivacySetting(Profile
+   // Users consenting to sync automatically enable UKM collection
+   auto* ukm_pref = prefs->FindPreference(
+       unified_consent::prefs::kUrlKeyedAnonymizedDataCollectionEnabled);
+-  auto* sync_consent_pref =
+-      prefs->FindPreference(prefs::kGoogleServicesConsentedToSync);
+ 
+   bool has_non_default_ukm =
+-      ukm_pref->GetValue()->GetBool() !=
+-          sync_consent_pref->GetValue()->GetBool() &&
+-      (ukm_pref->IsUserControlled() || sync_consent_pref->IsUserControlled());
++      ukm_pref->GetValue()->GetBool() != false && ukm_pref->IsUserControlled();
+ 
+   // Check the default value for each user facing content setting. Note that
+   // this will not include content setting exceptions set via permission
+@@ -176,8 +167,6 @@ std::map<std::string, bool> BuildProduct
+     PasswordProtectionUIType ui_type,
+     PasswordProtectionUIAction action) {
+   std::map<std::string, bool> product_specific_data;
+-  product_specific_data["Enhanced protection enabled"] =
+-      safe_browsing::IsEnhancedProtectionEnabled(*profile->GetPrefs());
+   product_specific_data["Is page info UI"] = false;
+   product_specific_data["Is modal dialog UI"] = false;
+   product_specific_data["Is interstitial UI"] = false;
+@@ -439,31 +428,12 @@ void TrustSafetySentimentService::Finish
+ void TrustSafetySentimentService::InteractedWithSafeBrowsingInterstitial(
+     bool did_proceed,
+     safe_browsing::SBThreatType threat_type) {
+-  std::map<std::string, bool> product_specific_data;
+-  product_specific_data["User proceeded past interstitial"] = did_proceed;
+-  product_specific_data["Enhanced protection enabled"] =
+-      safe_browsing::IsEnhancedProtectionEnabled(*profile_->GetPrefs());
+-  product_specific_data["Threat is phishing"] =
+-      threat_type == safe_browsing::SBThreatType::SB_THREAT_TYPE_URL_PHISHING ||
+-      threat_type ==
+-          safe_browsing::SBThreatType::SB_THREAT_TYPE_URL_CLIENT_SIDE_PHISHING;
+-  product_specific_data["Threat is malware"] =
+-      threat_type == safe_browsing::SBThreatType::SB_THREAT_TYPE_URL_MALWARE;
+-  product_specific_data["Threat is unwanted software"] =
+-      threat_type == safe_browsing::SBThreatType::SB_THREAT_TYPE_URL_UNWANTED;
+-  product_specific_data["Threat is billing"] =
+-      threat_type == safe_browsing::SBThreatType::SB_THREAT_TYPE_BILLING;
+-  DCHECK(!IsOtherSBInterstitialCategory(threat_type));
+-  TriggerOccurred(FeatureArea::kSafeBrowsingInterstitial,
+-                  product_specific_data);
+ }
+ 
+ void TrustSafetySentimentService::InteractedWithDownloadWarningUI(
+     DownloadItemWarningData::WarningSurface surface,
+     DownloadItemWarningData::WarningAction action) {
+   std::map<std::string, bool> product_specific_data;
+-  product_specific_data["Enhanced protection enabled"] =
+-      safe_browsing::IsEnhancedProtectionEnabled(*profile_->GetPrefs());
+   product_specific_data["Is mainpage UI"] = false;
+   product_specific_data["Is downloads page UI"] = false;
+   product_specific_data["Is download prompt UI"] = false;
+--- a/chrome/browser/ui/safety_hub/menu_notification_service.cc
++++ b/chrome/browser/ui/safety_hub/menu_notification_service.cc
+@@ -21,7 +21,6 @@
+ #include "chrome/browser/ui/safety_hub/safety_hub_service.h"
+ #include "chrome/common/chrome_features.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ #if BUILDFLAG(IS_ANDROID)
+ #include "chrome/browser/ui/safety_hub/password_status_check_result_android.h"
+@@ -144,14 +143,6 @@ SafetyHubMenuNotificationService::Safety
+       stored_notifications);
+ #endif  // !BUILDFLAG(IS_ANDROID)
+ 
+-  // Listen for changes to the Safe Browsing pref to accommodate the trigger
+-  // logic.
+-  registrar_.Init(pref_service);
+-  registrar_.Add(
+-      prefs::kSafeBrowsingEnabled,
+-      base::BindRepeating(
+-          &SafetyHubMenuNotificationService::OnSafeBrowsingPrefUpdate,
+-          base::Unretained(this)));
+ }
+ 
+ void SafetyHubMenuNotificationService::UpdateResultGetterForTesting(
+--- a/chrome/browser/ui/safety_hub/safe_browsing_result.cc
++++ b/chrome/browser/ui/safety_hub/safe_browsing_result.cc
+@@ -12,7 +12,6 @@
+ #include "chrome/browser/ui/safety_hub/safety_hub_result.h"
+ #include "chrome/grit/generated_resources.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "ui/base/l10n/l10n_util.h"
+ 
+ #if !BUILDFLAG(IS_ANDROID)
+@@ -54,18 +53,6 @@ SafetyHubSafeBrowsingResult::GetResult(c
+ // static
+ SafeBrowsingState SafetyHubSafeBrowsingResult::GetState(
+     const PrefService* pref_service) {
+-  if (safe_browsing::IsEnhancedProtectionEnabled(*pref_service)) {
+-    return SafeBrowsingState::kEnabledEnhanced;
+-  }
+-  if (safe_browsing::IsSafeBrowsingEnabled(*pref_service)) {
+-    return SafeBrowsingState::kEnabledStandard;
+-  }
+-  if (safe_browsing::IsSafeBrowsingPolicyManaged(*pref_service)) {
+-    return SafeBrowsingState::kDisabledByAdmin;
+-  }
+-  if (safe_browsing::IsSafeBrowsingExtensionControlled(*pref_service)) {
+-    return SafeBrowsingState::kDisabledByExtension;
+-  }
+   return SafeBrowsingState::kDisabledByUser;
+ }
+ 
+--- a/chrome/browser/ui/signin/dice_migration_service.cc
++++ b/chrome/browser/ui/signin/dice_migration_service.cc
+@@ -18,7 +18,6 @@
+ #include "chrome/browser/ui/toasts/toast_controller.h"
+ #include "components/pref_registry/pref_registry_syncable.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/signin/public/identity_manager/primary_account_mutator.h"
+ 
+@@ -33,36 +32,12 @@ constexpr char kForcedSigninBrowserInsta
+     "Signin.ForcedDiceMigration.BrowserInstanceAvailableAfterTimer";
+ 
+ bool IsUserEligibleForDiceMigration(Profile* profile) {
+-  signin::IdentityManager* identity_manager =
+-      IdentityManagerFactory::GetForProfile(profile);
+-  if (!identity_manager->HasPrimaryAccount(signin::ConsentLevel::kSignin) ||
+-      identity_manager->HasPrimaryAccount(signin::ConsentLevel::kSync)) {
+     // The user is not signed in or has sync enabled.
+     return false;
+-  }
+-
+-  // The user is implicitly signed in.
+-  return !profile->GetPrefs()->GetBoolean(prefs::kExplicitBrowserSignin);
+ }
+ 
+ bool MaybeMigrateUser(Profile* profile) {
+-  if (!IsUserEligibleForDiceMigration(profile)) {
+     return false;
+-  }
+-  PrefService* prefs = profile->GetPrefs();
+-  CHECK(prefs);
+-
+-  // TODO(crbug.com/399838468): Consider calling
+-  // `PrimaryAccountManager::SetExplicitBrowserSigninPrefs` upon explicit signin
+-  // pref change.
+-  prefs->SetBoolean(prefs::kPrefsThemesSearchEnginesAccountStorageEnabled,
+-                    true);
+-
+-  prefs->SetBoolean(prefs::kExplicitBrowserSignin, true);
+-
+-  // Mark the migration pref as successful.
+-  prefs->SetBoolean(kDiceMigrationMigrated, true);
+-  return true;
+ }
+ 
+ bool MaybeShowToast(BrowserWindowInterface* browser) {
+--- a/chrome/browser/ui/signin/signin_view_controller.cc
++++ b/chrome/browser/ui/signin/signin_view_controller.cc
+@@ -35,7 +35,6 @@
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_buildflags.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_prefs.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+@@ -378,14 +377,6 @@ void SigninViewController::SignoutOrReau
+           &SigninViewController::SignoutOrReauthWithPromptWithUnsyncedDataTypes,
+           weak_ptr_factory_.GetWeakPtr(), reauth_access_point,
+           profile_signout_source, token_signout_source);
+-  // Fetch the unsynced datatypes, as this is required to decide whether the
+-  // confirmation prompt is needed.
+-  if (sync_service) {
+-    sync_service->GetTypesWithUnsyncedData(
+-        syncer::TypesRequiringUnsyncedDataCheckOnSignout(),
+-        std::move(signout_prompt_with_datatypes));
+-    return;
+-  }
+   // No sync service pass empty datatypes.
+   std::move(signout_prompt_with_datatypes)
+       .Run(absl::flat_hash_map<syncer::DataType, size_t>());
+--- a/chrome/browser/ui/startup/first_run_service.cc
++++ b/chrome/browser/ui/startup/first_run_service.cc
+@@ -27,7 +27,6 @@
+ #include "components/prefs/pref_registry_simple.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/public/base/consent_level.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+@@ -70,32 +69,7 @@ enum class PolicyEffect {
+ };
+ 
+ PolicyEffect ComputeDevicePolicyEffect(Profile& profile) {
+-  const PrefService* const local_state = g_browser_process->local_state();
+-  if (!local_state->GetBoolean(prefs::kPromotionsEnabled)) {
+-    // Corresponding policy: PromotionsEnabled=false
+     return PolicyEffect::kDisabled;
+-  }
+-
+-  if (!SyncServiceFactory::IsSyncAllowed(&profile)) {
+-    // Corresponding policy: SyncDisabled=true
+-    return PolicyEffect::kDisabled;
+-  }
+-
+-  if (signin_util::IsForceSigninEnabled()) {
+-    // Corresponding policy: BrowserSignin=2
+-    // Debugging note: On Linux this policy is not supported and does not get
+-    // translated to the prefs (see crbug.com/41455343), but we still respond to
+-    // `prefs::kForceBrowserSignin` being set (e.g. if manually edited).
+-    return PolicyEffect::kDisabled;
+-  }
+-
+-  if (!profile.GetPrefs()->GetBoolean(prefs::kSigninAllowed) ||
+-      !profile.GetPrefs()->GetBoolean(prefs::kSigninAllowedOnNextStartup)) {
+-    // Corresponding policy: BrowserSignin=0
+-    return PolicyEffect::kDisabled;
+-  }
+-
+-  return PolicyEffect::kNone;
+ }
+ 
+ void SetFirstRunFinished(FirstRunService::FinishedReason reason) {
+--- a/chrome/browser/ui/toolbar/app_menu_model.cc
++++ b/chrome/browser/ui/toolbar/app_menu_model.cc
+@@ -120,7 +120,6 @@
+ #include "components/profile_metrics/browser_profile_type.h"
+ #include "components/saved_tab_groups/public/features.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/strings/grit/components_strings.h"
+ #include "components/sync/base/features.h"
+@@ -617,105 +616,7 @@ int ProfileSubMenuModel::GetAndIncrement
+ }
+ 
+ bool ProfileSubMenuModel::BuildSyncSection() {
+-#if !BUILDFLAG(IS_CHROMEOS)
+-  // TODO(crbug.com/440342282): Support personalized signin button.
+-  if (!CanOfferSignin(profile_, GaiaId(), /*email=*/std::string(),
+-                      /*allow_account_from_other_profile=*/true)
+-           .IsOk()) {
+     return false;
+-  }
+-#endif  // BUILDFLAG(IS_CHROMEOS)
+-
+-  if (!SyncServiceFactory::IsSyncAllowed(profile_)) {
+-    return false;
+-  }
+-
+-  signin::IdentityManager* identity_manager =
+-      IdentityManagerFactory::GetForProfile(profile_);
+-  AddTitle(GetSyncSectionTitle(profile_, identity_manager));
+-
+-  // First, check for sync errors. They may exist even if sync-the-feature is
+-  // disabled and only sync-the-transport is running.
+-  syncer::SyncService* service = SyncServiceFactory::GetForProfile(profile_);
+-  if (service) {
+-    const syncer::SyncService::UserActionableError error =
+-        service->GetUserActionableError();
+-    if (error != syncer::SyncService::UserActionableError::kNone) {
+-      int command_id = 0;
+-      const gfx::VectorIcon* icon = nullptr;
+-      int button_string_id =
+-          GetSyncErrorButtonStringId(error, /*support_title_case=*/true);
+-      switch (error) {
+-        case syncer::SyncService::UserActionableError::kNone:
+-          NOTREACHED();
+-        case syncer::SyncService::UserActionableError::kSignInNeedsUpdate:
+-          command_id = IDC_SHOW_SIGNIN_WHEN_PAUSED;
+-          if (identity_manager->HasPrimaryAccount(
+-                  signin::ConsentLevel::kSync)) {
+-            button_string_id = IDS_SYNC_RELOGIN_BUTTON_MAYBE_TITLE_CASE;
+-            icon = &vector_icons::kSyncOffChromeRefreshIcon;
+-          } else {
+-            // Merge this case with the others below once ConsentLevel::kSync is
+-            // gone.
+-            icon = &vector_icons::kAccountCircleOffChromeRefreshIcon;
+-          }
+-          break;
+-        case syncer::SyncService::UserActionableError::
+-            kNeedsTrustedVaultKeyForPasswords:
+-        case syncer::SyncService::UserActionableError::
+-            kTrustedVaultRecoverabilityDegradedForPasswords:
+-        case syncer::SyncService::UserActionableError::
+-            kTrustedVaultRecoverabilityDegradedForEverything:
+-        case syncer::SyncService::UserActionableError::
+-            kNeedsTrustedVaultKeyForEverything:
+-          command_id = IDC_SHOW_SIGNIN_WHEN_PAUSED;
+-          icon = &vector_icons::kAccountCircleOffChromeRefreshIcon;
+-          break;
+-        case syncer::SyncService::UserActionableError::kNeedsClientUpgrade:
+-          command_id = IDC_UPGRADE_DIALOG;
+-          icon = &vector_icons::kErrorOutlineIcon;
+-          break;
+-        case syncer::SyncService::UserActionableError::kNeedsPassphrase:
+-          command_id = IDC_SHOW_SYNC_PASSPHRASE_DIALOG;
+-          icon = &vector_icons::kErrorOutlineIcon;
+-          break;
+-        case syncer::SyncService::UserActionableError::
+-            kNeedsSettingsConfirmation:
+-        case syncer::SyncService::UserActionableError::kUnrecoverableError:
+-          // Only shown for "Sync-the-feature".
+-          command_id = IDC_SHOW_SYNC_SETTINGS;
+-          icon = &vector_icons::kErrorOutlineIcon;
+-          break;
+-        case syncer::SyncService::UserActionableError::kBookmarksLimitExceeded:
+-          // For this specific error (as opposed to all others), there is no
+-          // error UI in the menu.
+-          return true;
+-      }
+-      CHECK_NE(command_id, 0);
+-      AddItemWithStringIdAndVectorIcon(this, command_id, button_string_id,
+-                                       *icon);
+-      return true;
+-    }
+-  }
+-
+-  if (identity_manager->HasPrimaryAccount(signin::ConsentLevel::kSync)) {
+-    AddItemWithStringIdAndVectorIcon(this, IDC_SHOW_SYNC_SETTINGS,
+-                                     IDS_PROFILE_ROW_SYNC_IS_ON,
+-                                     vector_icons::kSyncChromeRefreshIcon);
+-  } else {
+-    if (syncer::IsReplaceSyncPromosWithSignInPromosEnabled()) {
+-      if (!identity_manager->HasPrimaryAccount(signin::ConsentLevel::kSignin)) {
+-        AddItemWithStringIdAndVectorIcon(this, IDC_SHOW_SIGNIN,
+-                                         IDS_PROFILE_MENU_SIGNIN_PROMO_BUTTON,
+-                                         vector_icons::kAccountCircleIcon);
+-      }
+-    } else {
+-      AddItemWithStringIdAndVectorIcon(this, IDC_TURN_ON_SYNC,
+-                                       IDS_PROFILE_ROW_TURN_ON_SYNC,
+-                                       vector_icons::kSyncOffChromeRefreshIcon);
+-    }
+-  }
+-  return true;
+ }
+ 
+ void ProfileSubMenuModel::BuildGuestProfileRow(Profile* profile) {
+--- a/chrome/browser/ui/views/download/bubble/download_toolbar_ui_controller.cc
++++ b/chrome/browser/ui/views/download/bubble/download_toolbar_ui_controller.cc
+@@ -51,7 +51,6 @@ DEFINE_USER_DATA(DownloadToolbarUIContro
+ #include "components/feature_engagement/public/feature_constants.h"
+ #include "components/safe_browsing/core/common/features.h"
+ #include "components/safe_browsing/core/common/safe_browsing_policy_handler.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "ui/base/l10n/l10n_util.h"
+ #include "ui/base/metadata/metadata_impl_macros.h"
+--- a/chrome/browser/ui/views/page_info/page_info_bubble_view_sync_browsertest.cc
++++ b/chrome/browser/ui/views/page_info/page_info_bubble_view_sync_browsertest.cc
+@@ -19,7 +19,6 @@
+ #include "components/safe_browsing/content/browser/password_protection/password_protection_test_util.h"
+ #include "components/safe_browsing/core/browser/password_protection/metrics_util.h"
+ #include "components/security_state/content/security_state_tab_helper.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/signin/public/identity_manager/identity_test_utils.h"
+--- a/chrome/browser/ui/views/profiles/avatar_toolbar_button.cc
++++ b/chrome/browser/ui/views/profiles/avatar_toolbar_button.cc
+@@ -55,7 +55,6 @@
+ #include "components/feature_engagement/public/feature_constants.h"
+ #include "components/feature_engagement/public/tracker.h"
+ #include "components/password_manager/content/common/web_ui_constants.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_prefs.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/tribool.h"
+--- a/chrome/browser/ui/views/profiles/avatar_toolbar_button_state_manager.cc
++++ b/chrome/browser/ui/views/profiles/avatar_toolbar_button_state_manager.cc
+@@ -69,7 +69,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_prefs.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+@@ -2581,12 +2580,6 @@ void AvatarToolbarButtonStateManager::Ma
+   PrefService* prefs = profile->GetPrefs();
+   CHECK(prefs);
+ 
+-  // Users who sign in after the migration and users migrated from DICe will be
+-  // notified with other promos communicating sign-in benefits.
+-  if (prefs->GetBoolean(prefs::kPrimaryAccountSetAfterSigninMigration) ||
+-      prefs->GetBoolean(kDiceMigrationMigrated)) {
+-    return;
+-  }
+ 
+   if (show_new_signin && !show_legacy) {
+     auto* const edu_service =
+--- a/chrome/browser/ui/views/profiles/profile_menu_view.cc
++++ b/chrome/browser/ui/views/profiles/profile_menu_view.cc
+@@ -84,7 +84,6 @@
+ #include "components/signin/core/browser/signin_error_controller.h"
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+@@ -1021,9 +1020,7 @@ void ProfileMenuView::MaybeBuildChromeAc
+   // Show the settings button when signed in to Chrome or to the web, or if
+   // signin is disallowed.
+   const bool should_show_settings_button =
+-      !identity_manager->GetExtendedAccountInfoForAccountsWithRefreshToken()
+-           .empty() ||
+-      !profile().GetPrefs()->GetBoolean(prefs::kSigninAllowed);
++      false;
+   if (!should_show_settings_button) {
+     return;
+   }
+@@ -1045,25 +1042,6 @@ void ProfileMenuView::MaybeBuildChromeAc
+ }
+ 
+ void ProfileMenuView::MaybeBuildGoogleServicesSettingsButton() {
+-  CHECK(!profile().IsGuestSession());
+-
+-  signin::IdentityManager* identity_manager =
+-      IdentityManagerFactory::GetForProfile(&profile());
+-
+-  if (!identity_manager) {
+-    return;
+-  }
+-
+-  // Show the services settings button  if signin is disallowed.
+-  if (profile().GetPrefs()->GetBoolean(prefs::kSigninAllowed)) {
+-    return;
+-  }
+-  AddFeatureButton(
+-      l10n_util::GetStringUTF16(IDS_PROFILE_MENU_OPEN_ACCOUNT_SETTINGS),
+-      base::BindRepeating(
+-          &ProfileMenuView::OnGoogleServicesSettingsButtonClicked,
+-          base::Unretained(this)),
+-      vector_icons::kSettingsChromeRefreshIcon);
+ }
+ 
+ void ProfileMenuView::MaybeBuildManageGoogleAccountButton() {
+--- a/chrome/browser/ui/views/profiles/profile_menu_view_browsertest.cc
++++ b/chrome/browser/ui/views/profiles/profile_menu_view_browsertest.cc
+@@ -106,7 +106,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/accounts_in_cookie_jar_info.h"
+ #include "components/signin/public/identity_manager/identity_test_utils.h"
+--- a/chrome/browser/ui/views/safe_browsing/password_reuse_modal_warning_dialog.cc
++++ b/chrome/browser/ui/views/safe_browsing/password_reuse_modal_warning_dialog.cc
+@@ -126,7 +126,6 @@ PasswordReuseModalWarningDialog::Passwor
+     OnWarningDone done_callback)
+     : content::WebContentsObserver(web_contents),
+       done_callback_(std::move(done_callback)),
+-      service_(service),
+       url_(web_contents->GetLastCommittedURL()),
+       password_type_(password_type) {
+   bool show_check_passwords = false;
+@@ -170,31 +169,13 @@ PasswordReuseModalWarningDialog::Passwor
+   SetCancelCallback(make_done_callback(WarningAction::IGNORE_WARNING));
+   SetCloseCallback(make_done_callback(WarningAction::CLOSE));
+ 
+-  // |service| maybe NULL in tests.
+-  if (service_) {
+-    service_->AddObserver(this);
+-  }
+-
+-  if (password_type.account_type() ==
+-      ReusedPasswordAccountType::SAVED_PASSWORD) {
+-    const std::u16string message_body =
+-        service_->GetWarningDetailText(password_type);
+-
+-    CreateSavedPasswordReuseModalWarningDialog(message_body);
+-  } else {
+-    views::Label* message_body_label = CreateMessageBodyLabel(
+-        service_
+-            ? service_->GetWarningDetailText(password_type)
+-            : l10n_util::GetStringUTF16(IDS_PAGE_INFO_CHANGE_PASSWORD_DETAILS));
+-    CreateGaiaPasswordReuseModalWarningDialog(message_body_label);
+-  }
++  views::Label* message_body_label = CreateMessageBodyLabel(
++      l10n_util::GetStringUTF16(IDS_PAGE_INFO_CHANGE_PASSWORD_DETAILS));
++  CreateGaiaPasswordReuseModalWarningDialog(message_body_label);
+   modal_construction_start_time_ = base::TimeTicks::Now();
+ }
+ 
+ PasswordReuseModalWarningDialog::~PasswordReuseModalWarningDialog() {
+-  if (service_) {
+-    service_->RemoveObserver(this);
+-  }
+   LogModalWarningDialogLifetime(modal_construction_start_time_);
+ }
+ 
+--- a/chrome/browser/ui/views/safe_browsing/password_reuse_modal_warning_dialog.h
++++ b/chrome/browser/ui/views/safe_browsing/password_reuse_modal_warning_dialog.h
+@@ -64,7 +64,6 @@ class PasswordReuseModalWarningDialog
+ 
+  private:
+   OnWarningDone done_callback_;
+-  raw_ptr<ChromePasswordProtectionService> service_;
+   const GURL url_;
+   const ReusedPasswordAccountType password_type_;
+ 
+--- a/chrome/browser/ui/views/toolbar/app_menu.cc
++++ b/chrome/browser/ui/views/toolbar/app_menu.cc
+@@ -66,7 +66,6 @@
+ #include "chrome/grit/theme_resources.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/saved_tab_groups/public/features.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/zoom/page_zoom.h"
+ #include "components/zoom/zoom_controller.h"
+@@ -401,75 +400,6 @@ void AddSignedInChipToProfileMenuItem(
+     const int horizontal_padding,
+     std::vector<base::CallbackListSubscription>&
+         profile_menu_subscription_list) {
+-  if (!profile->GetPrefs()->GetBoolean(prefs::kSigninAllowed) ||
+-      profile->IsIncognitoProfile()) {
+-    return;
+-  }
+-  constexpr int profile_chip_corner_radii = 100;
+-  raw_ptr<views::Label> profile_chip_label;
+-  const MenuConfig& config = MenuConfig::instance();
+-
+-  // We need to have the label of the profile chip within a
+-  // BoxLayoutView and inside border insets because MenuItemView will
+-  // layout the child items to the full height of the menu item in
+-  // MenuItemView::Layout().
+-  auto profile_chip =
+-      views::Builder<views::BoxLayoutView>()
+-          .SetInsideBorderInsets(
+-              gfx::Insets::VH(config.item_vertical_margin, 0))
+-          .AddChildren(
+-              views::Builder<views::Label>()
+-                  .SetText(GetSigninStatusChipString(profile))
+-                  .CopyAddressTo(&profile_chip_label)
+-                  .SetAutoColorReadabilityEnabled(false)
+-                  .SetEnabledColor(item->IsSelected()
+-                                       ? ui::kColorMenuItemForegroundSelected
+-                                       : ui::kColorMenuItemForeground)
+-                  .SetBackground(views::CreateRoundedRectBackground(
+-                      item->IsSelected()
+-                          ? ui::kColorAppMenuProfileRowChipHovered
+-                          : ui::kColorAppMenuProfileRowChipBackground,
+-                      profile_chip_corner_radii))
+-                  // Add additional horizontal padding. Vertical
+-                  // padding depends on menu margins to get alignment
+-                  // with other items in the menu.
+-                  .SetBorder(views::CreateEmptyBorder(gfx::Insets::VH(
+-                      0, views::LayoutProvider::Get()
+-                             ->GetInsetsMetric(views::INSETS_LABEL_BUTTON)
+-                             .left()))))
+-          .Build();
+-
+-  // MenuItemView has specific layout logic for child views which does not work
+-  // very well with more custom menu items. We use this view to add the correct
+-  // spacing between the profile chip and the edge of the menu.
+-  auto profile_chip_edge_spacing_view =
+-      views::Builder<views::View>()
+-          .SetPreferredSize(gfx::Size(horizontal_padding, 0))
+-          .Build();
+-  profile_menu_subscription_list.push_back(
+-      item->AddSelectedChangedCallback(base::BindRepeating(
+-          [](MenuItemView* menu_item_view, views::Label* chip_label,
+-             int corner_radius) {
+-            const bool selected = menu_item_view->IsSelected();
+-            chip_label->SetBackground(views::CreateRoundedRectBackground(
+-                selected ? ui::kColorAppMenuProfileRowChipHovered
+-                         : ui::kColorAppMenuProfileRowChipBackground,
+-                corner_radius));
+-            chip_label->SetEnabledColor(
+-                selected ? ui::kColorMenuItemForegroundSelected
+-                         : ui::kColorMenuItemForeground);
+-          },
+-          item, profile_chip_label, profile_chip_corner_radii)));
+-  item->AddChildView(std::move(profile_chip));
+-  item->AddChildView(std::move(profile_chip_edge_spacing_view));
+-  item->SetHighlightWhenSelectedWithChildViews(true);
+-  // MenuItemView only delegates accessible names when its title is empty with a
+-  // single container view. The Profile MenuItemView has a title and multiple
+-  // views. As a result, the accessible name must be manually computed to
+-  // account for the profile chip.
+-  item->GetViewAccessibility().SetName(
+-      views::MenuItemView::GetAccessibleNameForMenuItem(
+-          item->title(), GetSigninStatusChipString(profile), std::nullopt));
+ }
+ 
+ // AppMenuView is a view that can contain label buttons.
+--- a/chrome/browser/ui/views/user_education/browser_ntp_promos.cc
++++ b/chrome/browser/ui/views/user_education/browser_ntp_promos.cc
+@@ -25,7 +25,6 @@
+ #include "chrome/grit/branded_strings.h"
+ #include "chrome/grit/generated_resources.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/user_education/common/ntp_promo/ntp_promo_registry.h"
+ #include "components/user_education/common/ntp_promo/ntp_promo_specification.h"
+@@ -50,14 +49,7 @@ Profile* GetProfile(ContextPtr context)
+ 
+ NtpPromoSpecification::Eligibility CheckExtensionsPromoEligibility(
+     ContextPtr context) {
+-  // TODO(webium): add user education context for WebUI browser.
+-  if (!context) {
+     return NtpPromoSpecification::Eligibility::kIneligible;
+-  }
+-  return extensions::util::AnyCurrentlyInstalledExtensionIsFromWebstore(
+-             GetProfile(context))
+-             ? NtpPromoSpecification::Eligibility::kCompleted
+-             : NtpPromoSpecification::Eligibility::kEligible;
+ }
+ 
+ void InvokeExtensionsPromo(ContextPtr context) {
+--- a/chrome/browser/ui/webui/browser_command/browser_command_handler.cc
++++ b/chrome/browser/ui/webui/browser_command/browser_command_handler.cc
+@@ -46,7 +46,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/safe_browsing/content/browser/web_ui/safe_browsing_ui.h"
+ #include "components/safe_browsing/core/common/safe_browsing_policy_handler.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/safebrowsing_referral_methods.h"
+ #include "components/saved_tab_groups/public/features.h"
+ #include "components/tabs/public/tab_interface.h"
+@@ -102,13 +101,6 @@ void BrowserCommandHandler::CanExecuteCo
+     case Command::kOpenSafetyCheck:
+       can_execute = !enterprise_util::IsBrowserManaged(profile_);
+       break;
+-    case Command::kOpenSafeBrowsingEnhancedProtectionSettings: {
+-      bool managed = safe_browsing::SafeBrowsingPolicyHandler::
+-          IsSafeBrowsingProtectionLevelSetByPolicy(profile_->GetPrefs());
+-      bool already_enabled =
+-          safe_browsing::IsEnhancedProtectionEnabled(*(profile_->GetPrefs()));
+-      can_execute = !managed && !already_enabled;
+-    } break;
+     case Command::kOpenFeedbackForm:
+       can_execute = true;
+       break;
+--- a/chrome/browser/ui/webui/cr_components/history/history_util.cc
++++ b/chrome/browser/ui/webui/cr_components/history/history_util.cc
+@@ -21,7 +21,6 @@
+ #include "components/history/core/common/pref_names.h"
+ #include "components/history_clusters/core/history_clusters_prefs.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/strings/grit/components_strings.h"
+ #include "content/public/browser/web_ui_data_source.h"
+ #include "ui/base/l10n/l10n_util.h"
+@@ -86,7 +85,7 @@ content::WebUIDataSource* HistoryUtil::P
+ 
+   source->AddBoolean("isGuestSession", profile->IsGuestSession());
+   source->AddBoolean("isSignInAllowed",
+-                     prefs->GetBoolean(prefs::kSigninAllowed));
++                     false);
+ 
+   source->AddInteger(
+       "lastSelectedTab",
+--- a/chrome/browser/ui/webui/downloads/downloads_dom_handler.cc
++++ b/chrome/browser/ui/webui/downloads/downloads_dom_handler.cc
+@@ -57,7 +57,6 @@
+ #include "components/history/core/common/pref_names.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/safebrowsing_referral_methods.h"
+ #include "components/tabs/public/tab_interface.h"
+ #include "content/public/browser/browser_thread.h"
+--- a/chrome/browser/ui/webui/history/browsing_history_handler.cc
++++ b/chrome/browser/ui/webui/history/browsing_history_handler.cc
+@@ -61,7 +61,6 @@
+ #include "components/keyed_service/core/service_access_type.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/query_parser/snippet.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_prefs.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+--- a/chrome/browser/ui/webui/history/history_ui.cc
++++ b/chrome/browser/ui/webui/history/history_ui.cc
+@@ -62,7 +62,6 @@
+ #include "components/page_image_service/image_service_handler.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/sessions/core/session_types.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/strings/grit/components_strings.h"
+--- a/chrome/browser/ui/webui/management/management_ui_handler.cc
++++ b/chrome/browser/ui/webui/management/management_ui_handler.cc
+@@ -50,7 +50,6 @@
+ #include "components/policy/core/common/management/management_service.h"
+ #include "components/policy/core/common/policy_pref_names.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/strings/grit/components_strings.h"
+ #include "components/supervised_user/core/common/pref_names.h"
+--- a/chrome/browser/ui/webui/policy/policy_ui_handler.cc
++++ b/chrome/browser/ui/webui/policy/policy_ui_handler.cc
+@@ -81,7 +81,6 @@
+ #include "components/policy/proto/device_management_backend.pb.h"
+ #include "components/prefs/pref_change_registrar.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/strings/grit/components_strings.h"
+ #include "content/public/browser/browser_task_traits.h"
+@@ -364,13 +363,6 @@ void PolicyUIHandler::SetLocalTestPolici
+               ->local_test_policy_provider());
+   CHECK(local_test_provider);
+ 
+-#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_CHROMEOS)
+-  profile_->GetPrefs()->ClearPref(
+-      prefs::kUserCloudSigninPolicyResponseFromPolicyTestPage);
+-  profile_->GetPrefs()->SetDefaultPrefValue(
+-      prefs::kUserCloudSigninPolicyResponseFromPolicyTestPage,
+-      base::Value(profile_separation_policy_response));
+-#endif
+ 
+   profile_->GetProfilePolicyConnector()->UseLocalTestPolicyProvider();
+ 
+@@ -386,13 +378,6 @@ void PolicyUIHandler::RevertLocalTestPol
+   if (!PolicyUI::ShouldLoadTestPage(&profile_.get())) {
+     return;
+   }
+-#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_CHROMEOS)
+-  profile_->GetPrefs()->ClearPref(
+-      prefs::kUserCloudSigninPolicyResponseFromPolicyTestPage);
+-  profile_->GetPrefs()->SetDefaultPrefValue(
+-      prefs::kUserCloudSigninPolicyResponseFromPolicyTestPage,
+-      base::Value(std::string()));
+-#endif
+   profile_->GetProfilePolicyConnector()->RevertUseLocalTestPolicyProvider();
+ }
+ 
+--- a/chrome/browser/ui/webui/reset_password/reset_password_ui.cc
++++ b/chrome/browser/ui/webui/reset_password/reset_password_ui.cc
+@@ -24,7 +24,6 @@
+ #include "components/safe_browsing/core/browser/password_protection/metrics_util.h"
+ #include "components/safe_browsing/core/common/features.h"
+ #include "components/safe_browsing/core/common/proto/csd.pb.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/strings/grit/components_strings.h"
+ #include "components/url_formatter/url_formatter.h"
+ #include "components/user_prefs/user_prefs.h"
+--- a/chrome/browser/ui/webui/settings/people_handler.cc
++++ b/chrome/browser/ui/webui/settings/people_handler.cc
+@@ -58,7 +58,6 @@
+ #include "components/signin/core/browser/signin_error_controller.h"
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_prefs.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+@@ -442,10 +441,6 @@ void PeopleHandler::OnJavascriptAllowed(
+   PrefService* prefs = profile_->GetPrefs();
+   profile_pref_registrar_ = std::make_unique<PrefChangeRegistrar>();
+   profile_pref_registrar_->Init(prefs);
+-  profile_pref_registrar_->Add(
+-      prefs::kSigninAllowed,
+-      base::BindRepeating(&PeopleHandler::UpdateSyncStatus,
+-                          base::Unretained(this)));
+ #if BUILDFLAG(ENABLE_DICE_SUPPORT)
+   SigninPrefs::ObserveSigninPrefsChanges(
+       *profile_pref_registrar_,
+--- a/chrome/browser/ui/webui/settings/safety_hub_handler.cc
++++ b/chrome/browser/ui/webui/settings/safety_hub_handler.cc
+@@ -51,7 +51,6 @@
+ #include "components/password_manager/core/common/password_manager_pref_names.h"
+ #include "components/permissions/constants.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/site_engagement/content/site_engagement_service.h"
+--- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
++++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+@@ -96,7 +96,6 @@
+ #include "components/regional_capabilities/regional_capabilities_service.h"
+ #include "components/safe_browsing/core/common/features.h"
+ #include "components/safe_browsing/core/common/hashprefix_realtime/hash_realtime_utils.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/saved_tab_groups/public/features.h"
+ #include "components/signin/public/base/signin_buildflags.h"
+ #include "components/strings/grit/components_branded_strings.h"
+@@ -3952,11 +3951,6 @@ void AddSiteSettingsStrings(content::Web
+   html_source->AddLocalizedStrings(kSensorsLocalizedStrings);
+ 
+   html_source->AddBoolean(
+-      "enableSafeBrowsingSubresourceFilter",
+-      base::FeatureList::IsEnabled(
+-          subresource_filter::kSafeBrowsingSubresourceFilter));
+-
+-  html_source->AddBoolean(
+       "enableBlockAutoplayContentSetting",
+       base::FeatureList::IsEnabled(media::kAutoplayDisableSettings));
+ 
+--- a/chrome/browser/ui/webui/settings/settings_ui.cc
++++ b/chrome/browser/ui/webui/settings/settings_ui.cc
+@@ -128,7 +128,6 @@
+ #include "components/safe_browsing/core/common/features.h"
+ #include "components/search_engines/search_engines_switches.h"
+ #include "components/search_engines/template_url_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/subscription_eligibility/subscription_eligibility_service.h"
+ #include "components/sync/base/features.h"
+@@ -300,9 +299,7 @@ SettingsUI::SettingsUI(content::WebUI* w
+   AddSettingsPageUIHandler(std::make_unique<MacSystemSettingsHandler>());
+ #endif
+ 
+-  html_source->AddBoolean("signinAllowed", !profile->IsGuestSession() &&
+-                                               profile->GetPrefs()->GetBoolean(
+-                                                   prefs::kSigninAllowed));
++  html_source->AddBoolean("signinAllowed", false);
+ 
+   html_source->AddBoolean(
+       "shouldUseMetricsConsentRestructure",
+--- a/chrome/browser/ui/webui/signin/inline_login_handler.cc
++++ b/chrome/browser/ui/webui/signin/inline_login_handler.cc
+@@ -27,7 +27,6 @@
+ #include "chrome/common/pref_names.h"
+ #include "components/metrics/metrics_pref_names.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "content/public/browser/storage_partition.h"
+ #include "content/public/browser/web_contents.h"
+ #include "content/public/browser/web_ui.h"
+@@ -137,8 +136,6 @@ void InlineLoginHandler::ContinueHandleI
+   Profile* profile = Profile::FromWebUI(web_ui());
+   std::string default_email;
+   if (reason == signin_metrics::Reason::kSigninPrimaryAccount) {
+-    default_email = profile->GetPrefs()->GetString(
+-        prefs::kGoogleServicesLastSyncingUsername);
+   } else {
+     if (!net::GetValueForKeyInQuery(current_url, "email", &default_email)) {
+       default_email.clear();
+--- a/chrome/browser/ui/webui/signin/managed_user_profile_notice_handler.cc
++++ b/chrome/browser/ui/webui/signin/managed_user_profile_notice_handler.cc
+@@ -37,7 +37,6 @@
+ #include "chrome/grit/generated_resources.h"
+ #include "components/policy/core/browser/signin/profile_separation_policies.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/signin/public/identity_manager/signin_constants.h"
+ #include "components/strings/grit/components_strings.h"
+@@ -541,23 +540,6 @@ base::DictValue ManagedUserProfileNotice
+       dict.Set("email", base::UTF16ToUTF8(email_));
+       dict.Set("accountName", account_info.GetFullName().value_or(""));
+ 
+-#if !BUILDFLAG(IS_CHROMEOS)
+-      // We apply the checkLinkDataCheckboxByDefault to true value only if the
+-      // link data checkbox is visible and the policy
+-      // ProfileSeparationDataMigrationSettings is set to its OPTOUT value (2)
+-      // or the legacy policy EnterpriseProfileCreationKeepBrowsingData is set
+-      // to True.
+-      bool profile_separation_data_migration_settings_optout =
+-          Profile::FromWebUI(web_ui())->GetPrefs()->GetInteger(
+-              prefs::kProfileSeparationDataMigrationSettings) == 2;
+-      bool check_link_Data_checkbox_by_default_from_legacy_policy =
+-          g_browser_process->local_state()->GetBoolean(
+-              prefs::kEnterpriseProfileCreationKeepBrowsingData);
+-      dict.Set("checkLinkDataCheckboxByDefault",
+-               show_link_data_option_ &&
+-                   (profile_separation_data_migration_settings_optout ||
+-                    check_link_Data_checkbox_by_default_from_legacy_policy));
+-#endif
+       break;
+   }
+ 
+--- a/chrome/browser/ui/webui/signin/managed_user_profile_notice_ui.cc
++++ b/chrome/browser/ui/webui/signin/managed_user_profile_notice_ui.cc
+@@ -37,7 +37,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/regional_capabilities/regional_capabilities_service.h"
+ #include "components/signin/public/base/consent_level.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/signin/public/identity_manager/tribool.h"
+@@ -433,8 +432,7 @@ void ManagedUserProfileNoticeUI::Initial
+   // Change the text so that the "(Recommended)" label is not shown when the
+   // admin has set merging data as the default option.
+   bool profile_separation_data_migration_settings_optout =
+-      profile->GetPrefs()->GetInteger(
+-          prefs::kProfileSeparationDataMigrationSettings) == 2;
++      false;
+   bool check_link_data_checkbox_by_default_from_legacy_policy =
+       g_browser_process->local_state()->GetBoolean(
+           prefs::kEnterpriseProfileCreationKeepBrowsingData);
+--- a/chrome/browser/ui/webui/signin/signin_error_ui.cc
++++ b/chrome/browser/ui/webui/signin/signin_error_ui.cc
+@@ -26,7 +26,6 @@
+ #include "chrome/grit/generated_resources.h"
+ #include "chrome/grit/signin_resources.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/strings/grit/components_strings.h"
+ #include "content/public/browser/web_ui.h"
+ #include "content/public/browser/web_ui_data_source.h"
+--- a/chrome/browser/ui/webui/signin/signin_utils_desktop.cc
++++ b/chrome/browser/ui/webui/signin/signin_utils_desktop.cc
+@@ -17,7 +17,6 @@
+ #include "chrome/browser/ui/webui/signin/signin_ui_error.h"
+ #include "chrome/common/chrome_switches.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/signin/public/identity_manager/identity_utils.h"
+ #include "components/sync/base/features.h"
+@@ -28,111 +27,10 @@ SigninUIError CanOfferSignin(Profile* pr
+                              const GaiaId& gaia_id,
+                              const std::string& email,
+                              bool allow_account_from_other_profile) {
+-  if (!profile) {
+-    return SigninUIError::NoProfile(email);
+-  }
+-
+-  if (!profile->GetPrefs()->GetBoolean(prefs::kSigninAllowed)) {
+     return SigninUIError::SigninDisallowed(email);
+-  }
+-
+-  if (!email.empty()) {
+-    auto* identity_manager = IdentityManagerFactory::GetForProfile(profile);
+-    if (!identity_manager) {
+-      return SigninUIError::NoIdentityManager(email);
+-    }
+-
+-    // Make sure this username is not prohibited by policy.
+-    if (!signin::IsUsernameAllowedByPatternFromPrefs(
+-            g_browser_process->local_state(), email)) {
+-      return SigninUIError::UsernameNotAllowedByPatternFromPrefs(email);
+-    }
+-
+-    // If the identity manager already has a primary account, then this is a
+-    // re-auth scenario. Make sure the email just signed in corresponds to
+-    // the one sign in manager expects.
+-    std::string current_email =
+-        identity_manager
+-            ->GetPrimaryAccountInfo(
+-                syncer::IsReplaceSyncPromosWithSignInPromosEnabled()
+-                    ? signin::ConsentLevel::kSignin
+-                    : signin::ConsentLevel::kSync)
+-            .email;
+-    // TODO(crbug.com/440302112): Consider checking for the gaia_id equality
+-    // instead of the email for reauth flow detection.
+-    const bool same_email = gaia::AreEmailsSame(current_email, email);
+-    if (!current_email.empty() && !same_email) {
+-      return SigninUIError::WrongReauthAccount(email, current_email);
+-    }
+-
+-    allow_account_from_other_profile =
+-        allow_account_from_other_profile ||
+-        base::CommandLine::ForCurrentProcess()->HasSwitch(
+-            switches::kBypassAccountAlreadyUsedByAnotherProfileCheck);
+-    // If some profile, not just the current one, is already connected to this
+-    // account, don't offer sign in.
+-    if (g_browser_process && !same_email && !allow_account_from_other_profile) {
+-      ProfileManager* profile_manager = g_browser_process->profile_manager();
+-      if (profile_manager) {
+-        std::vector<ProfileAttributesEntry*> entries =
+-            profile_manager->GetProfileAttributesStorage()
+-                .GetAllProfilesAttributes();
+-
+-        for (const ProfileAttributesEntry* entry : entries) {
+-          // Ignore omitted profiles (these are notably profiles being created
+-          // using the signed-in profile creation flow). This is motivated by
+-          // these profile hanging around until the next restart which could
+-          // block subsequent profile creation, resulting in
+-          // SigninUIError::AccountAlreadyUsedByAnotherProfile.
+-          // TODO(crbug.com/40176394): This opens the possibility for getting
+-          // into a state with 2 profiles syncing to the same account:
+-          //  - start creating a new profile and sign-in,
+-          //  - enabled sync for the same account in another (existing) profile,
+-          //  - finish the profile creation by consenting to sync.
+-          // Properly addressing this would require deleting profiles from
+-          // cancelled flow right away, returning an error here for omitted
+-          // profiles, and fix the code that switches to the other syncing
+-          // profile so that the profile creation flow window gets activated for
+-          // profiles being created (instead of opening a new window).
+-          if (entry->IsOmitted() || entry->GetPath() == profile->GetPath()) {
+-            continue;
+-          }
+-          // If the feature is disabled, the below check on GaiaId equality is
+-          // equivalent to checking if the user is signed in.
+-          if (!syncer::IsReplaceSyncPromosWithSignInPromosEnabled()) {
+-            if (!entry->IsAuthenticated() && !entry->CanBeManaged()) {
+-              continue;
+-            }
+-          }
+-          if (gaia_id == entry->GetGAIAId()) {
+-            return SigninUIError::AccountAlreadyUsedByAnotherProfile(
+-                email, entry->GetPath());
+-          }
+-        }
+-      }
+-    }
+-
+-    // With force sign in enabled, cross account sign in is not allowed.
+-    if (signin_util::IsForceSigninEnabled() &&
+-        IsCrossAccountError(profile, gaia_id)) {
+-      std::string last_email = profile->GetPrefs()->GetString(
+-          prefs::kGoogleServicesLastSyncingUsername);
+-      return SigninUIError::ProfileWasUsedByAnotherAccount(email, last_email);
+-    }
+-  }
+-
+-  // This error has lower priority because it is not critical and may sometimes
+-  // be ignored.
+-  if (!ChromeSigninClient::ProfileAllowsSigninCookies(profile)) {
+-    return SigninUIError::SigninCookiesDisallowed(email);
+-  }
+-
+-  return SigninUIError::Ok();
+ }
+ 
+ bool IsCrossAccountError(Profile* profile, const GaiaId& gaia_id) {
+   DCHECK(!gaia_id.empty());
+-  const GaiaId last_gaia_id(
+-      profile->GetPrefs()->GetString(prefs::kGoogleServicesLastSyncingGaiaId));
+-  return !last_gaia_id.empty() && gaia_id != last_gaia_id;
++  return false;
+ }
+--- a/chrome/browser/ui/webui/signin/signout_confirmation/signout_confirmation_handler.cc
++++ b/chrome/browser/ui/webui/signin/signout_confirmation/signout_confirmation_handler.cc
+@@ -15,7 +15,6 @@
+ #include "chrome/browser/ui/signin/signin_view_controller.h"
+ #include "chrome/grit/branded_strings.h"
+ #include "chrome/grit/generated_resources.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/strings/grit/components_strings.h"
+ #include "components/sync/base/features.h"
+ #include "components/sync_bookmarks/constants.h"
+--- a/chrome/browser/ui/webui/signin/turn_sync_on_helper.cc
++++ b/chrome/browser/ui/webui/signin/turn_sync_on_helper.cc
+@@ -48,7 +48,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/core/browser/account_reconcilor.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_managed_status_finder.h"
+ #include "components/signin/public/identity_manager/accounts_mutator.h"
+@@ -253,8 +252,7 @@ void TurnSyncOnHelper::TurnSyncOnInterna
+   // confirmation dialog before starting sync.
+   // TODO(skym): Warn for high risk upgrade scenario
+   // (https://crbug.com/40450589).
+-  std::string last_email = profile_->GetPrefs()->GetString(
+-      prefs::kGoogleServicesLastSyncingUsername);
++  std::string last_email;
+   delegate_->ShowMergeSyncDataConfirmation(
+       last_email, account_info_.email,
+       base::BindOnce(&TurnSyncOnHelper::OnMergeAccountConfirmation,
+--- a/chrome/browser/ui/webui/signin/turn_sync_on_helper_delegate_impl.cc
++++ b/chrome/browser/ui/webui/signin/turn_sync_on_helper_delegate_impl.cc
+@@ -40,7 +40,6 @@
+ #include "components/policy/core/browser/signin/user_cloud_signin_restriction_policy_fetcher.h"
+ #include "components/policy/core/common/policy_utils.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "google_apis/gaia/gaia_auth_util.h"
+ #include "third_party/skia/include/core/SkColor.h"
+ #include "ui/base/base_window.h"
+@@ -258,26 +257,6 @@ void TurnSyncOnHelperDelegateImpl::OnPro
+     return;
+   }
+ 
+-  if (prompt_for_new_profile) {
+-    account_level_signin_restriction_policy_fetcher_
+-        ->GetManagedAccountsSigninRestriction(
+-            IdentityManagerFactory::GetForProfile(browser_->GetProfile()),
+-            account_info.account_id,
+-            base::BindOnce(&TurnSyncOnHelperDelegateImpl::
+-                               OnProfileSigninRestrictionsFetched,
+-                           weak_ptr_factory_.GetWeakPtr(), account_info,
+-                           std::move(callback)),
+-            policy::utils::IsPolicyTestingEnabled(
+-                browser_->GetProfile()->GetPrefs(), chrome::GetChannel())
+-                ? browser_->GetProfile()
+-                      ->GetPrefs()
+-                      ->GetDefaultPrefValue(
+-                          prefs::
+-                              kUserCloudSigninPolicyResponseFromPolicyTestPage)
+-                      ->GetString()
+-                : std::string());
+-    return;
+-  }
+ 
+   browser_->GetFeatures()
+       .signin_view_controller()
+--- a/chrome/browser/ui/webui/signin/turn_sync_on_helper_unittest.cc
++++ b/chrome/browser/ui/webui/signin/turn_sync_on_helper_unittest.cc
+@@ -54,7 +54,6 @@
+ #include "components/search_engines/template_url_service.h"
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_capabilities_test_mutator.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+--- a/chrome/browser/unified_consent/unified_consent_service_factory.cc
++++ b/chrome/browser/unified_consent/unified_consent_service_factory.cc
+@@ -13,7 +13,6 @@
+ #include "components/commerce/core/pref_names.h"
+ #include "components/embedder_support/pref_names.h"
+ #include "components/prefs/pref_registry_simple.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/spellcheck/browser/pref_names.h"
+ #include "components/sync_preferences/pref_service_syncable.h"
+ #include "components/unified_consent/unified_consent_metrics.h"
+@@ -34,8 +33,6 @@ namespace {
+ 
+ std::vector<std::string> GetSyncedServicePrefNames() {
+   return {
+-    prefs::kSearchSuggestEnabled, prefs::kSafeBrowsingEnabled,
+-        prefs::kSafeBrowsingScoutReportingEnabled,
+         spellcheck::prefs::kSpellCheckUseSpellingService,
+         commerce::kPriceEmailNotificationsEnabled,
+ #if BUILDFLAG(IS_ANDROID)
+--- a/chrome/common/extensions/api/privacy.json
++++ b/chrome/common/extensions/api/privacy.json
+@@ -63,16 +63,6 @@
+             "value": ["passwordSavingEnabled", {"type":"boolean"}],
+             "description": "If enabled, the password manager will ask if you want to save passwords. This preference's value is a boolean, defaulting to <code>true</code>."
+           },
+-          "safeBrowsingEnabled": {
+-            "$ref": "types.ChromeSetting",
+-            "value": ["safeBrowsingEnabled", {"type":"boolean"}],
+-            "description": "If enabled, Chrome does its best to protect you from phishing and malware. This preference's value is a boolean, defaulting to <code>true</code>."
+-          },
+-          "safeBrowsingExtendedReportingEnabled": {
+-            "$ref": "types.ChromeSetting",
+-            "value": ["safeBrowsingExtendedReportingEnabled", {"type":"boolean"}],
+-            "description": "If enabled, Chrome will send additional information to Google when SafeBrowsing blocks a page, such as the content of the blocked page. This preference's value is a boolean, defaulting to <code>false</code>."
+-          },
+           "searchSuggestEnabled": {
+             "$ref": "types.ChromeSetting",
+             "value": ["searchSuggestEnabled", {"type":"boolean"}],
+--- a/components/autofill/core/browser/data_manager/addresses/address_data_manager.cc
++++ b/components/autofill/core/browser/data_manager/addresses/address_data_manager.cc
+@@ -36,7 +36,6 @@
+ #include "components/autofill/core/common/autofill_prefs.h"
+ #include "components/autofill/core/common/dense_set.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/sync/base/data_type.h"
+ #include "components/sync/base/features.h"
+@@ -338,13 +337,7 @@ void AddressDataManager::RemoveLocalProf
+ }
+ 
+ bool AddressDataManager::IsEligibleForAddressAccountStorage() const {
+-  if (!sync_service_) {
+     return false;
+-  }
+-
+-  // The CONTACT_INFO data type is only running for eligible users. See
+-  // ContactInfoDataTypeController.
+-  return sync_service_->GetActiveDataTypes().Has(syncer::CONTACT_INFO);
+ }
+ 
+ void AddressDataManager::MigrateProfileToAccount(
+@@ -645,40 +638,7 @@ bool AddressDataManager::IsAutofillUserS
+ }
+ 
+ bool AddressDataManager::IsAutofillSyncToggleAvailable() const {
+-  if (syncer::IsReplaceSyncPromosWithSignInPromosEnabled()) {
+-    return false;
+-  }
+-
+-  if (!sync_service_) {
+-    return false;
+-  }
+-
+-  // Do not show the toggle if Sync is disabled on in error.
+-  if (sync_service_->GetTransportState() ==
+-          syncer::SyncService::TransportState::PAUSED ||
+-      sync_service_->GetTransportState() ==
+-          syncer::SyncService::TransportState::DISABLED) {
+     return false;
+-  }
+-
+-  // Do not show the toggle for syncing users.
+-  if (sync_service_->HasSyncConsent()) {
+-    return false;
+-  }
+-
+-  if (sync_service_->GetUserSettings()->IsTypeManagedByPolicy(
+-          syncer::UserSelectableType::kAutofill)) {
+-    return false;
+-  }
+-
+-  // TODO(crbug.com/40897778): Provide the correct
+-  // AccountManagedStatusFinderOutcome here. Currently it is not used, so
+-  // `kPending` is a safe placeholder.
+-  return contact_info_precondition_checker_ &&
+-         contact_info_precondition_checker_->GetPreconditionState(
+-             syncer::DataTypeController::PreconditionContext(
+-                 signin::AccountManagedStatusFinderOutcome::kPending)) ==
+-             syncer::DataTypeController::PreconditionState::kPreconditionsMet;
+ }
+ 
+ void AddressDataManager::SetAutofillSelectableTypeEnabled(bool enabled) {
+--- a/components/browser_sync/BUILD.gn
++++ b/components/browser_sync/BUILD.gn
+@@ -14,8 +14,6 @@ static_library("browser_sync") {
+     "sync_engine_factory_impl.h",
+     "sync_internals_message_handler.cc",
+     "sync_internals_message_handler.h",
+-    "sync_to_signin_migration.cc",
+-    "sync_to_signin_migration.h",
+   ]
+ 
+   public_deps = [
+--- a/components/collaboration/internal/collaboration_service_impl.cc
++++ b/components/collaboration/internal/collaboration_service_impl.cc
+@@ -19,7 +19,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/saved_tab_groups/public/tab_group_sync_service.h"
+ #include "components/signin/public/base/consent_level.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/sync/base/collaboration_id.h"
+ #include "components/sync/base/features.h"
+@@ -67,10 +66,6 @@ CollaborationServiceImpl::CollaborationS
+       prefs::kSharedTabGroupsManagedAccountSetting,
+       base::BindRepeating(&CollaborationServiceImpl::RefreshServiceStatus,
+                           base::Unretained(this)));
+-  registrar_.Add(
+-      ::prefs::kSigninAllowed,
+-      base::BindRepeating(&CollaborationServiceImpl::RefreshServiceStatus,
+-                          base::Unretained(this)));
+ }
+ 
+ CollaborationServiceImpl::~CollaborationServiceImpl() {
+@@ -418,150 +413,13 @@ SigninStatus CollaborationServiceImpl::G
+   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+   SigninStatus status = SigninStatus::kNotSignedIn;
+ 
+-  bool has_valid_primary_account =
+-      identity_manager_->HasPrimaryAccountWithRefreshToken(
+-          signin::ConsentLevel::kSignin) &&
+-      !identity_manager_->HasAccountWithRefreshTokenInPersistentErrorState(
+-          identity_manager_->GetPrimaryAccountId(
+-              signin::ConsentLevel::kSignin));
+-  if (has_valid_primary_account) {
+-    status = SigninStatus::kSignedIn;
+-  } else if (identity_manager_->HasPrimaryAccount(
+-                 signin::ConsentLevel::kSignin)) {
+-    status = SigninStatus::kSignedInPaused;
+-  } else if (!profile_prefs_->GetBoolean(::prefs::kSigninAllowed)) {
+-    status = SigninStatus::kSigninDisabled;
+-  }
+-
+-#if BUILDFLAG(IS_IOS)
+-  BrowserSigninMode policy_mode = static_cast<BrowserSigninMode>(
+-      local_prefs_->GetInteger(::prefs::kBrowserSigninPolicy));
+-  if (policy_mode == BrowserSigninMode::kDisabled) {
+     status = SigninStatus::kSigninDisabled;
+-  }
+-#endif
+ 
+   return status;
+ }
+ 
+ CollaborationStatus CollaborationServiceImpl::GetCollaborationStatus() {
+-  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+-  if (!base::FeatureList::IsEnabled(
+-          data_sharing::features::kDataSharingFeature) &&
+-      !base::FeatureList::IsEnabled(
+-          data_sharing::features::kDataSharingJoinOnly)) {
+     return CollaborationStatus::kDisabled;
+-  }
+-
+-  // Check if version out-of-date turn off shared tab groups data types and show
+-  // update chrome ui.
+-  if (base::FeatureList::IsEnabled(
+-          data_sharing::features::kSharedDataTypesKillSwitch)) {
+-    return base::FeatureList::IsEnabled(
+-               data_sharing::features::kDataSharingEnableUpdateChromeUI)
+-               ? CollaborationStatus::kVersionOutOfDateShowUpdateChromeUi
+-               : CollaborationStatus::kVersionOutOfDate;
+-  }
+-
+-  // Check if device policy allow signin.
+-#if BUILDFLAG(IS_IOS)
+-  BrowserSigninMode policy_mode = static_cast<BrowserSigninMode>(
+-      local_prefs_->GetInteger(::prefs::kBrowserSigninPolicy));
+-  if (policy_mode == BrowserSigninMode::kDisabled) {
+-    return CollaborationStatus::kDisabledForPolicy;
+-  }
+-#elif BUILDFLAG(IS_ANDROID)
+-  if (!profile_prefs_->GetBoolean(::prefs::kSigninAllowed) &&
+-      profile_prefs_->IsManagedPreference(::prefs::kSigninAllowed)) {
+-    return CollaborationStatus::kDisabledForPolicy;
+-  }
+-#else
+-  if (!profile_prefs_->GetBoolean(::prefs::kSigninAllowedOnNextStartup) &&
+-      profile_prefs_->IsManagedPreference(
+-          ::prefs::kSigninAllowedOnNextStartup)) {
+-    return CollaborationStatus::kDisabledForPolicy;
+-  }
+-#endif
+-
+-  // Check if device policy allow sync.
+-  if (current_status_.sync_status == SyncStatus::kSyncDisabledByEnterprise) {
+-    return CollaborationStatus::kDisabledForPolicy;
+-  }
+-
+-  // TODO(haileywang): Support collaboration status updates.
+-  CollaborationStatus status = CollaborationStatus::kDisabled;
+-  if (base::FeatureList::IsEnabled(
+-          data_sharing::features::kDataSharingFeature)) {
+-    status = CollaborationStatus::kEnabledCreateAndJoin;
+-  } else if (base::FeatureList::IsEnabled(
+-                 data_sharing::features::kDataSharingJoinOnly)) {
+-    status = CollaborationStatus::kAllowedToJoin;
+-  }
+-
+-  if (current_status_.signin_status == SigninStatus::kNotSignedIn) {
+-    return status;
+-  }
+-
+-  CoreAccountInfo account =
+-      identity_manager_->GetPrimaryAccountInfo(signin::ConsentLevel::kSignin);
+-  if (!signin::AccountManagedStatusFinder::MayBeEnterpriseUserBasedOnEmail(
+-          account.email)) {
+-    return status;
+-  }
+-
+-  // Enterprise account handling.
+-  if (!account_managed_status_finder_) {
+-    account_managed_status_finder_ =
+-        std::make_unique<signin::AccountManagedStatusFinder>(
+-            identity_manager_, account,
+-            base::BindOnce(&CollaborationServiceImpl::RefreshServiceStatus,
+-                           weak_ptr_factory_.GetWeakPtr()),
+-            base::Seconds(5));
+-  }
+-
+-  // Enterprise V2: Check enterprise policy to allow/disallow collaboration
+-  // feature.
+-  if (base::FeatureList::IsEnabled(
+-          data_sharing::features::kCollaborationEntrepriseV2)) {
+-    switch (account_managed_status_finder_->GetOutcome()) {
+-      case Outcome::kConsumerGmail:
+-      case Outcome::kConsumerWellKnown:
+-      case Outcome::kConsumerNotWellKnown:
+-        break;
+-      default:
+-        if (profile_prefs_->GetInteger(
+-                collaboration::prefs::kSharedTabGroupsManagedAccountSetting) ==
+-            static_cast<int>(
+-                prefs::SharedTabGroupsManagedAccountSetting::kDisabled)) {
+-          return CollaborationStatus::kDisabledForPolicy;
+-        }
+-    }
+-
+-    return status;
+-  }
+-
+-  // Enterprise V1: Figure out if collaboration feature is disabled by account
+-  // policy. This early check allows to not disable collaboration feature when
+-  // the user need to refresh their account (refresh tokens unavailable).
+-  switch (account_managed_status_finder_->GetOutcome()) {
+-    case Outcome::kPending:
+-      status = CollaborationStatus::kDisabledPending;
+-      break;
+-    case Outcome::kError:
+-    case Outcome::kTimeout:
+-      status = CollaborationStatus::kDisabled;
+-      break;
+-    case Outcome::kEnterpriseGoogleDotCom:
+-    case Outcome::kEnterprise:
+-      status = CollaborationStatus::kDisabledForPolicy;
+-      break;
+-    case Outcome::kConsumerGmail:
+-    case Outcome::kConsumerWellKnown:
+-    case Outcome::kConsumerNotWellKnown:
+-      break;
+-  }
+-
+-  return status;
+ }
+ 
+ void CollaborationServiceImpl::RefreshServiceStatus() {
+--- a/components/commerce/core/shopping_service.cc
++++ b/components/commerce/core/shopping_service.cc
+@@ -57,7 +57,6 @@
+ #include "components/search/ntp_features.h"
+ #include "components/session_proto_db/session_proto_storage.h"
+ #include "components/sessions/core/tab_restore_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/sync/base/features.h"
+ #include "components/sync/service/sync_service.h"
+ #include "components/unified_consent/url_keyed_data_collection_consent_helper.h"
+--- a/components/commerce/core/subscriptions/subscriptions_server_proxy.cc
++++ b/components/commerce/core/subscriptions/subscriptions_server_proxy.cc
+@@ -22,7 +22,6 @@
+ #include "components/commerce/core/subscriptions/commerce_subscription.h"
+ #include "components/endpoint_fetcher/endpoint_fetcher.h"
+ #include "components/signin/public/base/consent_level.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/sync/base/features.h"
+ #include "google_apis/gaia/gaia_constants.h"
+--- a/components/device_signals/core/browser/browser_utils.h
++++ b/components/device_signals/core/browser/browser_utils.h
+@@ -9,7 +9,6 @@
+ 
+ #include "build/build_config.h"
+ #include "components/device_signals/core/common/common_types.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ class PolicyBlocklistService;
+ class PrefService;
+--- a/components/feed/core/v2/feed_stream.cc
++++ b/components/feed/core/v2/feed_stream.cc
+@@ -61,7 +61,6 @@
+ #include "components/feed/feed_feature_list.h"
+ #include "components/offline_pages/task/closure_task.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "google_apis/gaia/gaia_id.h"
+ 
+ namespace feed {
+@@ -160,9 +159,6 @@ FeedStream::FeedStream(RefreshTaskSchedu
+   snippets_enabled_by_dse_.Init(prefs::kEnableSnippetsByDse, profile_prefs,
+                                 preference_change_callback);
+   has_stored_data_.Init(feed::prefs::kHasStoredData, profile_prefs);
+-  signin_allowed_.Init(
+-      ::prefs::kSigninAllowed, profile_prefs,
+-      base::BindRepeating(&FeedStream::ClearAll, GetWeakPtr()));
+ 
+   // Inserting this task first ensures that |store_| is initialized before
+   // it is used.
+--- a/components/feed/core/v2/public/feed_service.cc
++++ b/components/feed/core/v2/public/feed_service.cc
+@@ -33,7 +33,6 @@
+ #include "components/history/core/browser/history_types.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/public/base/consent_level.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "net/base/network_change_notifier.h"
+@@ -183,7 +182,7 @@ class FeedService::StreamDelegateImpl :
+   // Returns if signin is allowed on Android. Return true on other platform so
+   // behavior is unchanged there.
+   bool IsSigninAllowed() override {
+-    return profile_prefs_->GetBoolean(::prefs::kSigninAllowed);
++    return false;
+   }
+   void RegisterExperiments(const Experiments& experiments) override {
+     service_delegate_->RegisterExperiments(experiments);
+--- a/components/password_manager/core/browser/leak_detection/leak_detection_check_impl.cc
++++ b/components/password_manager/core/browser/leak_detection/leak_detection_check_impl.cc
+@@ -23,7 +23,6 @@
+ #include "components/password_manager/core/common/password_manager_pref_names.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/signin/public/identity_manager/access_token_fetcher.h"
+ #include "components/signin/public/identity_manager/access_token_info.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+@@ -226,14 +225,7 @@ bool LeakDetectionCheck::CanStartLeakChe
+     const PrefService& prefs,
+     const GURL& form_url,
+     std::unique_ptr<autofill::SavePasswordProgressLogger> logger) {
+-  const bool is_leak_protection_on =
+-      prefs.GetBoolean(prefs::kPasswordLeakDetectionEnabled);
+-  if (!is_leak_protection_on && logger) {
+-    logger->LogMessage(autofill::SavePasswordProgressLogger::
+-                           STRING_LEAK_DETECTION_DISABLED_FEATURE);
+-  }
+-  return is_leak_protection_on && !LeakDetectionCheck::IsURLBlockedByPolicy(
+-                                      prefs, form_url, logger.get());
++  return false;
+ }
+ 
+ void LeakDetectionCheckImpl::OnAccessTokenRequestCompleted(
+--- a/components/password_manager/core/browser/leak_detection_delegate.cc
++++ b/components/password_manager/core/browser/leak_detection_delegate.cc
+@@ -29,7 +29,6 @@
+ #include "components/password_manager/core/common/password_manager_features.h"
+ #include "components/password_manager/core/common/password_manager_pref_names.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "services/network/public/cpp/shared_url_loader_factory.h"
+ 
+ namespace password_manager {
+--- a/components/password_manager/core/browser/password_reuse_detector_impl.cc
++++ b/components/password_manager/core/browser/password_reuse_detector_impl.cc
+@@ -19,7 +19,6 @@
+ #include "components/password_manager/core/browser/password_store/password_store_consumer.h"
+ #include "components/password_manager/core/browser/password_store/psl_matching_helper.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "google_apis/gaia/gaia_auth_util.h"
+ #include "url/gurl.h"
+ 
+@@ -217,9 +216,7 @@ PasswordReuseDetectorImpl::CheckNonGaiaE
+   // Skips password reuse check if |domain| matches enterprise login URL or
+   // enterprise change password URL.
+   GURL page_url(domain);
+-  if (enterprise_password_urls_.has_value() &&
+-      safe_browsing::MatchesURLList(page_url,
+-                                    enterprise_password_urls_.value())) {
++  if (enterprise_password_urls_.has_value()) {
+     return std::nullopt;
+   }
+ 
+--- a/components/password_manager/core/browser/password_reuse_manager_impl.cc
++++ b/components/password_manager/core/browser/password_reuse_manager_impl.cc
+@@ -24,7 +24,6 @@
+ #include "components/password_manager/core/browser/password_reuse_detector.h"
+ #include "components/password_manager/core/browser/password_reuse_manager_signin_notifier.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/signin/public/base/consent_level.h"
+ #include "google_apis/gaia/gaia_auth_util.h"
+ 
+@@ -454,26 +453,6 @@ void PasswordReuseManagerImpl::ScheduleP
+ }
+ 
+ void PasswordReuseManagerImpl::ScheduleEnterprisePasswordURLUpdate() {
+-  DCHECK(main_task_runner_->RunsTasksInCurrentSequence());
+-  if (DelayUntilReady(
+-          &PasswordReuseManagerImpl::ScheduleEnterprisePasswordURLUpdate)) {
+-    return;
+-  }
+-  if (!prefs_) {
+-    return;
+-  }
+-  std::vector<GURL> enterprise_login_urls;
+-  safe_browsing::GetPasswordProtectionLoginURLsPref(*prefs_,
+-                                                    &enterprise_login_urls);
+-  GURL enterprise_change_password_url =
+-      safe_browsing::GetPasswordProtectionChangePasswordURLPref(*prefs_);
+-  if (!reuse_detector_) {
+-    return;
+-  }
+-  ScheduleTask(base::BindOnce(&PasswordReuseDetector::UseEnterprisePasswordURLs,
+-                              base::Unretained(reuse_detector_.get()),
+-                              std::move(enterprise_login_urls),
+-                              std::move(enterprise_change_password_url)));
+ }
+ 
+ void PasswordReuseManagerImpl::RequestLoginsFromStores() {
+--- a/components/password_manager/core/browser/password_sync_util.cc
++++ b/components/password_manager/core/browser/password_sync_util.cc
+@@ -10,7 +10,6 @@
+ #include "components/password_manager/core/browser/features/password_manager_features_util.h"
+ #include "components/password_manager/core/browser/password_form.h"
+ #include "components/password_manager/core/browser/password_manager_client.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/sync/base/user_selectable_type.h"
+ #include "components/sync/service/sync_user_settings.h"
+@@ -73,9 +72,7 @@ bool IsGaiaCredentialPage(const std::str
+ 
+ bool ShouldSaveEnterprisePasswordHash(const PasswordForm& form,
+                                       const PrefService& prefs) {
+-  return safe_browsing::MatchesPasswordProtectionLoginURL(form.url, prefs) ||
+-         safe_browsing::MatchesPasswordProtectionChangePasswordURL(form.url,
+-                                                                   prefs);
++  return false;
+ }
+ 
+ bool HasChosenToSyncPasswords(const syncer::SyncService* sync_service) {
+--- a/components/password_manager/core/browser/store_metrics_reporter.cc
++++ b/components/password_manager/core/browser/store_metrics_reporter.cc
+@@ -32,7 +32,6 @@
+ #include "components/password_manager/core/common/password_manager_pref_names.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "google_apis/gaia/gaia_auth_util.h"
+ #include "google_apis/gaia/gaia_urls.h"
+ 
+@@ -751,7 +750,7 @@ StoreMetricsReporter::StoreMetricsReport
+   is_account_storage_active_ =
+       features_util::IsAccountStorageActive(sync_service);
+ 
+-  is_safe_browsing_enabled_ = safe_browsing::IsSafeBrowsingEnabled(*prefs_);
++  is_safe_browsing_enabled_ = false;
+ 
+   if (settings) {
+     // TODO(crbug.com/358998546): use PasswordManagerSettingsService here.
+--- a/components/password_manager/core/browser/sync_credentials_filter.cc
++++ b/components/password_manager/core/browser/sync_credentials_filter.cc
+@@ -12,7 +12,6 @@
+ #include "components/password_manager/core/browser/password_manager_util.h"
+ #include "components/password_manager/core/browser/password_sync_util.h"
+ #include "components/signin/public/base/consent_level.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "google_apis/gaia/gaia_auth_util.h"
+@@ -29,48 +28,7 @@ bool SyncCredentialsFilter::ShouldSave(c
+   if (client_->IsOffTheRecord()) {
+     return false;
+   }
+-
+-  if (form.form_data.is_gaia_with_skip_save_password_form()) {
+-    return false;
+-  }
+-
+-  if (!sync_util::IsGaiaCredentialPage(form.signon_realm)) {
+-    return true;
+-  }
+-
+-  // Note that `sync_service` may be null in advanced cases like --disable-sync
+-  // being used as per syncer::IsSyncAllowedByFlag().
+-  const syncer::SyncService* sync_service = client_->GetSyncService();
+-
+-  // The requirement to fulfill is "don't offer to save a Gaia password inside
+-  // its own account".
+-  // Let's assume that if the browser is signed-in, new passwords are saved to
+-  // the primary signed-in account. Per sync_util::GetAccountForSaving(), that's
+-  // not always true, but let's not overcomplicate.
+-  const CoreAccountInfo primary_account = sync_service != nullptr
+-                                              ? sync_service->GetAccountInfo()
+-                                              : CoreAccountInfo();
+-  if (!primary_account.IsEmpty()) {
+-    // Only save if the account is not the same. If the username is empty, in
+-    // doubt don't save (this is relevant in the password change page).
+-    return !form.username_value.empty() &&
+-           !gaia::AreEmailsSame(base::UTF16ToUTF8(form.username_value),
+-                                primary_account.email);
+-  }
+-
+-// The browser is signed-out and the web just signed-in.
+-#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+-  // On desktop, this normally leads to immediate browser sign-in, in which case
+-  // we shouldn't offer saving. One exception is if browser sign-in is disabled.
+-  return !client_->GetPrefs()->GetBoolean(prefs::kSigninAllowed);
+-#else
+-  // On mobile, sign-in via the web page doesn't lead to browser sign-in, so
+-  // offer saving.
+-  // (Navigating to the Gaia web page opens Chrome UI which must be accepted to
+-  // perform browser+web sign-in. The code path here is only hit if that UI was
+-  // suppressed/ dismissed and the user interacted directly with the page.)
+   return true;
+-#endif
+ }
+ 
+ bool SyncCredentialsFilter::ShouldSaveGaiaPasswordHash(
+--- a/components/password_manager/core/browser/sync_credentials_filter_unittest.cc
++++ b/components/password_manager/core/browser/sync_credentials_filter_unittest.cc
+@@ -32,7 +32,6 @@
+ #include "components/password_manager/core/browser/sync_username_test_base.h"
+ #include "components/prefs/pref_registry_simple.h"
+ #include "components/prefs/testing_pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "testing/gtest/include/gtest/gtest.h"
+--- a/components/safe_browsing/content/browser/base_blocking_page.cc
++++ b/components/safe_browsing/content/browser/base_blocking_page.cc
+@@ -16,7 +16,6 @@
+ #include "components/safe_browsing/content/browser/content_unsafe_resource_util.h"
+ #include "components/safe_browsing/content/browser/safe_browsing_controller_client.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/utils.h"
+ #include "components/security_interstitials/content/security_interstitial_controller_client.h"
+ #include "components/security_interstitials/content/settings_page_helper.h"
+--- a/components/safe_browsing/content/browser/client_side_detection_service.cc
++++ b/components/safe_browsing/content/browser/client_side_detection_service.cc
+@@ -33,7 +33,6 @@
+ #include "components/safe_browsing/core/common/features.h"
+ #include "components/safe_browsing/core/common/proto/client_model.pb.h"
+ #include "components/safe_browsing/core/common/proto/csd.pb.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/safebrowsing_constants.h"
+ #include "components/safe_browsing/core/common/utils.h"
+ #include "content/public/browser/browser_task_traits.h"
+--- a/components/safe_browsing/content/browser/safe_browsing_navigation_observer_manager.cc
++++ b/components/safe_browsing/content/browser/safe_browsing_navigation_observer_manager.cc
+@@ -22,7 +22,6 @@
+ #include "components/safe_browsing/content/browser/web_ui/safe_browsing_ui.h"
+ #include "components/safe_browsing/core/browser/referrer_chain_provider.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/utils.h"
+ #include "components/sessions/content/session_tab_helper.h"
+ #include "content/public/browser/browser_context.h"
+@@ -376,7 +375,7 @@ GURL SafeBrowsingNavigationObserverManag
+ bool SafeBrowsingNavigationObserverManager::IsEnabledAndReady(
+     PrefService* prefs,
+     bool has_safe_browsing_service) {
+-  return IsSafeBrowsingEnabled(*prefs) && has_safe_browsing_service;
++  return false;
+ }
+ 
+ // static
+--- a/components/safe_browsing/content/browser/triggers/suspicious_site_trigger_unittest.cc
++++ b/components/safe_browsing/content/browser/triggers/suspicious_site_trigger_unittest.cc
+@@ -12,7 +12,6 @@
+ #include "build/build_config.h"
+ #include "components/prefs/testing_pref_service.h"
+ #include "components/safe_browsing/content/browser/triggers/mock_trigger_manager.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "content/public/test/browser_task_environment.h"
+ #include "content/public/test/navigation_simulator.h"
+ #include "content/public/test/test_renderer_host.h"
+--- a/components/safe_browsing/content/browser/triggers/trigger_manager.cc
++++ b/components/safe_browsing/content/browser/triggers/trigger_manager.cc
+@@ -13,7 +13,6 @@
+ #include "components/safe_browsing/content/browser/threat_details.h"
+ #include "components/safe_browsing/content/browser/web_contents_key.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/security_interstitials/core/unsafe_resource.h"
+ #include "content/public/browser/browser_context.h"
+ #include "content/public/browser/browser_thread.h"
+--- a/components/safe_browsing/content/browser/triggers/trigger_throttler.cc
++++ b/components/safe_browsing/content/browser/triggers/trigger_throttler.cc
+@@ -152,33 +152,6 @@ void TriggerThrottler::CleanupOldEvents(
+ 
+ void TriggerThrottler::LoadTriggerEventsFromPref() {
+   trigger_events_.clear();
+-  if (!local_state_prefs_) {
+-    return;
+-  }
+-
+-  const base::DictValue& event_dict =
+-      local_state_prefs_->GetDict(prefs::kSafeBrowsingTriggerEventTimestamps);
+-  for (auto trigger_pair : event_dict) {
+-    // Check that the first item in the pair is convertible to a trigger type
+-    // and that the second item is a list.
+-    int trigger_type_int;
+-    if (!base::StringToInt(trigger_pair.first, &trigger_type_int) ||
+-        trigger_type_int < static_cast<int>(TriggerType::kMinTriggerType) ||
+-        trigger_type_int > static_cast<int>(TriggerType::kMaxTriggerType)) {
+-      continue;
+-    }
+-    if (!trigger_pair.second.is_list()) {
+-      continue;
+-    }
+-
+-    const TriggerType trigger_type = static_cast<TriggerType>(trigger_type_int);
+-    for (const auto& timestamp : trigger_pair.second.GetList()) {
+-      if (timestamp.is_double()) {
+-        trigger_events_[trigger_type].push_back(
+-            base::Time::FromSecondsSinceUnixEpoch(timestamp.GetDouble()));
+-      }
+-    }
+-  }
+ }
+ 
+ void TriggerThrottler::WriteTriggerEventsToPref() {
+@@ -196,9 +169,6 @@ void TriggerThrottler::WriteTriggerEvent
+     trigger_dict.Set(base::NumberToString(static_cast<int>(trigger_item.first)),
+                      std::move(timestamps));
+   }
+-
+-  local_state_prefs_->SetDict(prefs::kSafeBrowsingTriggerEventTimestamps,
+-                              std::move(trigger_dict));
+ }
+ 
+ size_t TriggerThrottler::GetDailyQuotaForTrigger(
+--- a/components/safe_browsing/content/browser/triggers/trigger_throttler_unittest.cc
++++ b/components/safe_browsing/content/browser/triggers/trigger_throttler_unittest.cc
+@@ -9,7 +9,6 @@
+ #include "base/test/simple_test_clock.h"
+ #include "components/prefs/testing_pref_service.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "testing/gmock/include/gmock/gmock.h"
+ #include "testing/gtest/include/gtest/gtest.h"
+ 
+--- a/components/safe_browsing/content/browser/ui_manager.cc
++++ b/components/safe_browsing/content/browser/ui_manager.cc
+@@ -20,7 +20,6 @@
+ #include "components/safe_browsing/core/browser/db/v4_protocol_manager_util.h"
+ #include "components/safe_browsing/core/browser/ping_manager.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/utils.h"
+ #include "components/security_interstitials/content/security_interstitial_tab_helper.h"
+ #include "components/security_interstitials/core/unsafe_resource.h"
+--- a/components/safe_browsing/content/browser/ui_manager_unittest.cc
++++ b/components/safe_browsing/content/browser/ui_manager_unittest.cc
+@@ -17,7 +17,6 @@
+ #include "components/safe_browsing/content/browser/safe_browsing_controller_client.h"
+ #include "components/safe_browsing/core/browser/db/util.h"
+ #include "components/safe_browsing/core/browser/db/v4_protocol_manager_util.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/security_interstitials/content/security_interstitial_controller_client.h"
+ #include "components/security_interstitials/content/settings_page_helper.h"
+ #include "components/security_interstitials/core/base_safe_browsing_error_ui.h"
+--- a/components/safe_browsing/core/browser/db/sb_protocol_manager_util.cc
++++ b/components/safe_browsing/core/browser/db/sb_protocol_manager_util.cc
+@@ -84,7 +84,6 @@ void SetSbV4UrlPrefixForTesting(const ch
+ 
+ std::string GetReportUrl(const V4ProtocolConfig& config,
+                          const std::string& method,
+-                         const ExtendedReportingLevel* reporting_level,
+                          const bool is_enhanced_protection) {
+   std::string url = base::StringPrintf(
+       "%s/%s?client=%s&appver=%s&pver=4.0", kSbReportsURLPrefix, method.c_str(),
+@@ -94,10 +93,6 @@ std::string GetReportUrl(const V4Protoco
+     base::StringAppendF(&url, "&key=%s",
+                         base::EscapeQueryParamValue(api_key, true).c_str());
+   }
+-  if (reporting_level) {
+-    url.append(
+-        base::StringPrintf("&ext=%d", static_cast<int>(*reporting_level)));
+-  }
+   if (is_enhanced_protection) {
+     url.append(base::StringPrintf("&enh=%d", is_enhanced_protection));
+   }
+--- a/components/safe_browsing/core/browser/db/sb_protocol_manager_util.h
++++ b/components/safe_browsing/core/browser/db/sb_protocol_manager_util.h
+@@ -20,9 +20,10 @@
+ #include <vector>
+ 
+ #include "base/containers/flat_set.h"
++#include "base/files/file_path.h"
+ #include "base/gtest_prod_util.h"
++#include "base/time/time.h"
+ #include "components/safe_browsing/core/browser/db/safebrowsing.pb.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "url/gurl.h"
+ 
+ namespace net {
+@@ -60,7 +61,6 @@ void SetSbV4UrlPrefixForTesting(const ch
+ std::string GetReportUrl(
+     const V4ProtocolConfig& config,
+     const std::string& method,
+-    const ExtendedReportingLevel* reporting_level = nullptr,
+     const bool is_enhanced_protection = false);
+ 
+ // Used to specify the type of check to perform in CheckBrowseUrl function.
+--- a/components/safe_browsing/core/browser/db/util.h
++++ b/components/safe_browsing/core/browser/db/util.h
+@@ -17,7 +17,6 @@
+ #include "base/containers/flat_map.h"
+ #include "base/trace_event/traced_value.h"
+ #include "components/safe_browsing/core/browser/db/v4_protocol_manager_util.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ namespace safe_browsing {
+ 
+--- a/components/safe_browsing/core/browser/db/v4_local_database_manager.cc
++++ b/components/safe_browsing/core/browser/db/v4_local_database_manager.cc
+@@ -298,10 +298,9 @@ const V4LocalDatabaseManager*
+ scoped_refptr<V4LocalDatabaseManager> V4LocalDatabaseManager::Create(
+     const base::FilePath& base_path,
+     scoped_refptr<base::SequencedTaskRunner> ui_task_runner,
+-    scoped_refptr<base::SequencedTaskRunner> io_task_runner,
+-    ExtendedReportingLevelCallback extended_reporting_level_callback) {
++    scoped_refptr<base::SequencedTaskRunner> io_task_runner) {
+   return base::WrapRefCounted(new V4LocalDatabaseManager(
+-      base_path, extended_reporting_level_callback, std::move(ui_task_runner),
++      base_path, std::move(ui_task_runner),
+       std::move(io_task_runner), nullptr));
+ }
+ 
+@@ -324,13 +323,11 @@ void V4LocalDatabaseManager::CollectData
+ 
+ V4LocalDatabaseManager::V4LocalDatabaseManager(
+     const base::FilePath& base_path,
+-    ExtendedReportingLevelCallback extended_reporting_level_callback,
+     scoped_refptr<base::SequencedTaskRunner> ui_task_runner,
+     scoped_refptr<base::SequencedTaskRunner> io_task_runner,
+     scoped_refptr<base::SequencedTaskRunner> task_runner_for_tests)
+     : SafeBrowsingDatabaseManager(std::move(ui_task_runner)),
+       base_path_(base_path),
+-      extended_reporting_level_callback_(extended_reporting_level_callback),
+       list_infos_(GetListInfos()),
+       task_runner_(task_runner_for_tests
+                        ? task_runner_for_tests
+@@ -1190,8 +1187,7 @@ void V4LocalDatabaseManager::SetupUpdate
+                           weak_factory_.GetWeakPtr());
+ 
+   v4_update_protocol_manager_ = std::make_unique<V4UpdateProtocolManager>(
+-      url_loader_factory, config, update_callback,
+-      extended_reporting_level_callback_);
++      url_loader_factory, config, update_callback);
+ }
+ 
+ void V4LocalDatabaseManager::UpdateRequestCompleted(
+--- a/components/safe_browsing/core/browser/db/v4_local_database_manager.h
++++ b/components/safe_browsing/core/browser/db/v4_local_database_manager.h
+@@ -40,8 +40,7 @@ class V4LocalDatabaseManager : public Sa
+   static scoped_refptr<V4LocalDatabaseManager> Create(
+       const base::FilePath& base_path,
+       scoped_refptr<base::SequencedTaskRunner> ui_task_runner,
+-      scoped_refptr<base::SequencedTaskRunner> io_task_runner,
+-      ExtendedReportingLevelCallback extended_reporting_level_callback);
++      scoped_refptr<base::SequencedTaskRunner> io_task_runner);
+ 
+   V4LocalDatabaseManager(const V4LocalDatabaseManager&) = delete;
+   V4LocalDatabaseManager& operator=(const V4LocalDatabaseManager&) = delete;
+@@ -110,7 +109,6 @@ class V4LocalDatabaseManager : public Sa
+   // Must be initialized by calling StartOnUIThread() before using.
+   V4LocalDatabaseManager(
+       const base::FilePath& base_path,
+-      ExtendedReportingLevelCallback extended_reporting_level_callback,
+       scoped_refptr<base::SequencedTaskRunner> ui_task_runner,
+       scoped_refptr<base::SequencedTaskRunner> io_task_runner,
+       scoped_refptr<base::SequencedTaskRunner> task_runner_for_tests);
+@@ -410,10 +408,6 @@ class V4LocalDatabaseManager : public Sa
+   // ready to process next update.
+   DatabaseUpdatedCallback db_updated_callback_;
+ 
+-  // Callback to get the current extended reporting level. Needed by the update
+-  // manager.
+-  ExtendedReportingLevelCallback extended_reporting_level_callback_;
+-
+   // The client_state of each list currently being synced. This is updated each
+   // time a database update completes, and used to send list client_state
+   // information in the full hash request.
+--- a/components/safe_browsing/core/browser/db/v4_update_protocol_manager.cc
++++ b/components/safe_browsing/core/browser/db/v4_update_protocol_manager.cc
+@@ -80,20 +80,8 @@ static const int kV4TimerStartIntervalSe
+ // Maximum time, in seconds, to wait for a response to an update request.
+ static const int kV4TimerUpdateWaitSecMax = 15 * 60;  // 15 minutes
+ 
+-ChromeClientInfo::SafeBrowsingReportingPopulation GetReportingLevelProtoValue(
+-    ExtendedReportingLevel reporting_level) {
+-  switch (reporting_level) {
+-    case SBER_LEVEL_OFF:
+-      return ChromeClientInfo::OPT_OUT;
+-    case SBER_LEVEL_LEGACY:
+-      return ChromeClientInfo::EXTENDED;
+-    case SBER_LEVEL_SCOUT:
+-      return ChromeClientInfo::SCOUT;
+-    case SBER_LEVEL_ENHANCED_PROTECTION:
+-      return ChromeClientInfo::ENHANCED_PROTECTION;
+-    default:
+-      NOTREACHED() << "Unexpected reporting_level!";
+-  }
++ChromeClientInfo::SafeBrowsingReportingPopulation GetReportingLevelProtoValue() {
++  return ChromeClientInfo::OPT_OUT;
+ }
+ 
+ // V4UpdateProtocolManager implementation --------------------------------
+@@ -106,8 +94,7 @@ void V4UpdateProtocolManager::ResetUpdat
+ V4UpdateProtocolManager::V4UpdateProtocolManager(
+     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+     const V4ProtocolConfig& config,
+-    V4UpdateCallback update_callback,
+-    ExtendedReportingLevelCallback extended_reporting_level_callback)
++    V4UpdateCallback update_callback)
+     : update_error_count_(0),
+       update_back_off_mult_(1),
+       next_update_interval_(
+@@ -115,8 +102,7 @@ V4UpdateProtocolManager::V4UpdateProtoco
+                                                kV4TimerStartIntervalSecMax))),
+       config_(config),
+       url_loader_factory_(url_loader_factory),
+-      update_callback_(update_callback),
+-      extended_reporting_level_callback_(extended_reporting_level_callback) {
++      update_callback_(update_callback) {
+   // Do not auto-schedule updates. Let the owner (V4LocalDatabaseManager) do it
+   // when it is ready to process updates.
+ }
+@@ -211,11 +197,6 @@ std::string V4UpdateProtocolManager::Get
+         RICE);
+   }
+ 
+-  if (!extended_reporting_level_callback_.is_null()) {
+-    request.mutable_chrome_client_info()->set_reporting_population(
+-        GetReportingLevelProtoValue(extended_reporting_level_callback_.Run()));
+-  }
+-
+   SBProtocolManagerUtil::SetClientInfoFromConfig(request.mutable_client(),
+                                                  config_);
+ 
+--- a/components/safe_browsing/core/browser/db/v4_update_protocol_manager.h
++++ b/components/safe_browsing/core/browser/db/v4_update_protocol_manager.h
+@@ -41,9 +41,6 @@ namespace safe_browsing {
+ using V4UpdateCallback =
+     base::RepeatingCallback<void(std::unique_ptr<ParsedServerResponse>)>;
+ 
+-using ExtendedReportingLevelCallback =
+-    base::RepeatingCallback<ExtendedReportingLevel()>;
+-
+ class V4UpdateProtocolManager {
+  public:
+   V4UpdateProtocolManager(const V4UpdateProtocolManager&) = delete;
+@@ -58,8 +55,7 @@ class V4UpdateProtocolManager {
+   V4UpdateProtocolManager(
+       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+       const V4ProtocolConfig& config,
+-      V4UpdateCallback update_callback,
+-      ExtendedReportingLevelCallback extended_reporting_level_callback);
++      V4UpdateCallback update_callback);
+ 
+   void OnURLLoaderComplete(std::optional<std::string> response_body);
+ 
+@@ -184,8 +180,6 @@ class V4UpdateProtocolManager {
+   // complete.
+   base::OneShotTimer timeout_timer_;
+ 
+-  ExtendedReportingLevelCallback extended_reporting_level_callback_;
+-
+   SEQUENCE_CHECKER(sequence_checker_);
+ };
+ 
+--- a/components/safe_browsing/core/browser/password_protection/password_protection_service_base.h
++++ b/components/safe_browsing/core/browser/password_protection/password_protection_service_base.h
+@@ -28,7 +28,6 @@
+ #include "components/safe_browsing/core/browser/safe_browsing_metrics_collector.h"
+ #include "components/safe_browsing/core/browser/safe_browsing_token_fetcher.h"
+ #include "components/safe_browsing/core/common/proto/csd.pb.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/sessions/core/session_id.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "services/network/public/cpp/shared_url_loader_factory.h"
+@@ -148,10 +147,6 @@ class PasswordProtectionServiceBase : pu
+   // Returns if the warning UI is enabled.
+   bool IsWarningEnabled(ReusedPasswordAccountType password_type);
+ 
+-  // Returns the pref value of password protection warning trigger.
+-  virtual PasswordProtectionTrigger GetPasswordProtectionWarningTriggerPref(
+-      ReusedPasswordAccountType password_type) const = 0;
+-
+   // If |url| matches Safe Browsing allowlist domains, password protection
+   // change password URL, or password protection login URLs in the enterprise
+   // policy.
+--- a/components/safe_browsing/core/browser/realtime/policy_engine.cc
++++ b/components/safe_browsing/core/browser/realtime/policy_engine.cc
+@@ -11,7 +11,6 @@
+ #include "components/enterprise/connectors/core/common.h"
+ #include "components/enterprise/connectors/core/connectors_prefs.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/utils.h"
+ #include "components/unified_consent/pref_names.h"
+ #include "components/user_prefs/user_prefs.h"
+@@ -56,7 +55,7 @@ bool RealTimePolicyEngine::IsUserMbbOpte
+ 
+ // static
+ bool RealTimePolicyEngine::IsUserEpOptedIn(PrefService* pref_service) {
+-  return IsEnhancedProtectionEnabled(*pref_service);
++  return false;
+ }
+ 
+ // static
+@@ -118,15 +117,7 @@ bool RealTimePolicyEngine::CanPerformEnt
+     return false;
+   }
+ 
+-  if (pref_service->GetInteger(
+-          enterprise_connectors::kEnterpriseRealTimeUrlCheckMode) !=
+-      enterprise_connectors::REAL_TIME_CHECK_FOR_MAINFRAME_ENABLED) {
+-    base::UmaHistogramEnumeration("SafeBrowsing.RT.ConsumerVersionReason",
+-                                  ConsumerVersionReason::POLICY_DISABLED);
+-    return false;
+-  }
+-
+-  return true;
++  return false;
+ }
+ 
+ }  // namespace safe_browsing
+--- a/components/safe_browsing/core/browser/realtime/url_lookup_service.cc
++++ b/components/safe_browsing/core/browser/realtime/url_lookup_service.cc
+@@ -23,7 +23,6 @@
+ #include "components/safe_browsing/core/browser/utils/safe_browsing_web_app_utils.h"
+ #include "components/safe_browsing/core/browser/verdict_cache_manager.h"
+ #include "components/safe_browsing/core/common/proto/csd.pb.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/utils.h"
+ #include "components/unified_consent/pref_names.h"
+ #include "net/base/ip_address.h"
+@@ -105,8 +104,7 @@ bool RealTimeUrlLookupService::CanSendPa
+ }
+ 
+ bool RealTimeUrlLookupService::CanIncludeSubframeUrlInReferrerChain() const {
+-  return IsEnhancedProtectionEnabled(*pref_service_) &&
+-         CanPerformFullURLLookup();
++  return false;
+ }
+ 
+ bool RealTimeUrlLookupService::CanCheckSafeBrowsingDb() const {
+@@ -123,9 +121,7 @@ bool RealTimeUrlLookupService::CanCheckS
+ }
+ 
+ bool RealTimeUrlLookupService::CanSendRTSampleRequest() const {
+-  return IsExtendedReportingEnabled(*pref_service_) &&
+-         (bypass_protego_probability_for_tests_ ||
+-          base::RandDouble() <= kProbabilityForSendingSampledRequests);
++  return false;
+ }
+ 
+ std::string RealTimeUrlLookupService::GetUserEmail() const {
+@@ -242,14 +238,6 @@ RealTimeUrlLookupService::GetMinAllowedT
+ 
+ void RealTimeUrlLookupService::MaybeLogLastProtegoPingTimeToPrefs(
+     bool sent_with_token) {
+-  // `pref_service_` can be null in tests.
+-  if (pref_service_ && IsEnhancedProtectionEnabled(*pref_service_)) {
+-    pref_service_->SetTime(
+-        sent_with_token
+-            ? prefs::kSafeBrowsingEsbProtegoPingWithTokenLastLogTime
+-            : prefs::kSafeBrowsingEsbProtegoPingWithoutTokenLastLogTime,
+-        base::Time::Now());
+-  }
+ }
+ 
+ void RealTimeUrlLookupService::MaybeLogProtegoPingCookieHistograms(
+--- a/components/safe_browsing/core/browser/realtime/url_lookup_service_base.cc
++++ b/components/safe_browsing/core/browser/realtime/url_lookup_service_base.cc
+@@ -25,7 +25,6 @@
+ #include "components/safe_browsing/core/browser/referrer_chain_provider.h"
+ #include "components/safe_browsing/core/browser/verdict_cache_manager.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/safebrowsing_constants.h"
+ #include "components/safe_browsing/core/common/utils.h"
+ #include "net/base/ip_address.h"
+--- a/components/safe_browsing/core/browser/safe_browsing_metrics_collector.cc
++++ b/components/safe_browsing/core/browser/safe_browsing_metrics_collector.cc
+@@ -15,13 +15,11 @@
+ #include "components/password_manager/core/common/password_manager_pref_names.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/prefs/scoped_user_pref_update.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ namespace {
+ 
+ using EventType = safe_browsing::SafeBrowsingMetricsCollector::EventType;
+ using UserState = safe_browsing::SafeBrowsingMetricsCollector::UserState;
+-using SafeBrowsingState = safe_browsing::SafeBrowsingState;
+ 
+ const int kMetricsLoggingIntervalDay = 1;
+ 
+@@ -62,11 +60,6 @@ SafeBrowsingMetricsCollector::SafeBrowsi
+     PrefService* pref_service)
+     : pref_service_(pref_service) {
+   pref_change_registrar_.Init(pref_service_);
+-  pref_change_registrar_.Add(
+-      prefs::kSafeBrowsingEnhanced,
+-      base::BindRepeating(
+-          &SafeBrowsingMetricsCollector::OnEnhancedProtectionPrefChanged,
+-          base::Unretained(this)));
+ }
+ 
+ void SafeBrowsingMetricsCollector::Shutdown() {
+@@ -82,16 +75,6 @@ void SafeBrowsingMetricsCollector::
+ }
+ 
+ void SafeBrowsingMetricsCollector::StartLogging() {
+-  base::TimeDelta log_interval = base::Days(kMetricsLoggingIntervalDay);
+-  base::Time last_log_time =
+-      base::Time::FromDeltaSinceWindowsEpoch(base::Seconds(
+-          pref_service_->GetInt64(prefs::kSafeBrowsingMetricsLastLogTime)));
+-  base::TimeDelta delay = base::Time::Now() - last_log_time;
+-  if (delay >= log_interval) {
+-    LogMetricsAndScheduleNextLogging();
+-  } else {
+-    ScheduleNextLoggingAfterInterval(log_interval - delay);
+-  }
+ }
+ 
+ void SafeBrowsingMetricsCollector::LogMetricsAndScheduleNextLogging() {
+@@ -100,77 +83,10 @@ void SafeBrowsingMetricsCollector::LogMe
+   MaybeLogDailyEsbProtegoPingSent();
+   RemoveOldEventsFromPref();
+ 
+-  pref_service_->SetInt64(
+-      prefs::kSafeBrowsingMetricsLastLogTime,
+-      base::Time::Now().ToDeltaSinceWindowsEpoch().InSeconds());
+   ScheduleNextLoggingAfterInterval(base::Days(kMetricsLoggingIntervalDay));
+ }
+ 
+-safe_browsing::SafeBrowsingMetricsCollector::ProtegoPingType
+-SafeBrowsingMetricsCollector::GetMostRecentPingType(
+-    base::Time last_ping_with_token,
+-    base::Time last_ping_without_token,
+-    base::TimeDelta time_delta) {
+-  // If a ping with token was sent within the last time_delta,
+-  // the most recent ping type is kWithToken.
+-  // If both last_ping_with_token and last_ping_without_token are present,
+-  // we log kWithToken instead of kWithoutToken because if a token has been
+-  // sent before, we are certain that this account is a signed in account
+-  // and the server has received the token.
+-  // The kWithoutToken ping could be sent after the account logged out.
+-  if (base::Time::Now() - last_ping_with_token < time_delta) {
+-    return ProtegoPingType::kWithToken;
+-  } else if (base::Time::Now() - last_ping_without_token < time_delta) {
+-    return ProtegoPingType::kWithoutToken;
+-  }
+-  return ProtegoPingType::kNone;
+-}
+-
+ void SafeBrowsingMetricsCollector::MaybeLogDailyEsbProtegoPingSent() {
+-  if (GetSafeBrowsingState(*pref_service_) !=
+-      SafeBrowsingState::ENHANCED_PROTECTION) {
+-    return;
+-  }
+-
+-  auto last_ping_with_token = pref_service_->GetTime(
+-      prefs::kSafeBrowsingEsbProtegoPingWithTokenLastLogTime);
+-  auto last_ping_without_token = pref_service_->GetTime(
+-      prefs::kSafeBrowsingEsbProtegoPingWithoutTokenLastLogTime);
+-  auto most_recent_ping_type = last_ping_with_token > last_ping_without_token
+-                                   ? ProtegoPingType::kWithToken
+-                                   : ProtegoPingType::kWithoutToken;
+-  auto most_recent_ping_time =
+-      std::max(last_ping_with_token, last_ping_without_token);
+-
+-  auto most_recent_collector_run_time = PrefValueToTime(
+-      pref_service_->GetValue(prefs::kSafeBrowsingMetricsLastLogTime));
+-
+-  bool sent_ping_since_last_collector_run =
+-      most_recent_ping_time > most_recent_collector_run_time;
+-  base::UmaHistogramEnumeration(
+-      "SafeBrowsing.Enhanced.ProtegoRequestSentInLast24Hours",
+-      sent_ping_since_last_collector_run ? most_recent_ping_type
+-                                         : ProtegoPingType::kNone);
+-
+-  auto logged_ping_last_24_hours_type = GetMostRecentPingType(
+-      last_ping_with_token, last_ping_without_token, base::Hours(24));
+-  base::UmaHistogramEnumeration(
+-      "SafeBrowsing.Enhanced.ProtegoRequestSentInLast24Hours2",
+-      logged_ping_last_24_hours_type);
+-
+-  auto logged_ping_last_7_days_type = GetMostRecentPingType(
+-      last_ping_with_token, last_ping_without_token, base::Days(7));
+-
+-  base::UmaHistogramEnumeration(
+-      "SafeBrowsing.Enhanced.ProtegoRequestSentInLast7Days",
+-      logged_ping_last_7_days_type);
+-
+-  auto logged_ping_last_28_days_type = GetMostRecentPingType(
+-      last_ping_with_token, last_ping_without_token, base::Days(28));
+-
+-  base::UmaHistogramEnumeration(
+-      "SafeBrowsing.Enhanced.ProtegoRequestSentInLast28Days",
+-      logged_ping_last_28_days_type);
+ }
+ 
+ void SafeBrowsingMetricsCollector::ScheduleNextLoggingAfterInterval(
+@@ -182,75 +98,16 @@ void SafeBrowsingMetricsCollector::Sched
+ }
+ 
+ void SafeBrowsingMetricsCollector::LogDailyOptInMetrics() {
+-  base::UmaHistogramEnumeration("SafeBrowsing.Pref.Daily.SafeBrowsingState",
+-                                GetSafeBrowsingState(*pref_service_));
+-  base::UmaHistogramBoolean("SafeBrowsing.Pref.Daily.Extended",
+-                            IsExtendedReportingEnabled(*pref_service_));
+-  base::UmaHistogramBoolean("SafeBrowsing.Pref.Daily.SafeBrowsingModeManaged",
+-                            IsSafeBrowsingPolicyManaged(*pref_service_));
+-  base::UmaHistogramBoolean(
+-      "SafeBrowsing.Pref.Daily.PasswordLeakToggle",
+-      pref_service_->GetBoolean(
+-          password_manager::prefs::kPasswordLeakDetectionEnabled));
+ }
+ 
+ void SafeBrowsingMetricsCollector::LogDailyEventMetrics() {
+-  SafeBrowsingState sb_state = GetSafeBrowsingState(*pref_service_);
+-  if (sb_state == SafeBrowsingState::NO_SAFE_BROWSING) {
+-    return;
+-  }
+-  UserState user_state = GetUserState();
+-
+-  int total_bypass_count = 0;
+-  int total_security_sensitive_event_count = 0;
+-  for (int event_type_int = 0; event_type_int <= EventType::kMaxValue;
+-       event_type_int += 1) {
+-    EventType event_type = static_cast<EventType>(event_type_int);
+-    if (IsBypassEventType(event_type)) {
+-      int bypass_count = GetEventCountSince(user_state, event_type,
+-                                            base::Time::Now() - base::Days(28));
+-      total_bypass_count += bypass_count;
+-    }
+-    if (IsSecuritySensitiveEventType(event_type)) {
+-      int security_sensitive_event_count = GetEventCountSince(
+-          user_state, event_type, base::Time::Now() - base::Days(28));
+-      total_security_sensitive_event_count += security_sensitive_event_count;
+-    }
+-  }
+-  base::UmaHistogramCounts100(
+-      base::StrCat({"SafeBrowsing.Daily.BypassCountLast28Days.",
+-                    GetUserStateMetricSuffix(user_state), ".AllEvents"}),
+-      total_bypass_count);
+-  base::UmaHistogramCounts100(
+-      base::StrCat({"SafeBrowsing.Daily.SecuritySensitiveCountLast28Days.",
+-                    GetUserStateMetricSuffix(user_state), ".AllEvents"}),
+-      total_security_sensitive_event_count);
+ }
+ 
+ void SafeBrowsingMetricsCollector::RemoveOldEventsFromPref() {
+-  ScopedDictPrefUpdate update(pref_service_,
+-                              prefs::kSafeBrowsingEventTimestamps);
+-  base::DictValue& mutable_state_dict = update.Get();
+-
+-  for (auto state_map : mutable_state_dict) {
+-    for (auto event_map : state_map.second.GetDict()) {
+-      event_map.second.GetList().EraseIf([&](const auto& timestamp) {
+-        return base::Time::Now() - PrefValueToTime(timestamp) >
+-               base::Days(kEventMaxDurationDay);
+-      });
+-    }
+-  }
+ }
+ 
+ void SafeBrowsingMetricsCollector::AddSafeBrowsingEventToPref(
+     EventType event_type) {
+-  SafeBrowsingState sb_state = GetSafeBrowsingState(*pref_service_);
+-  // Skip the event if Safe Browsing is disabled.
+-  if (sb_state == SafeBrowsingState::NO_SAFE_BROWSING) {
+-    return;
+-  }
+-
+-  AddSafeBrowsingEventAndUserStateToPref(GetUserState(), event_type);
+ }
+ 
+ void SafeBrowsingMetricsCollector::AddBypassEventToPref(
+@@ -293,15 +150,7 @@ std::optional<base::Time> SafeBrowsingMe
+ std::optional<base::Time> SafeBrowsingMetricsCollector::GetLatestEventTimestamp(
+     EventTypeFilter event_type_filter) {
+   // Events are not logged when Safe Browsing is disabled.
+-  SafeBrowsingState sb_state = GetSafeBrowsingState(*pref_service_);
+-  if (sb_state == SafeBrowsingState::NO_SAFE_BROWSING) {
+     return std::nullopt;
+-  }
+-
+-  const std::optional<Event> event =
+-      GetLatestEventFromEventTypeFilter(GetUserState(), event_type_filter);
+-  return event ? std::optional<base::Time>(event.value().timestamp)
+-               : std::nullopt;
+ }
+ 
+ std::optional<base::Time>
+@@ -313,45 +162,15 @@ SafeBrowsingMetricsCollector::GetLatestS
+ void SafeBrowsingMetricsCollector::AddSafeBrowsingEventAndUserStateToPref(
+     UserState user_state,
+     EventType event_type) {
+-  ScopedDictPrefUpdate update(pref_service_,
+-                              prefs::kSafeBrowsingEventTimestamps);
+-  base::DictValue& mutable_state_dict = update.Get();
+-  base::DictValue* event_dict =
+-      mutable_state_dict.EnsureDict(UserStateToPrefKey(user_state));
+-  base::ListValue* timestamps =
+-      event_dict->EnsureList(EventTypeToPrefKey(event_type));
+-
+-  // Remove the oldest timestamp if the length of the timestamps hits the limit.
+-  while (timestamps->size() >= kTimestampsMaxLength) {
+-    timestamps->erase(timestamps->begin());
+-  }
+-
+-  timestamps->Append(TimeToPrefValue(base::Time::Now()));
+ }
+ 
+ void SafeBrowsingMetricsCollector::OnEnhancedProtectionPrefChanged() {
+-  // Pref changed by policy is not initiated by users, so this case is ignored.
+-  if (IsSafeBrowsingPolicyManaged(*pref_service_)) {
+-    return;
+-  }
+-
+-  if (!pref_service_->GetBoolean(prefs::kSafeBrowsingEnhanced)) {
+-    AddSafeBrowsingEventAndUserStateToPref(UserState::kEnhancedProtection,
+-                                           EventType::USER_STATE_DISABLED);
+-    LogEnhancedProtectionDisabledMetrics();
+-  } else {
+-    AddSafeBrowsingEventAndUserStateToPref(UserState::kEnhancedProtection,
+-                                           EventType::USER_STATE_ENABLED);
+-  }
+ }
+ 
+ const base::DictValue*
+ SafeBrowsingMetricsCollector::GetSafeBrowsingEventDictionary(
+     UserState user_state) {
+-  const base::DictValue& state_dict =
+-      pref_service_->GetDict(prefs::kSafeBrowsingEventTimestamps);
+-
+-  return state_dict.FindDict(UserStateToPrefKey(user_state));
++  return nullptr;
+ }
+ 
+ std::optional<SafeBrowsingMetricsCollector::Event>
+@@ -478,22 +297,6 @@ int SafeBrowsingMetricsCollector::GetEve
+   });
+ }
+ 
+-UserState SafeBrowsingMetricsCollector::GetUserState() {
+-  if (IsSafeBrowsingPolicyManaged(*pref_service_)) {
+-    return UserState::kManaged;
+-  }
+-
+-  SafeBrowsingState sb_state = GetSafeBrowsingState(*pref_service_);
+-  switch (sb_state) {
+-    case SafeBrowsingState::ENHANCED_PROTECTION:
+-      return UserState::kEnhancedProtection;
+-    case SafeBrowsingState::STANDARD_PROTECTION:
+-      return UserState::kStandardProtection;
+-    case SafeBrowsingState::NO_SAFE_BROWSING:
+-      NOTREACHED() << "Unexpected Safe Browsing state.";
+-  }
+-}
+-
+ bool SafeBrowsingMetricsCollector::IsBypassEventType(const EventType& type) {
+   switch (type) {
+     case EventType::USER_STATE_DISABLED:
+--- a/components/safe_browsing/core/browser/tailored_security_service/tailored_security_service.cc
++++ b/components/safe_browsing/core/browser/tailored_security_service/tailored_security_service.cc
+@@ -25,7 +25,6 @@
+ #include "components/safe_browsing/core/browser/tailored_security_service/tailored_security_service_util.h"
+ #include "components/safe_browsing/core/common/features.h"
+ #include "components/safe_browsing/core/common/safe_browsing_policy_handler.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/utils.h"
+ #include "components/signin/public/base/oauth_consumer_id.h"
+ #include "components/signin/public/identity_manager/access_token_info.h"
+@@ -244,15 +243,6 @@ TailoredSecurityService::TailoredSecurit
+     : identity_manager_(identity_manager),
+       sync_service_(sync_service),
+       prefs_(prefs) {
+-  // `prefs` can be nullptr in unit tests.
+-  if (prefs_) {
+-    pref_registrar_.Init(prefs_);
+-    pref_registrar_.Add(
+-        prefs::kAccountTailoredSecurityUpdateTimestamp,
+-        base::BindRepeating(
+-            &TailoredSecurityService::TailoredSecurityTimestampUpdateCallback,
+-            weak_ptr_factory_.GetWeakPtr()));
+-  }
+ }
+ 
+ TailoredSecurityService::~TailoredSecurityService() {
+@@ -422,34 +412,6 @@ void TailoredSecurityService::MaybeNotif
+     return;
+   }
+ 
+-  // TODO(crbug.com/483786422): Update the preference wiring in relevant each
+-  // generated.*pref class that acts whenever the settings bundle setting
+-  // changes.
+-  bool is_enhanced_protection_enabled =
+-      base::FeatureList::IsEnabled(safe_browsing::kBundledSecuritySettings)
+-          ? (GetSecurityBundleSetting(*prefs()) ==
+-             SecuritySettingsBundleSetting::ENHANCED)
+-          : IsEnhancedProtectionEnabled(*prefs());
+-  if (is_enabled && is_enhanced_protection_enabled) {
+-    RecordEnabledNotificationResult(
+-        TailoredSecurityNotificationResult::kEnhancedProtectionAlreadyEnabled);
+-    SaveRetryState(TailoredSecurityRetryState::NO_RETRY_NEEDED);
+-    return;
+-  }
+-
+-  if (is_enabled && !is_enhanced_protection_enabled) {
+-    for (auto& observer : observer_list_) {
+-      observer.OnSyncNotificationMessageRequest(true);
+-    }
+-  }
+-
+-  if (!is_enabled && is_enhanced_protection_enabled &&
+-      prefs()->GetBoolean(
+-          prefs::kEnhancedProtectionEnabledViaTailoredSecurity)) {
+-    for (auto& observer : observer_list_) {
+-      observer.OnSyncNotificationMessageRequest(false);
+-    }
+-  }
+ }
+ 
+ bool TailoredSecurityService::HistorySyncEnabledForUser() {
+--- a/components/safe_browsing/core/browser/tailored_security_service/tailored_security_service_observer_util.cc
++++ b/components/safe_browsing/core/browser/tailored_security_service/tailored_security_service_observer_util.cc
+@@ -8,7 +8,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/safe_browsing/core/browser/tailored_security_service/tailored_security_service.h"
+ #include "components/safe_browsing/core/common/safe_browsing_policy_handler.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/sync/base/user_selectable_type.h"
+ #include "components/sync/service/sync_service.h"
+ #include "components/sync/service/sync_user_settings.h"
+@@ -17,39 +16,12 @@
+ namespace safe_browsing {
+ 
+ bool CanQueryTailoredSecurityForUrl(GURL url) {
+-  return google_util::IsGoogleDomainUrl(
+-             url, google_util::ALLOW_SUBDOMAIN,
+-             google_util::ALLOW_NON_STANDARD_PORTS) ||
+-         google_util::IsYoutubeDomainUrl(url, google_util::ALLOW_SUBDOMAIN,
+-                                         google_util::ALLOW_NON_STANDARD_PORTS);
++  return false;
+ }
+ 
+ bool CanShowUnconsentedTailoredSecurityDialog(syncer::SyncService* sync_service,
+                                               PrefService* prefs) {
+-  if (IsEnhancedProtectionEnabled(*prefs))
+     return false;
+-
+-  if (!sync_service) {
+-    return false;
+-  }
+-
+-  bool sync_history_enabled =
+-      sync_service->GetUserSettings()->GetSelectedTypes().Has(
+-          syncer::UserSelectableType::kHistory);
+-  if (sync_history_enabled) {
+-    return false;
+-  }
+-
+-  if (prefs->GetBoolean(prefs::kAccountTailoredSecurityShownNotification)) {
+-    return false;
+-  }
+-
+-  if (SafeBrowsingPolicyHandler::IsSafeBrowsingProtectionLevelSetByPolicy(
+-          prefs)) {
+-    return false;
+-  }
+-
+-  return true;
+ }
+ 
+ }  // namespace safe_browsing
+--- a/components/safe_browsing/core/browser/web_ui/safe_browsing_ui_handler.cc
++++ b/components/safe_browsing/core/browser/web_ui/safe_browsing_ui_handler.cc
+@@ -59,21 +59,19 @@ SafeBrowsingUIHandler::~SafeBrowsingUIHa
+ void SafeBrowsingUIHandler::GetExperiments(const base::ListValue& args) {
+   DCHECK(!args.empty());
+   const std::string& callback_id = args[0].GetString();
+-  ResolveCallback(callback_id, GetFeatureStatusList());
++  ResolveCallback(callback_id, base::ListValue());
+ }
+ 
+ void SafeBrowsingUIHandler::GetPrefs(const base::ListValue& args) {
+   DCHECK(!args.empty());
+   const std::string& callback_id = args[0].GetString();
+-  ResolveCallback(callback_id,
+-                  safe_browsing::GetSafeBrowsingPreferencesList(user_prefs()));
++  ResolveCallback(callback_id, base::ListValue());
+ }
+ 
+ void SafeBrowsingUIHandler::GetPolicies(const base::ListValue& args) {
+   DCHECK(!args.empty());
+   const std::string& callback_id = args[0].GetString();
+-  ResolveCallback(callback_id,
+-                  safe_browsing::GetSafeBrowsingPoliciesList(user_prefs()));
++  ResolveCallback(callback_id, base::ListValue());
+ }
+ 
+ void SafeBrowsingUIHandler::GetCookie(const base::ListValue& args) {
+--- a/components/safe_browsing/core/common/BUILD.gn
++++ b/components/safe_browsing/core/common/BUILD.gn
+@@ -5,22 +5,8 @@
+ import("//components/safe_browsing/buildflags.gni")
+ import("//mojo/public/tools/bindings/mojom.gni")
+ 
+-static_library("safe_browsing_prefs") {
+-  sources = [
+-    "safe_browsing_prefs.cc",
+-    "safe_browsing_prefs.h",
+-  ]
+-
+-  configs += [ "//build/config/compiler:wexit_time_destructors" ]
+-
+-  deps = [
+-    ":features",
+-    "//components/pref_registry",
+-    "//components/prefs",
+-    "//net",
+-  ]
+-
+-  public_deps = [ "//base" ]
++group("safe_browsing_prefs") {
++  # SafeBrowsing prefs are disabled
+ }
+ 
+ source_set("safe_browsing_policy_handler") {
+--- a/components/safe_browsing/core/common/hashprefix_realtime/hash_realtime_utils.cc
++++ b/components/safe_browsing/core/common/hashprefix_realtime/hash_realtime_utils.cc
+@@ -12,7 +12,6 @@
+ #include "build/branding_buildflags.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/utils.h"
+ #include "components/variations/pref_names.h"
+ #include "components/variations/service/variations_service.h"
+@@ -102,71 +101,13 @@ HashRealTimeSelection DetermineHashRealT
+     std::optional<std::string> latest_country,
+     bool log_usage_histograms,
+     bool are_background_lookups_allowed) {
+-  // All prefs used in this method must match the ones returned by
+-  // |GetHashRealTimeSelectionConfiguringPrefs| so that consumers listening for
+-  // changes can receive them correctly.
+-  bool only_background_lookup_eligible =
+-      base::FeatureList::IsEnabled(kHashPrefixRealTimeLookupsSamplePing) &&
+-      safe_browsing::GetSafeBrowsingState(*prefs) ==
+-          SafeBrowsingState::ENHANCED_PROTECTION &&
+-      are_background_lookups_allowed;
+-
+-  struct Requirement {
+-    std::string failed_requirement_histogram_suffix;
+-    bool passes_requirement;
+-  } requirements[] = {
+-      {"IneligibleForSessionOrLocation",
+-       hash_realtime_utils::IsHashRealTimeLookupEligibleInSessionAndLocation(
+-           latest_country)},
+-      {"OffTheRecord", !is_off_the_record},
+-      {"IneligibleForSafeBrowsingState",
+-       safe_browsing::GetSafeBrowsingState(*prefs) ==
+-               SafeBrowsingState::STANDARD_PROTECTION ||
+-           only_background_lookup_eligible},
+-      {"NotAllowedByPolicy",
+-       safe_browsing::AreHashPrefixRealTimeLookupsAllowedByPolicy(*prefs)}};
+-  bool can_do_lookup = true;
+-  for (const auto& requirement : requirements) {
+-    if (!requirement.passes_requirement) {
+-      can_do_lookup = false;
+-    }
+-    if (log_usage_histograms) {
+-      base::UmaHistogramBoolean(
+-          base::StrCat({"SafeBrowsing.HPRT.Ineligible.",
+-                        requirement.failed_requirement_histogram_suffix}),
+-          !requirement.passes_requirement);
+-    }
+-  }
+-  if (log_usage_histograms) {
+-    base::UmaHistogramBoolean(
+-        "SafeBrowsing.HPRT.Ineligible.NoGoogleChromeBranding",
+-        !HasGoogleChromeBranding());
+-    base::UmaHistogramBoolean(
+-        "SafeBrowsing.HPRT.Ineligible.FeatureOff",
+-        !base::FeatureList::IsEnabled(kHashPrefixRealTimeLookups));
+-    base::UmaHistogramBoolean(
+-        "SafeBrowsing.HPRT.Ineligible.IneligibleForLocation",
+-        !IsHashRealTimeLookupEligibleInLocation(latest_country));
+-  }
+-  return can_do_lookup
+-             ?
+-#if BUILDFLAG(IS_ANDROID)
+-             (only_background_lookup_eligible
+-                  ? HashRealTimeSelection::kDatabaseManagerBackgroundOnly
+-                  : HashRealTimeSelection::kDatabaseManager)
+-#else
+-             (only_background_lookup_eligible
+-                  ? HashRealTimeSelection::kHashRealTimeServiceBackgroundOnly
+-                  : HashRealTimeSelection::kHashRealTimeService)
+-#endif
+-             : HashRealTimeSelection::kNone;
++  return HashRealTimeSelection::kNone;
+ }
+ 
+ HashRealTimeSelectionConfiguringPrefs
+ GetHashRealTimeSelectionConfiguringPrefs() {
+   std::vector<const char*> profile_prefs = {
+-      prefs::kSafeBrowsingEnabled, prefs::kSafeBrowsingEnhanced,
+-      prefs::kHashPrefixRealTimeChecksAllowedByPolicy};
++      };
+   // |kVariationsCountry| is used by |VariationsService::GetLatestCountry|.
+   std::vector<const char*> local_state_prefs = {
+       variations::prefs::kVariationsCountry};
+--- a/components/safe_browsing/core/common/safe_browsing_policy_handler.cc
++++ b/components/safe_browsing/core/common/safe_browsing_policy_handler.cc
+@@ -13,7 +13,6 @@
+ #include "components/policy/policy_constants.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/prefs/pref_value_map.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/strings/grit/components_strings.h"
+ 
+ namespace safe_browsing {
+@@ -181,34 +180,14 @@ void SafeBrowsingPolicyHandler::ApplyPol
+ 
+   if (!value.has_value())
+     return;
+-
+-  switch (value.value()) {
+-    case ProtectionLevel::kNoProtection:
+-      prefs->SetBoolean(prefs::kSafeBrowsingEnabled, false);
+-      prefs->SetBoolean(prefs::kSafeBrowsingEnhanced, false);
+-      return;
+-    case ProtectionLevel::kStandardProtection:
+-      prefs->SetBoolean(prefs::kSafeBrowsingEnabled, true);
+-      prefs->SetBoolean(prefs::kSafeBrowsingEnhanced, false);
+-      return;
+-    case ProtectionLevel::kEnhancedProtection:
+-      // |kSafeBrowsingEnhanced| is enabled, but so is
+-      // |kSafeBrowsingEnabled| because the extensions API should see Safe
+-      // Browsing as enabled. See https://crbug.com/1064722 for more background.
+-      prefs->SetBoolean(prefs::kSafeBrowsingEnabled, true);
+-      prefs->SetBoolean(prefs::kSafeBrowsingEnhanced, true);
+-      return;
+-  }
+ }
+ 
+ // static
+ SafeBrowsingPolicyHandler::ProtectionLevel
+ SafeBrowsingPolicyHandler::GetSafeBrowsingProtectionLevel(
+     const PrefService* pref_sevice) {
+-  bool safe_browsing_enhanced =
+-      pref_sevice->GetBoolean(prefs::kSafeBrowsingEnhanced);
+-  bool safe_browsing_enabled =
+-      pref_sevice->GetBoolean(prefs::kSafeBrowsingEnabled);
++  bool safe_browsing_enhanced = false;
++  bool safe_browsing_enabled = false;
+ 
+   if (safe_browsing_enhanced)
+     return ProtectionLevel::kEnhancedProtection;
+@@ -222,10 +201,8 @@ SafeBrowsingPolicyHandler::GetSafeBrowsi
+ // static
+ bool SafeBrowsingPolicyHandler::IsSafeBrowsingProtectionLevelSetByPolicy(
+     const PrefService* pref_service) {
+-  bool is_safe_browsing_enabled_managed =
+-      pref_service->IsManagedPreference(prefs::kSafeBrowsingEnabled);
+-  bool is_safe_browsing_enhanced_managed =
+-      pref_service->IsManagedPreference(prefs::kSafeBrowsingEnhanced);
++  bool is_safe_browsing_enabled_managed = false;
++  bool is_safe_browsing_enhanced_managed = false;
+   DCHECK_EQ(is_safe_browsing_enabled_managed,
+             is_safe_browsing_enhanced_managed);
+   return is_safe_browsing_enabled_managed && is_safe_browsing_enhanced_managed;
+--- a/components/safe_browsing/core/common/safe_browsing_prefs_unittest.cc
++++ b/components/safe_browsing/core/common/safe_browsing_prefs_unittest.cc
+@@ -2,7 +2,6 @@
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+ 
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ 
+ #include <string>
+ 
+--- a/components/safety_check/safety_check.cc
++++ b/components/safety_check/safety_check.cc
+@@ -4,8 +4,6 @@
+ 
+ #include "components/safety_check/safety_check.h"
+ 
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+-
+ namespace {
+ 
+ const base::TimeDelta kUnusedSitePermissionsRevocationCleanUpThreshold =
+@@ -20,21 +18,6 @@ base::TimeDelta GetUnusedSitePermissions
+ }
+ 
+ SafeBrowsingStatus CheckSafeBrowsing(PrefService* pref_service) {
+-  const PrefService::Preference* enabled_pref =
+-      pref_service->FindPreference(prefs::kSafeBrowsingEnabled);
+-  bool is_sb_enabled = pref_service->GetBoolean(prefs::kSafeBrowsingEnabled);
+-  bool is_sb_managed = enabled_pref->IsManaged();
+-
+-  if (is_sb_enabled && pref_service->GetBoolean(prefs::kSafeBrowsingEnhanced))
+-    return SafeBrowsingStatus::kEnabledEnhanced;
+-  if (is_sb_enabled && is_sb_managed)
+-    return SafeBrowsingStatus::kEnabledStandard;
+-  if (is_sb_enabled && !is_sb_managed)
+-    return SafeBrowsingStatus::kEnabledStandardAvailableEnhanced;
+-  if (is_sb_managed)
+-    return SafeBrowsingStatus::kDisabledByAdmin;
+-  if (enabled_pref->IsExtensionControlled())
+-    return SafeBrowsingStatus::kDisabledByExtension;
+   return SafeBrowsingStatus::kDisabled;
+ }
+ 
+--- a/components/security_interstitials/content/bad_clock_blocking_page.cc
++++ b/components/security_interstitials/content/bad_clock_blocking_page.cc
+@@ -7,7 +7,6 @@
+ #include <utility>
+ 
+ #include "base/strings/string_number_conversions.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/security_interstitials/content/security_interstitial_controller_client.h"
+ #include "components/security_interstitials/content/security_interstitial_page.h"
+ #include "components/security_interstitials/core/bad_clock_ui.h"
+--- a/components/security_interstitials/content/captive_portal_blocking_page.cc
++++ b/components/security_interstitials/content/captive_portal_blocking_page.cc
+@@ -14,7 +14,6 @@
+ #include "build/build_config.h"
+ #include "components/captive_portal/core/captive_portal_detector.h"
+ #include "components/captive_portal/core/captive_portal_metrics.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/security_interstitials/content/security_interstitial_controller_client.h"
+ #include "components/security_interstitials/core/controller_client.h"
+ #include "components/security_interstitials/core/metrics_helper.h"
+--- a/components/security_interstitials/content/mitm_software_blocking_page.cc
++++ b/components/security_interstitials/content/mitm_software_blocking_page.cc
+@@ -7,7 +7,6 @@
+ #include <utility>
+ 
+ #include "base/strings/string_number_conversions.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/security_interstitials/content/security_interstitial_controller_client.h"
+ #include "components/security_interstitials/content/security_interstitial_page.h"
+ #include "components/security_interstitials/core/metrics_helper.h"
+--- a/components/security_interstitials/content/security_interstitial_controller_client.cc
++++ b/components/security_interstitials/content/security_interstitial_controller_client.cc
+@@ -8,7 +8,6 @@
+ 
+ #include "components/prefs/pref_service.h"
+ #include "components/safe_browsing/core/common/features.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/safe_browsing/core/common/safebrowsing_referral_methods.h"
+ #include "components/security_interstitials/content/security_interstitial_page.h"
+ #include "components/security_interstitials/content/security_interstitial_tab_helper.h"
+@@ -173,11 +172,6 @@ PrefService* SecurityInterstitialControl
+   return prefs_;
+ }
+ 
+-const std::string
+-SecurityInterstitialControllerClient::GetExtendedReportingPrefName() const {
+-  return prefs::kSafeBrowsingScoutReportingEnabled;
+-}
+-
+ bool SecurityInterstitialControllerClient::CanLaunchDateAndTimeSettings() {
+   NOTREACHED();
+ }
+--- a/components/security_interstitials/content/security_interstitial_controller_client.h
++++ b/components/security_interstitials/content/security_interstitial_controller_client.h
+@@ -62,8 +62,6 @@ class SecurityInterstitialControllerClie
+   bool CanGoBackBeforeNavigation() override;
+ 
+  protected:
+-  // security_interstitials::ControllerClient overrides.
+-  const std::string GetExtendedReportingPrefName() const override;
+   content::WebContents* web_contents() { return &*web_contents_; }
+   content::RenderFrameHost* InterstitialRenderFrameHost() const;
+ 
+--- a/components/security_interstitials/content/security_interstitial_page.cc
++++ b/components/security_interstitials/content/security_interstitial_page.cc
+@@ -10,7 +10,6 @@
+ #include "base/values.h"
+ #include "components/grit/components_resources.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/security_interstitials/content/security_interstitial_controller_client.h"
+ #include "components/security_interstitials/core/common_string_util.h"
+ #include "components/security_interstitials/core/metrics_helper.h"
+@@ -30,13 +29,6 @@ SecurityInterstitialPage::SecurityInters
+       create_view_(true),
+       on_show_extended_reporting_pref_value_(false),
+       controller_(std::move(controller)) {
+-  // Determine if any prefs need to be updated prior to showing the security
+-  // interstitial. Note that some content embedders (such as Android WebView)
+-  // uses security interstitials without a prefservice.
+-  if (controller_->GetPrefService()) {
+-    safe_browsing::UpdatePrefsBeforeSecurityInterstitial(
+-        controller_->GetPrefService());
+-  }
+   SetUpMetrics();
+ }
+ 
+@@ -90,13 +82,7 @@ SecurityInterstitialControllerClient* Se
+ }
+ 
+ void SecurityInterstitialPage::SetUpMetrics() {
+-  // Remember the initial state of the extended reporting pref, to be compared
+-  // to the same data when the interstitial is closed.
+-  PrefService* prefs = controller_->GetPrefService();
+-  if (prefs) {
+-    on_show_extended_reporting_pref_value_ =
+-        safe_browsing::IsExtendedReportingEnabled(*prefs);
+-  }
++  on_show_extended_reporting_pref_value_ = false;
+ }
+ 
+ std::u16string SecurityInterstitialPage::GetFormattedHostName() const {
+--- a/components/security_interstitials/content/ssl_blocking_page.cc
++++ b/components/security_interstitials/content/ssl_blocking_page.cc
+@@ -11,7 +11,6 @@
+ #include "base/functional/callback_helpers.h"
+ #include "base/strings/string_number_conversions.h"
+ #include "base/time/time.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/security_interstitials/content/security_interstitial_controller_client.h"
+ #include "components/security_interstitials/content/security_interstitial_page.h"
+ #include "components/security_interstitials/core/controller_client.h"
+--- a/components/security_interstitials/core/controller_client.cc
++++ b/components/security_interstitials/core/controller_client.cc
+@@ -36,7 +36,6 @@ MetricsHelper* ControllerClient::metrics
+ 
+ void ControllerClient::SetReportingPreference(bool report) {
+   DCHECK(GetPrefService());
+-  GetPrefService()->SetBoolean(GetExtendedReportingPrefName(), report);
+   metrics_helper_->RecordUserInteraction(
+       report ? MetricsHelper::SET_EXTENDED_REPORTING_ENABLED
+              : MetricsHelper::SET_EXTENDED_REPORTING_DISABLED);
+--- a/components/security_interstitials/core/controller_client.h
++++ b/components/security_interstitials/core/controller_client.h
+@@ -149,9 +149,6 @@ class ControllerClient {
+   virtual void OpenReportingPrivacyInNewTab() {}
+   virtual void OpenWhitepaperInNewTab() {}
+ 
+- protected:
+-  virtual const std::string GetExtendedReportingPrefName() const = 0;
+-
+  private:
+   std::unique_ptr<MetricsHelper> metrics_helper_;
+   // Link to the help center.
+--- a/components/send_tab_to_self/entry_point_display_reason.cc
++++ b/components/send_tab_to_self/entry_point_display_reason.cc
+@@ -7,7 +7,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/send_tab_to_self/send_tab_to_self_model.h"
+ #include "components/send_tab_to_self/send_tab_to_self_sync_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/sync/service/sync_service.h"
+ #include "components/sync/service/sync_user_settings.h"
+@@ -19,11 +18,7 @@ namespace {
+ 
+ bool ShouldOfferSignin(syncer::SyncService* sync_service,
+                        PrefService* pref_service) {
+-  return pref_service->GetBoolean(prefs::kSigninAllowed) &&
+-         sync_service->GetAccountInfo().IsEmpty() &&
+-         !sync_service->HasDisableReason(
+-             syncer::SyncService::DISABLE_REASON_ENTERPRISE_POLICY) &&
+-         !sync_service->IsLocalSyncEnabled();
++  return false;
+ }
+ 
+ }  // namespace
+--- a/components/signin/core/browser/account_investigator.cc
++++ b/components/signin/core/browser/account_investigator.cc
+@@ -13,7 +13,6 @@
+ #include "components/prefs/pref_registry_simple.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/accounts_in_cookie_jar_info.h"
+ #include "components/signin/public/identity_manager/tribool.h"
+ #include "google_apis/gaia/gaia_auth_util.h"
+@@ -64,28 +63,18 @@ AccountInvestigator::AccountInvestigator
+     PrefService* pref_service,
+     signin::IdentityManager* identity_manager)
+     : pref_service_(pref_service),
+-      identity_manager_(identity_manager),
+-      timer_(pref_service,
+-             prefs::kGaiaCookiePeriodicReportTime,
+-             kPeriodicReportingInterval,
+-             base::BindRepeating(&AccountInvestigator::TryPeriodicReport,
+-                                 base::Unretained(this))) {}
++      identity_manager_(identity_manager) {}
+ 
+ AccountInvestigator::~AccountInvestigator() = default;
+ 
+ // static
+ void AccountInvestigator::RegisterPrefs(PrefRegistrySimple* registry) {
+-  registry->RegisterStringPref(prefs::kGaiaCookieHash, std::string());
+-  registry->RegisterDoublePref(prefs::kGaiaCookieChangedTime, 0);
+-  registry->RegisterTimePref(prefs::kGaiaCookiePeriodicReportTime,
+-                             base::Time());
+ }
+ 
+ void AccountInvestigator::Initialize() {
+   identity_manager_->AddObserver(this);
+   previously_authenticated_ =
+       identity_manager_->HasPrimaryAccount(signin::ConsentLevel::kSignin);
+-  timer_.Start();
+ }
+ 
+ void AccountInvestigator::Shutdown() {
+@@ -111,7 +100,7 @@ void AccountInvestigator::OnAccountsInCo
+   // a valid cached ListAccounts response ready for us. Or even both of these
+   // could be simultaneously happening, although this should be extremely
+   // infrequent.
+-  const std::string old_hash(pref_service_->GetString(prefs::kGaiaCookieHash));
++  const std::string old_hash;
+   const std::string new_hash(
+       HashAccounts(signed_in_accounts, signed_out_accounts));
+   const bool currently_authenticated =
+@@ -119,9 +108,6 @@ void AccountInvestigator::OnAccountsInCo
+   if (old_hash != new_hash) {
+     SharedCookieJarReport(signed_in_accounts, signed_out_accounts, Time::Now(),
+                           ReportingType::ON_CHANGE);
+-    pref_service_->SetString(prefs::kGaiaCookieHash, new_hash);
+-    pref_service_->SetDouble(prefs::kGaiaCookieChangedTime,
+-                             Time::Now().InSecondsFSinceUnixEpoch());
+   } else if (currently_authenticated && !previously_authenticated_) {
+     SignedInAccountRelationReport(signed_in_accounts, signed_out_accounts,
+                                   ReportingType::ON_CHANGE);
+@@ -251,8 +237,7 @@ void AccountInvestigator::SharedCookieJa
+     const std::vector<ListedAccount>& signed_out_accounts,
+     const Time now,
+     const ReportingType type) {
+-  const Time last_changed = Time::FromSecondsSinceUnixEpoch(
+-      pref_service_->GetDouble(prefs::kGaiaCookieChangedTime));
++  const Time last_changed = Time::Now();
+   base::TimeDelta stable_age;
+   if (!last_changed.is_null()) {
+     stable_age = std::max(now - last_changed, base::TimeDelta());
+--- a/components/signin/core/browser/account_investigator.h
++++ b/components/signin/core/browser/account_investigator.h
+@@ -119,8 +119,6 @@ class AccountInvestigator : public Keyed
+   raw_ptr<PrefService> pref_service_;
+   raw_ptr<signin::IdentityManager> identity_manager_;
+ 
+-  // Handles invoking our periodic logic at the right time.
+-  signin::PersistentRepeatingTimer timer_;
+ 
+   // If the GaiaCookieManagerService hasn't already cached the cookie data, it
+   // will not be able to return enough information for us to always perform
+--- a/components/signin/core/browser/account_investigator_unittest.cc
++++ b/components/signin/core/browser/account_investigator_unittest.cc
+@@ -14,7 +14,6 @@
+ #include "build/build_config.h"
+ #include "components/prefs/pref_registry_simple.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/identity_manager/account_capabilities_test_mutator.h"
+ #include "components/signin/public/identity_manager/accounts_in_cookie_jar_info.h"
+ #include "components/signin/public/identity_manager/identity_test_environment.h"
+--- a/components/signin/core/browser/account_reconcilor.cc
++++ b/components/signin/core/browser/account_reconcilor.cc
+@@ -30,7 +30,6 @@
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_client.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/accounts_cookie_mutator.h"
+ #include "components/signin/public/identity_manager/accounts_in_cookie_jar_info.h"
+--- a/components/signin/core/browser/account_reconcilor_unittest.cc
++++ b/components/signin/core/browser/account_reconcilor_unittest.cc
+@@ -37,7 +37,6 @@
+ #include "components/signin/public/base/list_accounts_test_utils.h"
+ #include "components/signin/public/base/signin_buildflags.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/base/test_signin_client.h"
+ #include "components/signin/public/identity_manager/account_capabilities_test_mutator.h"
+--- a/components/signin/core/browser/dice_account_reconcilor_delegate.cc
++++ b/components/signin/core/browser/dice_account_reconcilor_delegate.cc
+@@ -12,7 +12,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/accounts_in_cookie_jar_info.h"
+ #include "components/signin/public/identity_manager/accounts_mutator.h"
+--- a/components/signin/core/browser/signin_metrics_service.cc
++++ b/components/signin/core/browser/signin_metrics_service.cc
+@@ -21,7 +21,6 @@
+ #include "components/signin/core/browser/active_primary_accounts_metrics_recorder.h"
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_prefs.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+@@ -494,37 +493,10 @@ void SigninMetricsService::MaybeRecordMe
+       GetTimeOfWebSignin(account_info.account_id).has_value();
+   switch (access_point) {
+     case signin_metrics::AccessPoint::kAddressBubble:
+-      base::UmaHistogramCustomCounts(
+-          "Signin.ShowCountAtSignin.AddressSigninPromo",
+-          is_from_web_signin
+-              ? SigninPrefs(pref_service_.get())
+-                    .GetAddressSigninPromoImpressionCount(account_info.gaia)
+-              : pref_service_->GetInteger(
+-                    prefs::
+-                        kAddressSignInPromoShownCountPerProfileForLimitsExperiment),
+-          /*min=*/1, /*exclusive_max=*/10, /*buckets=*/10);
+       break;
+     case signin_metrics::AccessPoint::kPasswordBubble:
+-      base::UmaHistogramCustomCounts(
+-          "Signin.ShowCountAtSignin.PasswordSigninPromo",
+-          is_from_web_signin
+-              ? SigninPrefs(pref_service_.get())
+-                    .GetPasswordSigninPromoImpressionCount(account_info.gaia)
+-              : pref_service_->GetInteger(
+-                    prefs::
+-                        kPasswordSignInPromoShownCountPerProfileForLimitsExperiment),
+-          /*min=*/1, /*exclusive_max=*/10, /*buckets=*/10);
+       break;
+     case signin_metrics::AccessPoint::kBookmarkBubble:
+-      base::UmaHistogramCustomCounts(
+-          "Signin.ShowCountAtSignin.BookmarkSigninPromo",
+-          is_from_web_signin
+-              ? SigninPrefs(pref_service_.get())
+-                    .GetBookmarkSigninPromoImpressionCount(account_info.gaia)
+-              : pref_service_->GetInteger(
+-                    prefs::
+-                        kBookmarkSignInPromoShownCountPerProfileForLimitsExperiment),
+-          /*min=*/1, /*exclusive_max=*/10, /*buckets=*/10);
+       break;
+     case signin_metrics::AccessPoint::kChromeSigninInterceptBubble: {
+       const int uno_bubble_reprompt_count =
+--- a/components/signin/internal/identity_manager/account_tracker_service.cc
++++ b/components/signin/internal/identity_manager/account_tracker_service.cc
+@@ -35,7 +35,6 @@
+ #include "components/signin/internal/identity_manager/account_capabilities_constants.h"
+ #include "components/signin/internal/identity_manager/account_info_util.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_capabilities.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+@@ -130,11 +129,6 @@ AccountTrackerService::~AccountTrackerSe
+ 
+ // static
+ void AccountTrackerService::RegisterPrefs(PrefRegistrySimple* registry) {
+-  registry->RegisterListPref(prefs::kAccountInfo);
+-#if BUILDFLAG(IS_CHROMEOS)
+-  registry->RegisterIntegerPref(prefs::kAccountIdMigrationState,
+-                                AccountTrackerService::MIGRATION_NOT_STARTED);
+-#endif
+ }
+ 
+ void AccountTrackerService::Initialize(PrefService* pref_service,
+@@ -503,14 +497,12 @@ AccountTrackerService::ComputeNewMigrati
+ void AccountTrackerService::SetMigrationState(AccountIdMigrationState state) {
+   DCHECK(state != MIGRATION_DONE || AreAllAccountsMigrated())
+       << "state: " << state << ", accounts = " << AccountsToString(accounts_);
+-  pref_service_->SetInteger(prefs::kAccountIdMigrationState, state);
+ }
+ 
+ // static
+ AccountTrackerService::AccountIdMigrationState
+ AccountTrackerService::GetMigrationState(const PrefService* pref_service) {
+-  return static_cast<AccountTrackerService::AccountIdMigrationState>(
+-      pref_service->GetInteger(prefs::kAccountIdMigrationState));
++  return MIGRATION_NOT_STARTED;
+ }
+ #endif  // BUILDFLAG(IS_CHROMEOS)
+ 
+@@ -590,28 +582,6 @@ void AccountTrackerService::OnAccountIma
+     const CoreAccountId& account_id,
+     const std::string& image_url_with_size,
+     bool success) {
+-  if (!success || !pref_service_) {
+-    return;
+-  }
+-
+-  base::DictValue* dict = nullptr;
+-  ScopedListPrefUpdate update(pref_service_, prefs::kAccountInfo);
+-  for (base::Value& value : *update) {
+-    base::DictValue* maybe_dict = value.GetIfDict();
+-    if (maybe_dict) {
+-      const std::string* account_key =
+-          maybe_dict->FindString(signin::kAccountIdKey);
+-      if (account_key && *account_key == account_id.ToString()) {
+-        dict = maybe_dict;
+-        break;
+-      }
+-    }
+-  }
+-
+-  if (!dict) {
+-    return;
+-  }
+-  dict->Set(signin::kLastDownloadedImageURLWithSizeKey, image_url_with_size);
+ }
+ 
+ void AccountTrackerService::RemoveAccountImageFromDisk(
+@@ -624,155 +594,17 @@ void AccountTrackerService::RemoveAccoun
+ }
+ 
+ void AccountTrackerService::LoadFromPrefs() {
+-  const base::ListValue& list = pref_service_->GetList(prefs::kAccountInfo);
+-  std::set<std::string> to_remove;
+-#if BUILDFLAG(IS_CHROMEOS)
+-  std::vector<std::pair<AccountInfo, std::string>> accounts_to_migrate;
+-#endif
+-  for (const auto& i : list) {
+-    const base::DictValue* dict = i.GetIfDict();
+-    if (!dict) {
+-      continue;
+-    }
+-
+-    const std::string* account_key = dict->FindString(signin::kAccountIdKey);
+-    if (!account_key) {
+-      continue;
+-    }
+-
+-    // Ignore empty account ids.
+-    if (account_key->empty()) {
+-      to_remove.insert(*account_key);
+-      continue;
+-    }
+-    // Ignore incorrectly persisted non-canonical account ids.
+-    if (account_key->find('@') != std::string::npos &&
+-        *account_key != gaia::CanonicalizeEmail(*account_key)) {
+-      to_remove.insert(*account_key);
+-      continue;
+-    }
+-
+-    if (base::FeatureList::IsEnabled(switches::kGaiaAccountIdEnforcement)) {
+-      std::optional<AccountInfo> deserialized_account_info =
+-          signin::DeserializeAccountInfo(*dict);
+-      if (!deserialized_account_info) {
+-        to_remove.insert(*account_key);
+-        continue;
+-      }
+-#if BUILDFLAG(IS_CHROMEOS)
+-      if (deserialized_account_info->GetAccountId().ToString() !=
+-          *account_key) {
+-        accounts_to_migrate.emplace_back(*deserialized_account_info,
+-                                         *account_key);
+-        // Do not insert into accounts_ here and finish reading the list first.
+-        // This is needed to avoid re-migrating accounts that were already
+-        // migrated.
+-        continue;
+-      }
+-#endif
+-      CoreAccountId account_id = deserialized_account_info->GetAccountId();
+-      auto [it, inserted] =
+-          accounts_.insert({account_id, std::move(*deserialized_account_info)});
+-      NotifyAccountUpdated(it->second);
+-    } else {
+-      CoreAccountId account_id = CoreAccountId::FromString(*account_key);
+-      StartTrackingAccount(account_id);
+-      AccountInfo& account_info = accounts_[account_id];
+-      std::optional<AccountInfo> deserialized_account_info =
+-          signin::DeserializeAccountInfo(*dict);
+-      if (deserialized_account_info) {
+-        account_info = std::move(*deserialized_account_info);
+-      }
+-      account_info.account_id = account_id;
+-      if (!account_info.gaia.empty()) {
+-        NotifyAccountUpdated(account_info);
+-      }
+-    }
+-  }
+-
+-  // Remove any obsolete prefs.
+-  for (const auto& account_id : to_remove) {
+-    RemoveFromPrefs(account_id);
+-    RemoveAccountImageFromDisk(account_id);
+-  }
+-
+-#if BUILDFLAG(IS_CHROMEOS)
+-  if (base::FeatureList::IsEnabled(switches::kGaiaAccountIdEnforcement)) {
+-    if (GetMigrationState() != MIGRATION_DONE) {
+-      if (accounts_.empty() && accounts_to_migrate.empty()) {
+-        SetMigrationState(MIGRATION_DONE);
+-      } else {
+-        SetMigrationState(MIGRATION_IN_PROGRESS);
+-        for (const auto& [account_info, account_key] : accounts_to_migrate) {
+-          // Do not overwrite accounts that were already migrated (in case of
+-          // a partial migration crashing, etc.).
+-          if (!accounts_.contains(account_info.GetAccountId())) {
+-            SaveToPrefs(account_info);
+-            accounts_.insert({account_info.GetAccountId(), account_info});
+-            NotifyAccountUpdated(account_info);
+-          }
+-
+-          // Remove the information saved under the old account id.
+-          RemoveFromPrefs(account_key);
+-          RemoveAccountImageFromDisk(account_key);
+-        }
+-      }
+-    }
+-    CHECK(AreAllAccountsMigrated())
+-        << "state: " << (int)GetMigrationState()
+-        << ", accounts = " << AccountsToString(accounts_);
+-  } else {
+-    if (GetMigrationState() != MIGRATION_DONE) {
+-      const AccountIdMigrationState new_state = ComputeNewMigrationState();
+-      SetMigrationState(new_state);
+-
+-      if (new_state == MIGRATION_IN_PROGRESS) {
+-        MigrateToGaiaId();
+-      }
+-    }
+-    DCHECK(GetMigrationState() != MIGRATION_DONE || AreAllAccountsMigrated())
+-        << "state: " << (int)GetMigrationState()
+-        << ", accounts = " << AccountsToString(accounts_);
+-  }
+-  UMA_HISTOGRAM_ENUMERATION("Signin.AccountTracker.GaiaIdMigrationState",
+-                            GetMigrationState(), NUM_MIGRATION_STATES);
+-#else
+-  DCHECK(AreAllAccountsMigrated())
+-      << "accounts = " << AccountsToString(accounts_);
+-#endif  // BUILDFLAG(IS_CHROMEOS)
+-
+-  UMA_HISTOGRAM_COUNTS_100("Signin.AccountTracker.CountOfLoadedAccounts",
+-                           accounts_.size());
+ }
+ 
+ base::DictValue* AccountTrackerService::FindOrCreateDictForAccount(
+     ScopedListPrefUpdate& update,
+     const CoreAccountId& account_id) {
+-  for (base::Value& value : *update) {
+-    base::DictValue* dict = value.GetIfDict();
+-    if (dict) {
+-      const std::string* account_key = dict->FindString(signin::kAccountIdKey);
+-      if (account_key && *account_key == account_id.ToString()) {
+-        return dict;
+-      }
+-    }
+-  }
+-
+   update->Append(base::DictValue());
+   base::DictValue* new_dict = &update->back().GetDict();
+-  new_dict->Set(signin::kAccountIdKey, account_id.ToString());
+   return new_dict;
+ }
+ 
+ void AccountTrackerService::SaveToPrefs(const AccountInfo& account_info) {
+-  if (!pref_service_) {
+-    return;
+-  }
+-
+-  ScopedListPrefUpdate update(pref_service_, prefs::kAccountInfo);
+-  base::DictValue* dict =
+-      FindOrCreateDictForAccount(update, account_info.account_id);
+-  dict->Merge(signin::SerializeAccountInfo(account_info));
+ }
+ 
+ void AccountTrackerService::RemoveFromPrefs(
+@@ -781,15 +613,6 @@ void AccountTrackerService::RemoveFromPr
+     return;
+   }
+ 
+-  ScopedListPrefUpdate update(pref_service_, prefs::kAccountInfo);
+-  update->EraseIf([&account_id](const base::Value& value) {
+-    if (!value.is_dict()) {
+-      return false;
+-    }
+-    const std::string* account_key =
+-        value.GetDict().FindString(signin::kAccountIdKey);
+-    return account_key && *account_key == account_id;
+-  });
+ }
+ 
+ CoreAccountId AccountTrackerService::PickAccountIdForAccount(
+--- a/components/signin/internal/identity_manager/account_tracker_service_unittest.cc
++++ b/components/signin/internal/identity_manager/account_tracker_service_unittest.cc
+@@ -32,7 +32,6 @@
+ #include "components/signin/internal/identity_manager/fake_profile_oauth2_token_service.h"
+ #include "components/signin/public/base/avatar_icon_util.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/base/test_signin_client.h"
+ #include "components/signin/public/identity_manager/account_capabilities.h"
+--- a/components/signin/internal/identity_manager/gaia_cookie_manager_service.cc
++++ b/components/signin/internal/identity_manager/gaia_cookie_manager_service.cc
+@@ -32,7 +32,6 @@
+ #include "components/signin/internal/identity_manager/oauth_multilogin_helper.h"
+ #include "components/signin/public/base/signin_buildflags.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/accounts_in_cookie_jar_info.h"
+ #include "components/signin/public/identity_manager/set_accounts_in_cookie_result.h"
+@@ -433,20 +432,7 @@ GaiaCookieManagerService::GaiaCookieMana
+       listAccountsUnexpectedServerResponseRetried_(false),
+       external_cc_result_fetched_(false),
+       list_accounts_stale_(true) {
+-  std::string gaia_cookie_last_list_accounts_binary_data =
+-      signin_client_->GetPrefs()->GetString(
+-          prefs::kGaiaCookieLastListAccountsBinaryData);
+-
+-  // Parse ListAccounts data from prefs.
+-  bool parse_success = gaia::ParseBinaryListAccountsData(
+-      gaia_cookie_last_list_accounts_binary_data, &accounts_);
+-
+-  if (!parse_success) {
+     accounts_.clear();
+-    return;
+-  }
+-
+-  InitializeListedAccountsIds();
+ }
+ 
+ GaiaCookieManagerService::~GaiaCookieManagerService() {
+@@ -457,8 +443,6 @@ GaiaCookieManagerService::~GaiaCookieMan
+ 
+ // static
+ void GaiaCookieManagerService::RegisterPrefs(PrefRegistrySimple* registry) {
+-  registry->RegisterStringPref(prefs::kGaiaCookieLastListAccountsBinaryData,
+-                               std::string());
+ }
+ 
+ void GaiaCookieManagerService::InitCookieListener() {
+@@ -683,8 +667,6 @@ void GaiaCookieManagerService::OnListAcc
+   bool parse_success = gaia::ParseBinaryListAccountsData(data, &accounts_);
+   if (!parse_success) {
+     accounts_.clear();
+-    signin_client_->GetPrefs()->ClearPref(
+-        prefs::kGaiaCookieLastListAccountsBinaryData);
+     GoogleServiceAuthError error =
+         GoogleServiceAuthError::FromUnexpectedServiceResponse(
+             "Error parsing ListAccounts response");
+@@ -692,8 +674,6 @@ void GaiaCookieManagerService::OnListAcc
+     return;
+   }
+ 
+-  signin_client_->GetPrefs()->SetString(
+-      prefs::kGaiaCookieLastListAccountsBinaryData, data);
+   RecordListAccountsFailure(GoogleServiceAuthError::NONE);
+ 
+   InitializeListedAccountsIds();
+--- a/components/signin/internal/identity_manager/gaia_cookie_manager_service_unittest.cc
++++ b/components/signin/internal/identity_manager/gaia_cookie_manager_service_unittest.cc
+@@ -25,7 +25,6 @@
+ #include "components/prefs/testing_pref_service.h"
+ #include "components/signin/internal/identity_manager/account_tracker_service.h"
+ #include "components/signin/internal/identity_manager/fake_profile_oauth2_token_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/base/test_signin_client.h"
+ #include "components/signin/public/identity_manager/accounts_in_cookie_jar_info.h"
+--- a/components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc
++++ b/components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate.cc
+@@ -32,7 +32,6 @@
+ #include "components/signin/public/base/hybrid_encryption_key.h"
+ #include "components/signin/public/base/signin_client.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+ #include "components/signin/public/webdata/token_service_table.h"
+--- a/components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate_unittest.cc
++++ b/components/signin/internal/identity_manager/mutable_profile_oauth2_token_service_delegate_unittest.cc
+@@ -40,7 +40,6 @@
+ #include "components/signin/public/base/device_id_helper.h"
+ #include "components/signin/public/base/hybrid_encryption_key.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/base/test_signin_client.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+--- a/components/signin/internal/identity_manager/primary_account_manager.cc
++++ b/components/signin/internal/identity_manager/primary_account_manager.cc
+@@ -29,7 +29,6 @@
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_client.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_prefs.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+@@ -255,166 +254,25 @@ PrimaryAccountManager::PrimaryAccountMan
+   DCHECK(account_tracker_service_);
+   ScopedPrefCommit scoped_pref_commit(client_->GetPrefs(),
+                                       /*commit_on_destroy=*/false);
+-#if !BUILDFLAG(ENABLE_DICE_SUPPORT)
+-  scoped_pref_commit.ClearPref(prefs::kExplicitBrowserSignin);
+-#endif
+-
+-  // Prepare prefs before loading them.
+-  PrepareToLoadPrefs();
+-
+-  PrefService* prefs = client_->GetPrefs();
+-  std::string pref_account_id =
+-      prefs->GetString(prefs::kGoogleServicesAccountId);
+-  bool pref_consented_to_sync =
+-      prefs->GetBoolean(prefs::kGoogleServicesConsentedToSync);
+-  LogPrimaryAccountPrefsOnInitialize(pref_account_id, pref_consented_to_sync);
+-
+-  if (pref_account_id.empty()) {
+     SetPrimaryAccountInternal(CoreAccountInfo(), /*consented_to_sync=*/false,
+                               scoped_pref_commit);
+-  } else {
+-    auto [account_info, account_info_state] =
+-        GetOrRestorePrimaryAccountInfoOnInitialize(pref_account_id,
+-                                                   pref_consented_to_sync);
+-    base::UmaHistogramEnumeration(
+-        "Signin.PAMInitialize.PrimaryAccountInfoState", account_info_state);
+-
+-    if (pref_consented_to_sync && !account_info.IsEmpty()) {
+-      SetPrimaryAccountInternal(account_info, /*consented_to_sync=*/true,
+-                                scoped_pref_commit);
+-
+-#if !BUILDFLAG(IS_IOS)
+-      // Ensure that the last syncing account data is consistent with the
+-      // primary account. The last signed-in account data is written inside
+-      // SetPrimaryAccountInternal().
+-      scoped_pref_commit.SetString(prefs::kGoogleServicesLastSyncingGaiaId,
+-                                   account_info.gaia.ToString());
+-      scoped_pref_commit.SetString(prefs::kGoogleServicesLastSyncingUsername,
+-                                   account_info.email);
+-#endif  // !BUILDFLAG(IS_IOS)
+-    } else {
+-      SetPrimaryAccountInternal(account_info, /*consented_to_sync=*/false,
+-                                scoped_pref_commit);
+-    }
+-  }
+ 
+   // PrimaryAccountManager is initialized once the primary account and consent
+   // level are loaded.
+   CHECK(primary_account_.has_value());
+-
+-#if BUILDFLAG(ENABLE_DICE_SUPPORT)
+-  if (!prefs->GetBoolean(prefs::kExplicitBrowserSignin) &&
+-      HasPrimaryAccount(signin::ConsentLevel::kSync)) {
+-    // A profile that is opted in to sync can be migrated to explicit browser
+-    // sign-in as the user has explicitly signed in to the browser when they
+-    // opted in to sync.
+-    scoped_pref_commit.SetBoolean(prefs::kExplicitBrowserSignin, true);
+-  }
+-#endif
+-
+-  // `prefs::kPrefsThemesSearchEnginesAccountStorageEnabled` is set for sync
+-  // users and new signed in users. It is not cleared on sign out.
+-  if (base::FeatureList::IsEnabled(
+-          switches::kEnablePreferencesAccountStorage)) {
+-    if (HasPrimaryAccount(signin::ConsentLevel::kSync)) {
+-      scoped_pref_commit.SetBoolean(
+-          prefs::kPrefsThemesSearchEnginesAccountStorageEnabled, true);
+-    }
+-  } else {
+-    scoped_pref_commit.ClearPref(
+-        prefs::kPrefsThemesSearchEnginesAccountStorageEnabled);
+-  }
+-
+-#if BUILDFLAG(ENABLE_DICE_SUPPORT)
+-  if (HasPrimaryAccount(signin::ConsentLevel::kSignin) &&
+-      !HasPrimaryAccount(signin::ConsentLevel::kSync)) {
+-    SigninPrefs signin_prefs(*prefs);
+-    if (ShouldEnableExtensionsExplicitBrowserSigninPrefForSignedInUser()) {
+-      signin_prefs.SetExtensionsExplicitBrowserSignin(
+-          GetPrimaryAccount().account_info.gaia, true);
+-    }
+-
+-    if (ShouldEnableBookmarksExplicitBrowserSigninPrefForSignedInUser()) {
+-      signin_prefs.SetBookmarksExplicitBrowserSignin(
+-          GetPrimaryAccount().account_info.gaia, true);
+-    }
+-  }
+-#endif  // BUILDFLAG(ENABLE_DICE_SUPPORT)
+-
+-  // It is important to only load credentials after starting to observe the
+-  // token service.
+-  token_service_observation_.Observe(token_service_);
+-  token_service_->LoadCredentials(
+-      GetPrimaryAccountId(signin::ConsentLevel::kSignin));
+ }
+ 
+ PrimaryAccountManager::~PrimaryAccountManager() = default;
+ 
+ // static
+ void PrimaryAccountManager::RegisterProfilePrefs(PrefRegistrySimple* registry) {
+-#if !BUILDFLAG(IS_IOS)
+-  registry->RegisterStringPref(prefs::kGoogleServicesLastSyncingGaiaId,
+-                               std::string());
+-  registry->RegisterStringPref(prefs::kGoogleServicesLastSyncingUsername,
+-                               std::string());
+-#endif  // !BUILDFLAG(IS_IOS)
+-  registry->RegisterStringPref(prefs::kGoogleServicesLastSignedInUsername,
+-                               std::string());
+-  registry->RegisterStringPref(prefs::kGoogleServicesAccountId, std::string());
+-  registry->RegisterBooleanPref(prefs::kGoogleServicesConsentedToSync, false);
+-  registry->RegisterStringPref(
+-      prefs::kGoogleServicesSyncingGaiaIdMigratedToSignedIn, std::string());
+-  registry->RegisterStringPref(
+-      prefs::kGoogleServicesSyncingUsernameMigratedToSignedIn, std::string());
+-  registry->RegisterIntegerPref(prefs::kGoogleServicesSyncingUserMigrationType,
+-                                /*SyncToSigninMigrationType::kUnknown=*/0);
+-  registry->RegisterBooleanPref(prefs::kSigninAllowed, true);
+-  registry->RegisterBooleanPref(prefs::kSignedInWithCredentialProvider, false);
+-  registry->RegisterBooleanPref(prefs::kExplicitBrowserSignin, false);
+-  registry->RegisterBooleanPref(
+-      prefs::kPrefsThemesSearchEnginesAccountStorageEnabled, false);
+-  registry->RegisterBooleanPref(prefs::kPrimaryAccountSetAfterSigninMigration,
+-                                false);
+ }
+ 
+ // static
+ void PrimaryAccountManager::RegisterPrefs(PrefRegistrySimple* registry) {
+-  registry->RegisterStringPref(prefs::kGoogleServicesUsernamePattern,
+-                               std::string());
+ }
+ 
+ void PrimaryAccountManager::PrepareToLoadPrefs() {
+-  // Check this method is only called before loading the primary account.
+-  CHECK(!primary_account_.has_value());
+-
+-  PrefService* prefs = client_->GetPrefs();
+-
+-  // If the user is clearing the token service from the command line, then
+-  // clear their login info also (not valid to be logged in without any
+-  // tokens).
+-  base::CommandLine* cmd_line = base::CommandLine::ForCurrentProcess();
+-  if (cmd_line->HasSwitch(switches::kClearTokenService)) {
+-    prefs->SetString(prefs::kGoogleServicesAccountId, "");
+-    prefs->SetBoolean(prefs::kGoogleServicesConsentedToSync, false);
+-  }
+-
+-#if BUILDFLAG(IS_CHROMEOS)
+-  // Migrate primary account ID from email to Gaia ID if needed.
+-  std::string pref_account_id =
+-      prefs->GetString(prefs::kGoogleServicesAccountId);
+-  if (!pref_account_id.empty()) {
+-    if (account_tracker_service_->GetMigrationState() ==
+-        AccountTrackerService::MIGRATION_IN_PROGRESS) {
+-      CoreAccountInfo account_info =
+-          account_tracker_service_->FindAccountInfoByEmail(pref_account_id);
+-      // |account_info.gaia| could be empty if |account_id| is already gaia id.
+-      if (!account_info.gaia.empty()) {
+-        pref_account_id = account_info.gaia.ToString();
+-        prefs->SetString(prefs::kGoogleServicesAccountId, pref_account_id);
+-      }
+-    }
+-  }
+-#endif
+ }
+ 
+ std::pair<CoreAccountInfo, PrimaryAccountManager::InitializeAccountInfoState>
+@@ -445,36 +303,6 @@ PrimaryAccountManager::GetOrRestorePrima
+ #if BUILDFLAG(IS_IOS)
+   NOTREACHED();
+ #else
+-  PrefService* prefs = client_->GetPrefs();
+-  const GaiaId last_syncing_gaia_id =
+-      GaiaId(prefs->GetString(prefs::kGoogleServicesLastSyncingGaiaId));
+-  if (last_syncing_gaia_id.empty()) {
+-    return std::make_pair(CoreAccountInfo(),
+-                          InitializeAccountInfoState::
+-                              kEmptyAccountInfo_RestoreFailedNoLastSyncGaiaId);
+-  }
+-  std::string last_syncing_email =
+-      prefs->GetString(prefs::kGoogleServicesLastSyncingUsername);
+-  if (last_syncing_email.empty()) {
+-    return std::make_pair(CoreAccountInfo(),
+-                          InitializeAccountInfoState::
+-                              kEmptyAccountInfo_RestoreFailedNoLastSyncEmail);
+-  }
+-
+-  if (account_id != account_tracker_service_->PickAccountIdForAccount(
+-                        last_syncing_gaia_id, last_syncing_email)) {
+-    return std::make_pair(
+-        CoreAccountInfo(),
+-        InitializeAccountInfoState::
+-            kEmptyAccountInfo_RestoreFailedAccountIdDontMatch);
+-  }
+-
+-  CHECK_EQ(
+-      account_id,
+-      account_tracker_service_->SeedAccountInfo(
+-          last_syncing_gaia_id, last_syncing_email,
+-          signin_metrics::AccessPoint::kRestorePrimaryAccountOnProfileLoad));
+-
+   return std::make_pair(account_tracker_service_->GetAccountInfo(account_id),
+                         InitializeAccountInfoState::
+                             kEmptyAccountInfo_RestoreSuccessFromLastSyncInfo);
+@@ -569,10 +397,9 @@ void PrimaryAccountManager::SetSyncPrima
+ 
+ #if DCHECK_IS_ON()
+   {
+-    std::string pref_account_id =
+-        client_->GetPrefs()->GetString(prefs::kGoogleServicesAccountId);
++    std::string pref_account_id;
+     bool consented_to_sync =
+-        client_->GetPrefs()->GetBoolean(prefs::kGoogleServicesConsentedToSync);
++        false;
+ 
+     DCHECK(pref_account_id.empty() || !consented_to_sync ||
+            pref_account_id == account_info.account_id.ToString())
+@@ -583,16 +410,6 @@ void PrimaryAccountManager::SetSyncPrima
+ 
+   SetPrimaryAccountInternal(account_info, /*consented_to_sync=*/true,
+                             scoped_pref_commit);
+-
+-#if !BUILDFLAG(IS_IOS)
+-  // Go ahead and update the last signed in account info here as well. Once a
+-  // user is signed in the corresponding preferences should match. Doing it here
+-  // as opposed to on signin allows us to catch the upgrade scenario.
+-  scoped_pref_commit.SetString(prefs::kGoogleServicesLastSyncingGaiaId,
+-                               account_info.gaia.ToString());
+-  scoped_pref_commit.SetString(prefs::kGoogleServicesLastSyncingUsername,
+-                               account_info.email);
+-#endif  // !BUILDFLAG(IS_IOS)
+ }
+ 
+ void PrimaryAccountManager::SetPrimaryAccountInternal(
+@@ -604,24 +421,6 @@ void PrimaryAccountManager::SetPrimaryAc
+   // 'account_info' might be a reference to the contents of `primary_account_`.
+   // Create a PrimaryAccount object before calling emplace to avoid crashes.
+   primary_account_.emplace(PrimaryAccount(account_info, consented_to_sync));
+-  std::string account_id =
+-      GetPrimaryAccount().account_info.account_id.ToString();
+-  scoped_pref_commit.SetString(prefs::kGoogleServicesAccountId, account_id);
+-  scoped_pref_commit.SetBoolean(prefs::kGoogleServicesConsentedToSync,
+-                                GetPrimaryAccount().consented_to_sync);
+-  // If this was a sign-out (account ID is empty), also clear the "account was
+-  // migrated" prefs.
+-  if (account_id.empty()) {
+-    scoped_pref_commit.ClearPref(
+-        prefs::kGoogleServicesSyncingGaiaIdMigratedToSignedIn);
+-    scoped_pref_commit.ClearPref(
+-        prefs::kGoogleServicesSyncingUsernameMigratedToSignedIn);
+-    scoped_pref_commit.ClearPref(
+-        prefs::kGoogleServicesSyncingUserMigrationType);
+-  } else {
+-    scoped_pref_commit.SetString(prefs::kGoogleServicesLastSignedInUsername,
+-                                 account_info.email);
+-  }
+ }
+ 
+ void PrimaryAccountManager::UpdatePrimaryAccountInfo() {
+@@ -752,103 +551,6 @@ PrimaryAccountChangeEvent::State Primary
+ void PrimaryAccountManager::SetExplicitBrowserSigninPrefs(
+     const PrimaryAccountChangeEvent& event_details,
+     ScopedPrefCommit& scoped_pref_commit) {
+-  switch (event_details.GetEventTypeFor(signin::ConsentLevel::kSignin)) {
+-    case PrimaryAccountChangeEvent::Type::kNone:
+-      break;
+-    case PrimaryAccountChangeEvent::Type::kCleared:
+-#if BUILDFLAG(ENABLE_DICE_SUPPORT)
+-      scoped_pref_commit.ClearPref(prefs::kExplicitBrowserSignin);
+-#endif
+-      return;
+-    case PrimaryAccountChangeEvent::Type::kSet:
+-      CHECK(event_details.GetSetPrimaryAccountAccessPoint().has_value());
+-      if (syncer::IsReplaceSyncPromosWithSignInPromosEnabled()) {
+-        scoped_pref_commit.SetBoolean(
+-            prefs::kPrimaryAccountSetAfterSigninMigration, true);
+-      }
+-
+-#if BUILDFLAG(ENABLE_DICE_SUPPORT)
+-      signin_metrics::AccessPoint access_point =
+-          event_details.GetSetPrimaryAccountAccessPoint().value();
+-      GaiaId current_gaia_id =
+-          event_details.GetCurrentState().primary_account.gaia;
+-
+-      if (access_point == signin_metrics::AccessPoint::kWebSignin) {
+-        // TODO(crbug.com/475822503): Delete this code once Dice migration is
+-        // complete.
+-        scoped_pref_commit.ClearPref(prefs::kExplicitBrowserSignin);
+-        // Reset explicit sign-in prefs for the relevant data types.
+-        scoped_pref_commit.SetBoolean(
+-            prefs::kPrefsThemesSearchEnginesAccountStorageEnabled, false);
+-        SigninPrefs(*client_->GetPrefs())
+-            .SetExtensionsExplicitBrowserSignin(current_gaia_id, false);
+-        SigninPrefs(*client_->GetPrefs())
+-            .SetBookmarksExplicitBrowserSignin(current_gaia_id, false);
+-        break;
+-      }
+-
+-      scoped_pref_commit.SetBoolean(prefs::kExplicitBrowserSignin, true);
+-#endif
+-
+-      if (base::FeatureList::IsEnabled(
+-              switches::kEnablePreferencesAccountStorage)) {
+-        scoped_pref_commit.SetBoolean(
+-            prefs::kPrefsThemesSearchEnginesAccountStorageEnabled, true);
+-      }
+-
+-#if BUILDFLAG(ENABLE_DICE_SUPPORT)
+-      if (ShouldEnableExtensionExplicitBrowserSigninPrefOnSignIn(
+-              access_point)) {
+-        // Record an opt in for the extensions explicit signin feature and use
+-        // the existing pref to determine if it's a new or existing opt in.
+-        bool is_new_opt_in =
+-            !SigninPrefs(*client_->GetPrefs())
+-                 .GetExtensionsExplicitBrowserSignin(current_gaia_id);
+-
+-        if (access_point ==
+-            signin_metrics::AccessPoint::kExtensionInstallBubble) {
+-          base::UmaHistogramBoolean(
+-              "Signin.Extensions.ExplicitSigninFromExtensionInstallBubble",
+-              is_new_opt_in);
+-        }
+-        base::UmaHistogramBoolean(
+-            "Signin.Extensions.ExplicitSigninFromAnyAccessPoint",
+-            is_new_opt_in);
+-        SigninPrefs(*client_->GetPrefs())
+-            .SetExtensionsExplicitBrowserSignin(current_gaia_id, true);
+-      }
+-
+-      if (ShouldEnableBookmarksExplicitBrowserSigninPrefOnSignIn(
+-              access_point)) {
+-        // Record an explicit signin for bookmarks for this account only. This
+-        // should happen for every new sign in if `kExplicitSigninForBookmarks`
+-        // is enabled, as this pref will be used to determine whether users are
+-        // eligible for account storage or not.
+-        SigninPrefs(*client_->GetPrefs())
+-            .SetBookmarksExplicitBrowserSignin(current_gaia_id, true);
+-      }
+-#endif  //  BUILDFLAG(ENABLE_DICE_SUPPORT)
+-  }
+-
+-#if BUILDFLAG(ENABLE_DICE_SUPPORT)
+-  // If the user turns on sync, disable account storage for bookmarks. This
+-  // way the user does not get duplicate data if they turn off sync (and
+-  // choose to preserve their data locally) and then sign in again.
+-  // This is safe to remove with the deprecation of
+-  // `signin::ConsentLevel::kSync`.
+-  if (event_details.GetEventTypeFor(signin::ConsentLevel::kSync) ==
+-      signin::PrimaryAccountChangeEvent::Type::kSet) {
+-    auto current_gaia_id = event_details.GetCurrentState().primary_account.gaia;
+-    auto prefs = SigninPrefs(*client_->GetPrefs());
+-
+-    if (prefs.GetBookmarksExplicitBrowserSignin(current_gaia_id)) {
+-      base::UmaHistogramBoolean(
+-          "Signin.Bookmarks.SyncTurnedOnWithAccountStorageEnabled", true);
+-    }
+-
+-    prefs.SetBookmarksExplicitBrowserSignin(current_gaia_id, false);
+-  }
+-#endif
+ }
+ 
+ void PrimaryAccountManager::FirePrimaryAccountChanged(
+--- a/components/signin/internal/identity_manager/primary_account_manager_unittest.cc
++++ b/components/signin/internal/identity_manager/primary_account_manager_unittest.cc
+@@ -31,7 +31,6 @@
+ #include "components/signin/public/base/gaia_id_hash.h"
+ #include "components/signin/public/base/signin_client.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_prefs.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/base/test_signin_client.h"
+--- a/components/signin/internal/identity_manager/primary_account_mutator_impl.cc
++++ b/components/signin/internal/identity_manager/primary_account_mutator_impl.cc
+@@ -17,7 +17,6 @@
+ #include "components/signin/public/base/signin_buildflags.h"
+ #include "components/signin/public/base/signin_client.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "google_apis/gaia/core_account_id.h"
+ 
+@@ -57,7 +56,7 @@ PrimaryAccountMutatorImpl::SetPrimaryAcc
+   DCHECK(!account_info.gaia.empty());
+ 
+ #if !BUILDFLAG(IS_CHROMEOS)
+-  bool is_signin_allowed = pref_service_->GetBoolean(prefs::kSigninAllowed);
++  bool is_signin_allowed = false;
+   if (!is_signin_allowed) {
+     return PrimaryAccountError::kSigninNotAllowed;
+   }
+--- a/components/signin/internal/identity_manager/profile_oauth2_token_service.cc
++++ b/components/signin/internal/identity_manager/profile_oauth2_token_service.cc
+@@ -15,7 +15,6 @@
+ #include "components/signin/internal/identity_manager/profile_oauth2_token_service_delegate.h"
+ #include "components/signin/public/base/device_id_helper.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "google_apis/gaia/gaia_constants.h"
+ #include "google_apis/gaia/google_service_auth_error.h"
+ #include "google_apis/gaia/oauth2_access_token_consumer.h"
+@@ -107,8 +106,6 @@ bool ProfileOAuth2TokenService::HasRefre
+ // static
+ void ProfileOAuth2TokenService::RegisterProfilePrefs(
+     PrefRegistrySimple* registry) {
+-  registry->RegisterStringPref(prefs::kGoogleServicesSigninScopedDeviceId,
+-                               std::string());
+ }
+ 
+ ProfileOAuth2TokenServiceDelegate* ProfileOAuth2TokenService::GetDelegate() {
+--- a/components/signin/internal/identity_manager/profile_oauth2_token_service_delegate_chromeos_unittest.cc
++++ b/components/signin/internal/identity_manager/profile_oauth2_token_service_delegate_chromeos_unittest.cc
+@@ -30,7 +30,6 @@
+ #include "components/signin/internal/identity_manager/account_tracker_service.h"
+ #include "components/signin/internal/identity_manager/mock_profile_oauth2_token_service_observer.h"
+ #include "components/signin/internal/identity_manager/profile_oauth2_token_service_observer.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/test_signin_client.h"
+ #include "components/signin/public/identity_manager/account_capabilities_test_mutator.h"
+ #include "components/signin/public/identity_manager/account_info.h"
+--- a/components/signin/public/base/BUILD.gn
++++ b/components/signin/public/base/BUILD.gn
+@@ -166,8 +166,6 @@ component("signin_switches") {
+   defines = [ "IS_SIGNIN_SWITCHES_IMPL" ]
+ 
+   sources = [
+-    "signin_pref_names.cc",
+-    "signin_pref_names.h",
+     "signin_switches.cc",
+     "signin_switches.h",
+   ]
+--- a/components/signin/public/base/device_id_helper.cc
++++ b/components/signin/public/base/device_id_helper.cc
+@@ -8,7 +8,6 @@
+ #include "base/command_line.h"
+ #include "base/uuid.h"
+ #include "components/prefs/pref_service.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ 
+ namespace signin {
+@@ -16,20 +15,12 @@ namespace signin {
+ #if !BUILDFLAG(IS_CHROMEOS)
+ 
+ std::string GetSigninScopedDeviceId(PrefService* prefs) {
+-  std::string signin_scoped_device_id =
+-      prefs->GetString(prefs::kGoogleServicesSigninScopedDeviceId);
+-  if (signin_scoped_device_id.empty()) {
+-    // If device_id doesn't exist then generate new and save in prefs.
+-    signin_scoped_device_id = RecreateSigninScopedDeviceId(prefs);
+-  }
+-  return signin_scoped_device_id;
++  return RecreateSigninScopedDeviceId(prefs);
+ }
+ 
+ std::string RecreateSigninScopedDeviceId(PrefService* prefs) {
+   std::string signin_scoped_device_id = GenerateSigninScopedDeviceId();
+   DCHECK(!signin_scoped_device_id.empty());
+-  prefs->SetString(prefs::kGoogleServicesSigninScopedDeviceId,
+-                   signin_scoped_device_id);
+   return signin_scoped_device_id;
+ }
+ 
+--- a/components/signin/public/base/device_id_helper_unittest.cc
++++ b/components/signin/public/base/device_id_helper_unittest.cc
+@@ -7,7 +7,6 @@
+ #include <string>
+ 
+ #include "build/build_config.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/sync_preferences/testing_pref_service_syncable.h"
+ #include "testing/gtest/include/gtest/gtest.h"
+ 
+@@ -23,40 +22,23 @@ TEST(DeviceIdHelper, GenerateSigninScope
+ 
+ TEST(DeviceIdHelper, RecreateSigninScopedDeviceId) {
+   sync_preferences::TestingPrefServiceSyncable prefs;
+-  prefs.registry()->RegisterStringPref(
+-      prefs::kGoogleServicesSigninScopedDeviceId, std::string());
+-  ASSERT_TRUE(
+-      prefs.GetString(prefs::kGoogleServicesSigninScopedDeviceId).empty());
+ 
+   std::string device_id_1 = RecreateSigninScopedDeviceId(&prefs);
+   EXPECT_FALSE(device_id_1.empty());
+-  EXPECT_EQ(device_id_1,
+-            prefs.GetString(prefs::kGoogleServicesSigninScopedDeviceId));
+ 
+   std::string device_id_2 = RecreateSigninScopedDeviceId(&prefs);
+   EXPECT_FALSE(device_id_2.empty());
+   EXPECT_NE(device_id_1, device_id_2);
+-  EXPECT_EQ(device_id_2,
+-            prefs.GetString(prefs::kGoogleServicesSigninScopedDeviceId));
+ }
+ 
+ TEST(DeviceIdHelper, GetSigninScopedDeviceId) {
+   sync_preferences::TestingPrefServiceSyncable prefs;
+-  prefs.registry()->RegisterStringPref(
+-      prefs::kGoogleServicesSigninScopedDeviceId, std::string());
+-
+-  ASSERT_TRUE(
+-      prefs.GetString(prefs::kGoogleServicesSigninScopedDeviceId).empty());
+ 
+   std::string device_id_1 = GetSigninScopedDeviceId(&prefs);
+   EXPECT_FALSE(device_id_1.empty());
+-  EXPECT_EQ(device_id_1,
+-            prefs.GetString(prefs::kGoogleServicesSigninScopedDeviceId));
+ 
+   std::string device_id_2 = GetSigninScopedDeviceId(&prefs);
+   EXPECT_EQ(device_id_1, device_id_2);
+-  EXPECT_EQ(device_id_2,
+-            prefs.GetString(prefs::kGoogleServicesSigninScopedDeviceId));
+ }
+ 
+ #endif
+--- a/components/signin/public/base/signin_prefs.cc
++++ b/components/signin/public/base/signin_prefs.cc
+@@ -12,7 +12,6 @@
+ #include "components/prefs/pref_registry_simple.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/prefs/scoped_user_pref_update.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "google_apis/gaia/gaia_id.h"
+ 
+@@ -178,8 +177,6 @@ SigninPrefs::~SigninPrefs() = default;
+ 
+ void SigninPrefs::RegisterProfilePrefs(PrefRegistrySimple* registry) {
+   registry->RegisterDictionaryPref(kSigninAccountPrefs);
+-  registry->RegisterIntegerPref(prefs::kHistorySyncSuccessiveDeclineCount, 0);
+-  registry->RegisterInt64Pref(prefs::kHistorySyncLastDeclinedTimestamp, 0);
+ }
+ 
+ void SigninPrefs::MigrateObsoleteSigninPrefs() {
+@@ -502,40 +499,31 @@ int SigninPrefs::GetSyncPromoIdentityPil
+ 
+ int SigninPrefs::GetHistoryPageHistorySyncPromoShownCount(
+     const GaiaId& gaia_id) const {
+-  return GetIntPrefForAccount(gaia_id,
+-                              prefs::kHistoryPageHistorySyncPromoShownCount);
++  return 0;
+ }
+ 
+ void SigninPrefs::IncrementHistoryPageHistorySyncPromoShownCount(
+     const GaiaId& gaia_id) {
+-  IncrementIntPrefForAccount(gaia_id,
+-                             prefs::kHistoryPageHistorySyncPromoShownCount);
+ }
+ 
+ std::optional<base::Time>
+ SigninPrefs::GetHistoryPageHistorySyncPromoLastDismissedTimestamp(
+     const GaiaId& gaia_id) const {
+-  return GetTimePref(gaia_id,
+-                     prefs::kHistoryPageHistorySyncPromoLastDismissedTimestamp);
++  return base::Time();
+ }
+ 
+ void SigninPrefs::SetHistoryPageHistorySyncPromoLastDismissedTimestamp(
+     const GaiaId& gaia_id,
+     base::Time last_dismissed_timestamp) {
+-  SetTimePref(last_dismissed_timestamp, gaia_id,
+-              prefs::kHistoryPageHistorySyncPromoLastDismissedTimestamp);
+ }
+ 
+ bool SigninPrefs::GetHistoryPageHistorySyncPromoShownAfterDismissal(
+     const GaiaId& gaia_id) const {
+-  return GetBooleanPrefForAccount(
+-      gaia_id, prefs::kHistoryPageHistorySyncPromoShownAfterDismissal);
++  return true;
+ }
+ 
+ void SigninPrefs::SetHistoryPageHistorySyncPromoShownAfterDismissal(
+     const GaiaId& gaia_id) {
+-  SetBooleanPrefForAccount(
+-      gaia_id, prefs::kHistoryPageHistorySyncPromoShownAfterDismissal, true);
+ }
+ 
+ void SigninPrefs::IncrementBookmarkBatchUploadPromoDismissCountWithLastTime(
+--- a/components/signin/public/base/signin_switches.cc
++++ b/components/signin/public/base/signin_switches.cc
+@@ -8,7 +8,6 @@
+ #include "base/time/time.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/public/base/signin_buildflags.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ 
+ #if BUILDFLAG(IS_WIN)
+ #include "base/win/windows_version.h"
+@@ -280,10 +279,6 @@ BASE_FEATURE(kEnableBoundSessionCredenti
+ #endif
+ );
+ bool IsBoundSessionCredentialsEnabled(const PrefService* profile_prefs) {
+-  // Enterprise policy takes precedence over the feature value.
+-  if (profile_prefs->HasPrefPath(prefs::kBoundSessionCredentialsEnabled)) {
+-    return profile_prefs->GetBoolean(prefs::kBoundSessionCredentialsEnabled);
+-  }
+   return base::FeatureList::IsEnabled(kEnableBoundSessionCredentials);
+ }
+ // Restricts the DBSC registration URL path to a single allowed string.
+@@ -304,10 +299,6 @@ BASE_FEATURE(kEnableChromeRefreshTokenBi
+ #endif
+ );
+ bool IsChromeRefreshTokenBindingEnabled(const PrefService* profile_prefs) {
+-  // Enterprise policy takes precedence over the feature value.
+-  if (profile_prefs->HasPrefPath(prefs::kBoundSessionCredentialsEnabled)) {
+-    return profile_prefs->GetBoolean(prefs::kBoundSessionCredentialsEnabled);
+-  }
+   return base::FeatureList::IsEnabled(kEnableChromeRefreshTokenBinding);
+ }
+ #endif  // BUILDFLAG(ENABLE_DICE_SUPPORT)
+--- a/components/signin/public/identity_manager/identity_utils.cc
++++ b/components/signin/public/identity_manager/identity_utils.cc
+@@ -14,7 +14,6 @@
+ #include "base/strings/utf_string_conversions.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/signin/public/base/consent_level.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/accounts_in_cookie_jar_info.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+@@ -62,8 +61,7 @@ bool IsUsernameAllowedByPattern(std::str
+ 
+ bool IsUsernameAllowedByPatternFromPrefs(const PrefService* prefs,
+                                          const std::string& username) {
+-  return IsUsernameAllowedByPattern(
+-      username, prefs->GetString(prefs::kGoogleServicesUsernamePattern));
++  return true;
+ }
+ 
+ base::flat_set<GaiaId> GetAllGaiaIdsForKeyedPreferences(
+--- a/components/signin/public/identity_manager/identity_utils_unittest.cc
++++ b/components/signin/public/identity_manager/identity_utils_unittest.cc
+@@ -12,7 +12,6 @@
+ #include "components/prefs/pref_service.h"
+ #include "components/prefs/testing_pref_service.h"
+ #include "components/signin/public/base/consent_level.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/accounts_in_cookie_jar_info.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+--- a/components/signin/public/identity_manager/primary_account_mutator_unittest.cc
++++ b/components/signin/public/identity_manager/primary_account_mutator_unittest.cc
+@@ -14,7 +14,6 @@
+ #include "components/signin/public/base/consent_level.h"
+ #include "components/signin/public/base/signin_buildflags.h"
+ #include "components/signin/public/base/signin_metrics.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/signin/public/identity_manager/identity_manager.h"
+ #include "components/signin/public/identity_manager/identity_test_environment.h"
+--- a/components/supervised_user/core/browser/supervised_user_pref_store.cc
++++ b/components/supervised_user/core/browser/supervised_user_pref_store.cc
+@@ -21,7 +21,6 @@
+ #include "components/policy/core/common/policy_pref_names.h"
+ #include "components/prefs/pref_value_map.h"
+ #include "components/safe_search_api/safe_search_util.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/supervised_user/core/browser/device_parental_controls.h"
+ #include "components/supervised_user/core/browser/family_link_settings_service.h"
+@@ -51,14 +50,6 @@ struct FamilyLinkSettingsPrefMappingEntr
+ 
+ FamilyLinkSettingsPrefMappingEntry kFamilyLinkSettingsPrefMapping[] = {
+     {
+-        supervised_user::kSigninAllowed,
+-        prefs::kSigninAllowed,
+-    },
+-    {
+-        supervised_user::kSigninAllowedOnNextStartup,
+-        prefs::kSigninAllowedOnNextStartup,
+-    },
+-    {
+         supervised_user::kSkipParentApprovalToInstallExtensions,
+         prefs::kSkipParentApprovalToInstallExtensions,
+     },
+--- a/components/sync/service/sync_prefs.cc
++++ b/components/sync/service/sync_prefs.cc
+@@ -24,8 +24,6 @@
+ #include "components/saved_tab_groups/public/pref_names.h"
+ #include "components/signin/public/base/gaia_id_hash.h"
+ #include "components/signin/public/base/signin_buildflags.h"
+-#include "components/signin/public/base/signin_pref_names.h"
+-#include "components/signin/public/base/signin_prefs.h"
+ #include "components/signin/public/base/signin_switches.h"
+ #include "components/sync/base/account_pref_utils.h"
+ #include "components/sync/base/features.h"
+@@ -92,34 +90,12 @@ DecodeTrustedVaultAutoUpgradeExperimentG
+ 
+ bool IsBookmarksSelectedByDefaultInTransportMode(PrefService& pref_service,
+                                                  const GaiaId& gaia_id) {
+-#if BUILDFLAG(IS_IOS) || BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_CHROMEOS)
+   return IsReplaceSyncPromosWithSignInPromosEnabled();
+-#else
+-  // If `kReplaceSyncPromosWithSignInPromos` is enabled, bookmarks and reading
+-  // list are enabled by default for new sign-ins (not pre-existing sessions).
+-  // This pref is set if the above conditions are met.
+-  // Note: If `kReplaceSyncPromosWithSignInPromos` gets disabled, the pref is
+-  // not reset and users will keep their bookmarks because that reduces the
+-  // risks of perceived dataloss.
+-  return SigninPrefs(pref_service).GetBookmarksExplicitBrowserSignin(gaia_id) ||
+-         base::FeatureList::IsEnabled(
+-             kEnableBookmarksSelectedTypeOnSigninForTesting);
+-#endif  // BUILDFLAG(IS_IOS) || BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_CHROMEOS)
+ }
+ 
+ bool IsExtensionsSelectedByDefaultInTransportMode(PrefService& pref_service,
+                                                   const GaiaId& gaia_id) {
+-#if BUILDFLAG(IS_IOS) || BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_CHROMEOS)
+   return IsReplaceSyncPromosWithSignInPromosEnabled();
+-#else
+-  // if `kReplaceSyncPromosWithSignInPromos` is enabled, extensions are enabled
+-  // by default for new sign-ins (not pre-existing sessions). This pref is set
+-  // if the above conditions are met.
+-  // Note: If `kReplaceSyncPromosWithSignInPromos` gets disabled, the pref is
+-  // not reset and users will keep their extensions because that reduces the
+-  // risks of perceived dataloss.
+-  return SigninPrefs(pref_service).GetExtensionsExplicitBrowserSignin(gaia_id);
+-#endif  // BUILDFLAG(IS_IOS) || BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_CHROMEOS)
+ }
+ 
+ }  // namespace
+@@ -160,15 +136,6 @@ SyncPrefs::SyncPrefs(PrefService* pref_s
+       base::BindRepeating(&SyncPrefs::OnSelectedTypesPrefChanged,
+                           base::Unretained(this)));
+ 
+-#if BUILDFLAG(ENABLE_DICE_SUPPORT)
+-  // The explicit browser signin pref is used for determining whether some data
+-  // types are selected by default. Therefore, upon a change, the selected types
+-  //  may change.
+-  pref_change_registrar_.Add(
+-      ::prefs::kExplicitBrowserSignin,
+-      base::BindRepeating(&SyncPrefs::OnSelectedTypesPrefChanged,
+-                          base::Unretained(this)));
+-#endif  // BUILDFLAG(ENABLE_DICE_SUPPORT)
+ }
+ 
+ SyncPrefs::~SyncPrefs() {
+@@ -1153,9 +1120,7 @@ bool SyncPrefs::IsTypeSelectedByDefaultI
+                                                          gaia_id);
+     case UserSelectableType::kPreferences:
+     case UserSelectableType::kThemes:
+-      return IsReplaceSyncPromosWithSignInPromosEnabled() ||
+-             pref_service_->GetBoolean(
+-                 ::prefs::kPrefsThemesSearchEnginesAccountStorageEnabled);
++      return false;
+     case UserSelectableType::kExtensions:
+       return IsExtensionsSelectedByDefaultInTransportMode(*pref_service_,
+                                                           gaia_id);
+--- a/components/sync_preferences/common_syncable_prefs_database.cc
++++ b/components/sync_preferences/common_syncable_prefs_database.cc
+@@ -25,7 +25,6 @@
+ #include "components/password_manager/core/common/password_manager_pref_names.h"
+ #include "components/payments/core/payment_prefs.h"
+ #include "components/plus_addresses/core/common/plus_address_prefs.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/saved_tab_groups/public/pref_names.h"
+ #include "components/sharing_message/pref_names.h"
+ #include "components/sync/base/data_type.h"
+@@ -94,9 +93,7 @@ enum {
+   // kSyncedLastTimePasswordCheckCompleted = 43, (deprecated)
+   kWasAutoSignInFirstRunExperienceShown = 44,
+   kCanMakePaymentEnabled = 45,
+-  kAccountTailoredSecurityUpdateTimestamp = 46,
+   kCookieControlsMode = 47,
+-  kSafeBrowsingEnabled = 48,
+   // kSyncedDefaultSearchProviderGUID = 49, (deprecated)
+   kPrefForceTriggerTranslateCount = 50,
+   // kPrefNeverPromptSitesDeprecated = 51, (deprecated)
+@@ -290,10 +287,6 @@ constexpr auto kCommonSyncablePrefsAllow
+         {payments::kCanMakePaymentEnabled,
+          {syncable_prefs_ids::kCanMakePaymentEnabled, syncer::PREFERENCES,
+           PrefSensitivity::kNone, MergeBehavior::kNone}},
+-        {prefs::kAccountTailoredSecurityUpdateTimestamp,
+-         {syncable_prefs_ids::kAccountTailoredSecurityUpdateTimestamp,
+-          syncer::PRIORITY_PREFERENCES, PrefSensitivity::kNone,
+-          MergeBehavior::kNone}},
+         {prefs::kCookieControlsMode,
+          {syncable_prefs_ids::kCookieControlsMode, syncer::PREFERENCES,
+           PrefSensitivity::kNone, MergeBehavior::kNone}},
+@@ -329,9 +322,6 @@ constexpr auto kCommonSyncablePrefsAllow
+          {syncable_prefs_ids::kCrossDeviceTipsHomeModuleEnabled,
+           syncer::PREFERENCES, PrefSensitivity::kNone,
+           MergeBehavior::kMergeableDict}},
+-        {prefs::kSafeBrowsingEnabled,
+-         {syncable_prefs_ids::kSafeBrowsingEnabled, syncer::PREFERENCES,
+-          PrefSensitivity::kNone, MergeBehavior::kNone}},
+         {tab_groups::prefs::kAutoPinNewTabGroups,
+          {syncable_prefs_ids::kAutoPinNewTabGroups, syncer::PREFERENCES,
+           PrefSensitivity::kNone, MergeBehavior::kNone}},
+--- a/extensions/browser/extension_allowlist.cc
++++ b/extensions/browser/extension_allowlist.cc
+@@ -8,7 +8,6 @@
+ #include "base/metrics/histogram_functions.h"
+ #include "base/observer_list.h"
+ #include "components/safe_browsing/core/browser/safe_browsing_metrics_collector.h"
+-#include "components/safe_browsing/core/common/safe_browsing_prefs.h"
+ #include "components/user_prefs/user_prefs.h"
+ #include "content/public/browser/browser_context.h"
+ #include "extensions/browser/allowlist_state.h"
+@@ -78,10 +77,6 @@ ExtensionAllowlist::ExtensionAllowlist(
+   // enforcements.
+   PrefService* prefs = user_prefs::UserPrefs::Get(browser_context_);
+   pref_change_registrar_.Init(prefs);
+-  pref_change_registrar_.Add(
+-      prefs::kSafeBrowsingEnhanced,
+-      base::BindRepeating(&ExtensionAllowlist::OnSafeBrowsingEnhancedChanged,
+-                          base::Unretained(this)));
+ }
+ 
+ ExtensionAllowlist::~ExtensionAllowlist() = default;
+@@ -254,15 +249,8 @@ void ExtensionAllowlist::OnExtensionInst
+ }
+ 
+ void ExtensionAllowlist::SetAllowlistEnforcementFields() {
+-  PrefService* prefs = user_prefs::UserPrefs::Get(browser_context_);
+-  if (safe_browsing::IsEnhancedProtectionEnabled(*prefs)) {
+-    warnings_enabled_ = true;
+-    should_auto_disable_extensions_ = base::FeatureList::IsEnabled(
+-        extensions_features::kSafeBrowsingCrxAllowlistAutoDisable);
+-  } else {
+     warnings_enabled_ = false;
+     should_auto_disable_extensions_ = false;
+-  }
+ }
+ 
+ // `ApplyEnforcement` can be called when an extension becomes not allowlisted or
+@@ -416,10 +404,6 @@ void ExtensionAllowlist::NotifyExtension
+ }
+ 
+ void ExtensionAllowlist::ReportExtensionReEnabledEvent() {
+-  DCHECK(metrics_collector_);
+-  metrics_collector_->AddSafeBrowsingEventToPref(
+-      safe_browsing::SafeBrowsingMetricsCollector::EventType::
+-          NON_ALLOWLISTED_EXTENSION_RE_ENABLED);
+ }
+ 
+ }  // namespace extensions

--- a/patches/ungoogled/core/ungoogled-chromium/toggle-translation-via-switch.patch
+++ b/patches/ungoogled/core/ungoogled-chromium/toggle-translation-via-switch.patch
@@ -1,0 +1,106 @@
+# Disables translation and removes the "Translate to" context menu when --translate-script-url flag is not set
+--- a/chrome/browser/renderer_context_menu/render_view_context_menu.cc
++++ b/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+@@ -197,6 +197,7 @@
+ #include "components/strings/grit/components_strings.h"
+ #include "components/supervised_user/core/browser/supervised_user_preferences.h"
+ #include "components/supervised_user/core/browser/supervised_user_url_filtering_service.h"
++#include "components/translate/core/common/translate_switches.h"
+ #include "components/translate/core/browser/translate_download_manager.h"
+ #include "components/translate/core/browser/translate_manager.h"
+ #include "components/translate/core/browser/translate_prefs.h"
+@@ -2371,6 +2372,7 @@ void RenderViewContextMenu::AppendPageIt
+   }
+ 
+   if (CanTranslate(/*menu_logging=*/true)) {
++   if (base::CommandLine::ForCurrentProcess()->HasSwitch(translate::switches::kTranslateScriptURL))
+     AppendTranslateItem();
+   }
+ }
+--- a/components/translate/core/browser/translate_language_list.cc
++++ b/components/translate/core/browser/translate_language_list.cc
+@@ -12,6 +12,7 @@
+ #include <string_view>
+ 
+ #include "base/check.h"
++#include "base/command_line.h"
+ #include "base/functional/bind.h"
+ #include "base/json/json_reader.h"
+ #include "base/lazy_instance.h"
+@@ -26,6 +27,7 @@
+ #include "components/translate/core/browser/translate_event_details.h"
+ #include "components/translate/core/browser/translate_url_fetcher.h"
+ #include "components/translate/core/browser/translate_url_util.h"
++#include "components/translate/core/common/translate_switches.h"
+ #include "components/translate/core/common/translate_util.h"
+ #include "net/base/url_util.h"
+ #include "ui/base/l10n/l10n_util.h"
+@@ -390,6 +392,9 @@ GURL TranslateLanguageList::TranslateLan
+ }
+ 
+ void TranslateLanguageList::RequestLanguageList() {
++  const base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
++  if (!command_line.HasSwitch(translate::switches::kTranslateScriptURL))
++    return;
+   // If resource requests are not allowed, we'll get a callback when they are.
+   if (!resource_requests_allowed_) {
+     request_pending_ = true;
+--- a/components/translate/core/browser/translate_manager.cc
++++ b/components/translate/core/browser/translate_manager.cc
+@@ -858,8 +858,9 @@ void TranslateManager::FilterIsTranslate
+         TriggerDecision::kDisabledOffline);
+   }
+ 
+-  if (!ignore_missing_key_for_testing_ &&
+-      !::google_apis::HasAPIKeyConfigured()) {
++  const base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
++  if (!command_line.HasSwitch(translate::switches::kTranslateScriptURL) ||
++      (!ignore_missing_key_for_testing_ && !::google_apis::HasAPIKeyConfigured())) {
+     // Without an API key, translate won't work, so don't offer to translate in
+     // the first place. Leave kOfferTranslateEnabled on, though, because that
+     // settings syncs and we don't want to turn off translate everywhere else.
+--- a/components/translate/core/browser/translate_ranker_impl.cc
++++ b/components/translate/core/browser/translate_ranker_impl.cc
+@@ -152,12 +152,9 @@ TranslateRankerImpl::TranslateRankerImpl
+                                          ukm::UkmRecorder* ukm_recorder)
+     : ukm_recorder_(ukm_recorder),
+       is_uma_logging_enabled_(false),
+-      is_query_enabled_(base::FeatureList::IsEnabled(kTranslateRankerQuery)),
+-      is_enforcement_enabled_(
+-          base::FeatureList::IsEnabled(kTranslateRankerEnforcement)),
+-      is_previous_language_matches_override_enabled_(
+-          base::FeatureList::IsEnabled(
+-              translate::kTranslateRankerPreviousLanguageMatchesOverride)) {
++      is_query_enabled_(false),
++      is_enforcement_enabled_(false),
++      is_previous_language_matches_override_enabled_(false) {
+   if (is_query_enabled_ || is_enforcement_enabled_) {
+     model_loader_ = std::make_unique<assist_ranker::RankerModelLoaderImpl>(
+         base::BindRepeating(&ValidateModel),
+@@ -231,6 +228,8 @@ bool TranslateRankerImpl::ShouldOfferTra
+   // (or become False).
+   const bool kDefaultResponse = true;
+ 
++  return kDefaultResponse;
++
+   translate_event->set_ranker_request_timestamp_sec(
+       (base::TimeTicks::Now() - base::TimeTicks()).InSeconds());
+   translate_event->set_ranker_version(GetModelVersion());
+--- a/components/translate/core/browser/translate_script.cc
++++ b/components/translate/core/browser/translate_script.cc
+@@ -167,8 +167,13 @@ void TranslateScript::OnScriptFetchCompl
+                         server_params.c_str());
+ 
+     GURL security_origin = translate::GetTranslateSecurityOrigin();
+-    base::StringAppendF(&data_, "var securityOrigin = '%s';\n",
+-                        security_origin.spec().c_str());
++    const base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
++    if (command_line.HasSwitch(translate::switches::kTranslateScriptURL)) {
++      base::StringAppendF(&data_, "var securityOrigin = '%s';\n",
++                          security_origin.spec().c_str());
++    } else {
++      base::StringAppendF(&data_, "var securityOrigin = '';\n");
++    }
+ 
+     // Load embedded translate.js.
+     data_.append(ui::ResourceBundle::GetSharedInstance().LoadDataResourceString(

--- a/patches/ungoogled/extra/debian/disable/google-api-warning.patch
+++ b/patches/ungoogled/extra/debian/disable/google-api-warning.patch
@@ -1,0 +1,16 @@
+description: disable the google api key warning when those aren't found
+author: Michael Gilbert <mgilbert@debian.org>
+
+--- a/chrome/browser/ui/startup/infobar_utils.cc
++++ b/chrome/browser/ui/startup/infobar_utils.cc
+@@ -184,10 +184,6 @@ void AddInfoBarsIfNecessary(BrowserWindo
+   infobars::ContentInfoBarManager* infobar_manager =
+       infobars::ContentInfoBarManager::FromWebContents(web_contents);
+ 
+-  if (!google_apis::HasAPIKeyConfigured()) {
+-    GoogleApiKeysInfoBarDelegate::Create(infobar_manager);
+-  }
+-
+   if (ObsoleteSystem::IsObsoleteNowOrSoon()) {
+     PrefService* local_state = g_browser_process->local_state();
+     if (!local_state ||

--- a/patches/ungoogled/extra/inox-patchset/0006-modify-default-prefs.patch
+++ b/patches/ungoogled/extra/inox-patchset/0006-modify-default-prefs.patch
@@ -1,0 +1,146 @@
+
+--- a/chrome/browser/background/extensions/background_mode_manager.cc
++++ b/chrome/browser/background/extensions/background_mode_manager.cc
+@@ -348,7 +348,7 @@ BackgroundModeManager::~BackgroundModeMa
+ 
+ // static
+ void BackgroundModeManager::RegisterPrefs(PrefRegistrySimple* registry) {
+-  registry->RegisterBooleanPref(prefs::kBackgroundModeEnabled, true);
++  registry->RegisterBooleanPref(prefs::kBackgroundModeEnabled, false);
+ }
+ 
+ void BackgroundModeManager::RegisterProfile(Profile* profile) {
+--- a/chrome/browser/chrome_content_browser_client.cc
++++ b/chrome/browser/chrome_content_browser_client.cc
+@@ -1534,7 +1534,7 @@ void ChromeContentBrowserClient::Registe
+ void ChromeContentBrowserClient::RegisterProfilePrefs(
+     user_prefs::PrefRegistrySyncable* registry) {
+   registry->RegisterBooleanPref(prefs::kDisable3DAPIs, false);
+-  registry->RegisterBooleanPref(prefs::kEnableHyperlinkAuditing, true);
++  registry->RegisterBooleanPref(prefs::kEnableHyperlinkAuditing, false);
+   // Register user prefs for mapping SitePerProcess and IsolateOrigins in
+   // user policy in addition to the same named ones in Local State (which are
+   // used for mapping the command-line flags).
+--- a/chrome/browser/net/profile_network_context_service.cc
++++ b/chrome/browser/net/profile_network_context_service.cc
+@@ -613,7 +613,7 @@ void ProfileNetworkContextService::Confi
+ void ProfileNetworkContextService::RegisterProfilePrefs(
+     user_prefs::PrefRegistrySyncable* registry) {
+   registry->RegisterBooleanPref(embedder_support::kAlternateErrorPagesEnabled,
+-                                true);
++                                false);
+   registry->RegisterBooleanPref(prefs::kQuicAllowed, true);
+   registry->RegisterBooleanPref(prefs::kGloballyScopeHTTPAuthCacheEnabled,
+                                 false);
+--- a/chrome/browser/preloading/preloading_prefs.h
++++ b/chrome/browser/preloading/preloading_prefs.h
+@@ -23,7 +23,7 @@ enum class NetworkPredictionOptions {
+   kWifiOnlyDeprecated = 1,
+   kDisabled = 2,
+   kExtended = 3,
+-  kDefault = kWifiOnlyDeprecated,
++  kDefault = kDisabled,
+ };
+ 
+ // Enum representing possible values of the Preload Pages opt-in state. These
+--- a/chrome/browser/profiles/profile.cc
++++ b/chrome/browser/profiles/profile.cc
+@@ -337,7 +337,7 @@ const char Profile::kProfileKey[] = "__P
+ void Profile::RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
+   registry->RegisterBooleanPref(
+       prefs::kSearchSuggestEnabled,
+-      true,
++      false,
+       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+ #if BUILDFLAG(IS_ANDROID)
+   registry->RegisterStringPref(
+--- a/chrome/browser/resources/settings/reset_page/reset_profile_dialog.html
++++ b/chrome/browser/resources/settings/reset_page/reset_profile_dialog.html
+@@ -33,7 +33,7 @@
+         </cr-button>
+       </div>
+       <div slot="footer">
+-        <cr-checkbox id="sendSettings" checked>
++        <cr-checkbox id="sendSettings">
+           $i18nRaw{resetPageFeedback}</cr-checkbox>
+       </div>
+     </cr-dialog>
+--- a/chrome/browser/ui/browser_ui_prefs.cc
++++ b/chrome/browser/ui/browser_ui_prefs.cc
+@@ -137,7 +137,7 @@ void RegisterBrowserUserPrefs(user_prefs
+   registry->RegisterBooleanPref(prefs::kWebAppCreateInAppsMenu, true);
+   registry->RegisterBooleanPref(prefs::kWebAppCreateInQuickLaunchBar, true);
+   registry->RegisterBooleanPref(
+-      translate::prefs::kOfferTranslateEnabled, true,
++      translate::prefs::kOfferTranslateEnabled, false,
+       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+   registry->RegisterDictionaryPref(prefs::kBrowserWindowPlacement);
+   registry->RegisterDictionaryPref(prefs::kBrowserWindowPlacementPopup);
+--- a/components/autofill/core/common/autofill_prefs.cc
++++ b/components/autofill/core/common/autofill_prefs.cc
+@@ -35,7 +35,7 @@ constexpr char kAutofillRanExtraDeduplic
+ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
+   // Synced prefs. Used for cross-device choices, e.g., credit card Autofill.
+   registry->RegisterBooleanPref(
+-      kAutofillProfileEnabled, true,
++      kAutofillProfileEnabled, false,
+       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+   registry->RegisterIntegerPref(
+       kAutofillLastVersionDeduped, 0,
+@@ -66,7 +66,7 @@ void RegisterProfilePrefs(user_prefs::Pr
+       kAutofillHasSeenIban, false,
+       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+   registry->RegisterBooleanPref(
+-      kAutofillCreditCardEnabled, true,
++      kAutofillCreditCardEnabled, false,
+       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+   registry->RegisterBooleanPref(
+       kAutofillPaymentCvcStorage, true,
+--- a/components/bookmarks/browser/bookmark_utils.cc
++++ b/components/bookmarks/browser/bookmark_utils.cc
+@@ -450,7 +450,7 @@ bool DoesBookmarkContainWords(const std:
+ 
+ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
+   registry->RegisterBooleanPref(
+-      prefs::kShowBookmarkBar, false,
++      prefs::kShowBookmarkBar, true,
+       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+   registry->RegisterBooleanPref(prefs::kEditBookmarksEnabled, true);
+   registry->RegisterBooleanPref(
+--- a/components/content_settings/core/browser/cookie_settings.cc
++++ b/components/content_settings/core/browser/cookie_settings.cc
+@@ -78,7 +78,7 @@ void CookieSettings::RegisterProfilePref
+     user_prefs::PrefRegistrySyncable* registry) {
+   registry->RegisterIntegerPref(
+       prefs::kCookieControlsMode,
+-      static_cast<int>(CookieControlsMode::kIncognitoOnly),
++      static_cast<int>(CookieControlsMode::kBlockThirdParty),
+       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+ }
+ 
+--- a/components/password_manager/core/browser/password_manager.cc
++++ b/components/password_manager/core/browser/password_manager.cc
+@@ -546,10 +546,10 @@ PasswordForm CreateFormForLeakCheck(cons
+ void PasswordManager::RegisterProfilePrefs(
+     user_prefs::PrefRegistrySyncable* registry) {
+   registry->RegisterBooleanPref(
+-      prefs::kCredentialsEnableService, true,
++      prefs::kCredentialsEnableService, false,
+       user_prefs::PrefRegistrySyncable::SYNCABLE_PRIORITY_PREF);
+   registry->RegisterBooleanPref(
+-      prefs::kCredentialsEnableAutosignin, true,
++      prefs::kCredentialsEnableAutosignin, false,
+       user_prefs::PrefRegistrySyncable::SYNCABLE_PRIORITY_PREF);
+   registry->RegisterBooleanPref(
+       prefs::kWasAutoSignInFirstRunExperienceShown, false,
+--- a/components/payments/core/payment_prefs.cc
++++ b/components/payments/core/payment_prefs.cc
+@@ -11,7 +11,7 @@ namespace payments {
+ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
+   registry->RegisterBooleanPref(kPaymentsFirstTransactionCompleted, false);
+   registry->RegisterBooleanPref(
+-      kCanMakePaymentEnabled, true,
++      kCanMakePaymentEnabled, false,
+       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+ }
+ 

--- a/patches/ungoogled/extra/inox-patchset/0013-disable-missing-key-warning.patch
+++ b/patches/ungoogled/extra/inox-patchset/0013-disable-missing-key-warning.patch
@@ -1,0 +1,12 @@
+--- a/chrome/browser/ui/startup/google_api_keys_infobar_delegate.cc
++++ b/chrome/browser/ui/startup/google_api_keys_infobar_delegate.cc
+@@ -17,9 +17,6 @@
+ // static
+ void GoogleApiKeysInfoBarDelegate::Create(
+     infobars::ContentInfoBarManager* infobar_manager) {
+-  infobar_manager->AddInfoBar(
+-      CreateConfirmInfoBar(std::unique_ptr<ConfirmInfoBarDelegate>(
+-          new GoogleApiKeysInfoBarDelegate())));
+ }
+ 
+ GoogleApiKeysInfoBarDelegate::GoogleApiKeysInfoBarDelegate() = default;

--- a/patches/ungoogled/extra/inox-patchset/0019-disable-battery-status-service.patch
+++ b/patches/ungoogled/extra/inox-patchset/0019-disable-battery-status-service.patch
@@ -1,0 +1,102 @@
+--- a/services/device/battery/battery_status_service.cc
++++ b/services/device/battery/battery_status_service.cc
+@@ -22,10 +22,7 @@ BatteryStatusService::BatteryStatusServi
+       update_callback_(
+           base::BindRepeating(&BatteryStatusService::NotifyConsumers,
+                               base::Unretained(this))),
+-      status_updated_(false),
+       is_shutdown_(false) {
+-  callback_list_.set_removal_callback(base::BindRepeating(
+-      &BatteryStatusService::ConsumersChanged, base::Unretained(this)));
+ }
+ 
+ BatteryStatusService::~BatteryStatusService() = default;
+@@ -40,58 +37,16 @@ base::CallbackListSubscription BatterySt
+   DCHECK(main_thread_task_runner_->BelongsToCurrentThread());
+   DCHECK(!is_shutdown_);
+ 
+-  if (!battery_fetcher_)
+-    battery_fetcher_ = BatteryStatusManager::Create(update_callback_);
+-
+-  if (callback_list_.empty()) {
+-    bool success = battery_fetcher_->StartListeningBatteryChange();
+-    // On failure pass the default values back.
+-    if (!success)
+-      callback.Run(mojom::BatteryStatus());
+-  }
+-
+-  if (status_updated_) {
+-    // Send recent status to the new callback if already available.
+-    callback.Run(status_);
+-  }
++  // Always pass the default values.
++  callback.Run(mojom::BatteryStatus());
+ 
+   return callback_list_.Add(callback);
+ }
+ 
+-void BatteryStatusService::ConsumersChanged() {
+-  if (is_shutdown_)
+-    return;
+-
+-  if (callback_list_.empty()) {
+-    battery_fetcher_->StopListeningBatteryChange();
+-    status_updated_ = false;
+-  }
+-}
+-
+ void BatteryStatusService::NotifyConsumers(const mojom::BatteryStatus& status) {
+-  DCHECK(!is_shutdown_);
+-
+-  main_thread_task_runner_->PostTask(
+-      FROM_HERE,
+-      base::BindOnce(&BatteryStatusService::NotifyConsumersOnMainThread,
+-                     base::Unretained(this), status));
+-}
+-
+-void BatteryStatusService::NotifyConsumersOnMainThread(
+-    const mojom::BatteryStatus& status) {
+-  DCHECK(main_thread_task_runner_->BelongsToCurrentThread());
+-  if (callback_list_.empty())
+-    return;
+-
+-  status_ = status;
+-  status_updated_ = true;
+-  callback_list_.Notify(status_);
+ }
+ 
+ void BatteryStatusService::Shutdown() {
+-  if (!callback_list_.empty())
+-    battery_fetcher_->StopListeningBatteryChange();
+-  battery_fetcher_.reset();
+   is_shutdown_ = true;
+ }
+ 
+@@ -102,9 +57,6 @@ BatteryStatusService::GetUpdateCallbackF
+ 
+ void BatteryStatusService::SetBatteryManagerForTesting(
+     std::unique_ptr<BatteryStatusManager> test_battery_manager) {
+-  battery_fetcher_ = std::move(test_battery_manager);
+-  status_ = mojom::BatteryStatus();
+-  status_updated_ = false;
+   is_shutdown_ = false;
+   main_thread_task_runner_ = base::SingleThreadTaskRunner::GetCurrentDefault();
+ }
+--- a/services/device/battery/battery_status_service.h
++++ b/services/device/battery/battery_status_service.h
+@@ -59,15 +59,10 @@ class BatteryStatusService {
+   // Updates current battery status and sends new status to interested
+   // render processes. Can be called on any thread via a callback.
+   void NotifyConsumers(const mojom::BatteryStatus& status);
+-  void NotifyConsumersOnMainThread(const mojom::BatteryStatus& status);
+-  void ConsumersChanged();
+ 
+   scoped_refptr<base::SingleThreadTaskRunner> main_thread_task_runner_;
+-  std::unique_ptr<BatteryStatusManager> battery_fetcher_;
+   BatteryUpdateCallbackList callback_list_;
+   BatteryUpdateCallback update_callback_;
+-  mojom::BatteryStatus status_;
+-  bool status_updated_;
+   bool is_shutdown_;
+ };
+ 

--- a/patches/ungoogled/extra/ungoogled-chromium/default-webrtc-ip-handling-policy.patch
+++ b/patches/ungoogled/extra/ungoogled-chromium/default-webrtc-ip-handling-policy.patch
@@ -1,0 +1,11 @@
+--- a/chrome/browser/ui/browser_ui_prefs.cc
++++ b/chrome/browser/ui/browser_ui_prefs.cc
+@@ -150,7 +150,7 @@ void RegisterBrowserUserPrefs(user_prefs
+                                 false);
+ #endif
+   registry->RegisterStringPref(prefs::kWebRTCIPHandlingPolicy,
+-                               blink::kWebRTCIPHandlingDefault);
++                               blink::kWebRTCIPHandlingDisableNonProxiedUdp);
+   registry->RegisterListPref(prefs::kWebRTCIPHandlingUrl, base::ListValue());
+   registry->RegisterBooleanPref(prefs::kWebRTCPostQuantumKeyAgreement, false);
+   registry->RegisterStringPref(prefs::kWebRTCUDPPortRange, std::string());

--- a/patches/ungoogled/extra/ungoogled-chromium/disable-dial-repeating-discovery.patch
+++ b/patches/ungoogled/extra/ungoogled-chromium/disable-dial-repeating-discovery.patch
@@ -1,0 +1,25 @@
+# Disables the dial registry's repeating discovery timer
+# This caused unnecessary SSDP network spam
+
+--- a/chrome/browser/media/router/discovery/dial/dial_registry.cc
++++ b/chrome/browser/media/router/discovery/dial/dial_registry.cc
+@@ -160,10 +160,6 @@ void DialRegistry::StartPeriodicDiscover
+   }
+ 
+   dial_ = CreateDialService();
+-  DoDiscovery();
+-  repeating_timer_ = std::make_unique<base::RepeatingTimer>();
+-  repeating_timer_->Start(FROM_HERE, refresh_interval_delta_, this,
+-                          &DialRegistry::DoDiscovery);
+   // Always send the current device list with the next discovery request.  This
+   // may not be necessary, but is done to match previous behavior.
+   ++registry_generation_;
+@@ -181,8 +177,6 @@ void DialRegistry::StopPeriodicDiscovery
+     return;
+   }
+ 
+-  repeating_timer_->Stop();
+-  repeating_timer_.reset();
+   ClearDialService();
+ }
+ 

--- a/patches/ungoogled/extra/ungoogled-chromium/disable-fedcm-by-default.patch
+++ b/patches/ungoogled/extra/ungoogled-chromium/disable-fedcm-by-default.patch
@@ -1,0 +1,13 @@
+# Disable Federated Credential Management (FedCM) by default
+
+--- a/content/public/common/content_features.cc
++++ b/content/public/common/content_features.cc
+@@ -389,7 +389,7 @@ BASE_FEATURE(kEnsureExistingRendererAliv
+ // by the flag in RuntimeEnabledFeatures on the blink side. See also
+ // the use of kSetOnlyIfOverridden in content/child/runtime_features.cc.
+ // We enable it here by default to support use in origin trials.
+-BASE_FEATURE(kFedCm, base::FEATURE_ENABLED_BY_DEFAULT);
++BASE_FEATURE(kFedCm, base::FEATURE_DISABLED_BY_DEFAULT);
+ 
+ // Kill switch for checking if there is an ongoing embedder task in the auto
+ // re-authn flow.

--- a/patches/ungoogled/extra/ungoogled-chromium/disable-intranet-redirect-detector.patch
+++ b/patches/ungoogled/extra/ungoogled-chromium/disable-intranet-redirect-detector.patch
@@ -1,0 +1,16 @@
+# Disables the intranet redirect detector. It generates extra DNS requests and the functionality using this is disabled
+# See this page for more information: https://mikewest.org/2012/02/chrome-connects-to-three-random-domains-at-startup
+
+--- a/chrome/browser/intranet_redirect_detector.cc
++++ b/chrome/browser/intranet_redirect_detector.cc
+@@ -118,9 +118,7 @@ void IntranetRedirectDetector::FinishSle
+   simple_loaders_.clear();
+   resulting_origins_.clear();
+ 
+-  const base::CommandLine* cmd_line = base::CommandLine::ForCurrentProcess();
+-  if (cmd_line->HasSwitch(switches::kDisableBackgroundNetworking))
+-    return;
++  return;
+ 
+   DCHECK(simple_loaders_.empty() && resulting_origins_.empty());
+ 

--- a/patches/ungoogled/quarantine.series
+++ b/patches/ungoogled/quarantine.series
@@ -1,0 +1,30 @@
+# Xplorer — quarantined ungoogled-chromium patches (vendored but NOT applied)
+#
+# Same provenance as series (ungoogled-chromium 149.0.7827.155-1). These are kept in-repo
+# so they can be rebased and graduated into series once they apply to our Chromium pin,
+# but scripts/apply_ungoogled.sh does NOT apply them. Each line notes WHY it is quarantined.
+#
+# Two reasons appear:
+#   [DRIFT]      = fails `git apply --check` against our 151 tree (ungoogled targets 149;
+#                  needs a hand re-anchor now, or graduate when ungoogled ships a 150/151 tag).
+#   [TRADEOFF]   = applies fine, but changes a capability we deliberately keep; opt in knowingly.
+#   [COUPLED]    = only meaningful together with a GN flag we are holding back (safe_browsing_mode=0).
+
+# SafeBrowsing build-out stubs — required ONLY if you set safe_browsing_mode=0 in args.gn.
+# Both currently fail on 151. Until they are rebased, do NOT set safe_browsing_mode=0 or the
+# link will break. (Runtime SB *reporting* is already removed by the two iridium patches in series.)
+core/inox-patchset/0001-fix-building-without-safebrowsing.patch      # [DRIFT][COUPLED]
+core/ungoogled-chromium/fix-building-without-safebrowsing.patch      # [DRIFT][COUPLED]
+
+# High-value degoogling that needs a 151 re-anchor:
+core/ungoogled-chromium/disable-privacy-sandbox.patch               # [DRIFT] remove Google Privacy Sandbox ad APIs
+core/ungoogled-chromium/toggle-translation-via-switch.patch         # [DRIFT] gate translate.googleapis behind a flag
+core/ungoogled-chromium/remove-unused-preferences-fields.patch      # [DRIFT]
+core/ungoogled-chromium/disable-google-host-detection.patch         # [DRIFT] kills X-Client-Data header; RECONCILE: touches suggest plumbing near Grok omnibox — verify before graduating
+extra/ungoogled-chromium/disable-fedcm-by-default.patch             # [DRIFT] FedCM off by default
+extra/inox-patchset/0006-modify-default-prefs.patch                # [DRIFT] privacy-leaning default prefs
+
+# Capability tradeoffs (apply cleanly, but we keep the capability by default):
+core/inox-patchset/0005-disable-default-extensions.patch            # [DRIFT][TRADEOFF] removes bundled Google apps
+core/ungoogled-chromium/extensions-manifestv2.patch                # [DRIFT][TRADEOFF] re-enables MV2 extensions
+core/ungoogled-chromium/disable-webstore-urls.patch                # [TRADEOFF] removes Chrome Web Store access — conflicts with Xplorer's "every extension runs"; enable only if you want full Web Store removal

--- a/patches/ungoogled/series
+++ b/patches/ungoogled/series
@@ -1,0 +1,53 @@
+# Xplorer — active ungoogled-chromium degoogling series
+#
+# Vendored from ungoogled-chromium 149.0.7827.155-1
+#   (git 2a53b77d33b055a4a41139007fb60b6ec1960a48, https://github.com/ungoogled-software/ungoogled-chromium)
+# Upstream is BSD-3-Clause; see ./LICENSE.ungoogled. Patches are vendored VERBATIM
+# (byte-identical to upstream) so they diff cleanly against future ungoogled refreshes.
+#
+# These patches REMOVE Google phone-home / telemetry / tracking channels only. They were
+# each verified to apply cleanly to Xplorer's pinned Chromium 151.0.7897.0 tree (AFTER
+# Xplorer's own overlay) via `git apply --check`. They are applied by scripts/apply_ungoogled.sh,
+# which runs AFTER patches/apply_integration.py so Xplorer's Grok + branding edits stay
+# authoritative; application is best-effort (a drifted patch is logged, not fatal).
+#
+# DELIBERATELY EXCLUDED (see docs/UNGOOGLED.md): domain substitution (qjz9zk), binary
+# pruning, and every patch touching default search / new-tab / branding (they fight
+# Xplorer's Grok-as-default-search and Xplorer branding). Patches that do not apply to 151
+# or carry capability tradeoffs live in quarantine.series and are NOT applied.
+#
+# NOTE: a few of these change behavior, not just telemetry — flagged [BEHAVIORAL] below.
+
+# --- inox-patchset (Google phone-home removal) ---
+core/inox-patchset/0003-disable-autofill-download-manager.patch   # no autofill crowdsourcing upload to Google
+core/inox-patchset/0015-disable-update-pings.patch                # empty updater Update/Ping URLs
+core/inox-patchset/0021-disable-rlz.patch                         # compile out RLZ search-attribution tracking
+
+# --- iridium-browser (SafeBrowsing reporting removal; SB itself stays compiled in) ---
+core/iridium-browser/safe_browsing-disable-incident-reporting.patch          # no SB incident-report upload
+core/iridium-browser/safe_browsing-disable-reporting-of-safebrowsing-over.patch  # no client-side phishing verdict upload
+
+# --- ungoogled-chromium core ---
+core/ungoogled-chromium/disable-crash-reporter.patch              # no crash-dump upload to Google
+core/ungoogled-chromium/disable-fonts-googleapis-references.patch # drop fonts.googleapis.com references
+core/ungoogled-chromium/disable-gaia.patch                       # [BEHAVIORAL] no browser-level Google sign-in / sync
+core/ungoogled-chromium/disable-gcm.patch                        # disable Google Cloud Messaging (push)
+core/ungoogled-chromium/disable-network-time-tracker.patch       # no time.google network-time ping
+core/ungoogled-chromium/disable-untraceable-urls.patch           # blank RLZ financial-ping endpoint
+core/ungoogled-chromium/disable-webrtc-log-uploader.patch        # no WebRTC log upload to Google
+core/ungoogled-chromium/doh-changes.patch                        # [BEHAVIORAL] neutral DoH defaults (no Google auto-DoH)
+core/ungoogled-chromium/disable-mei-preload.patch                # drop Google Media-Engagement preload data
+core/ungoogled-chromium/remove-f1-shortcut.patch                 # F1 no longer opens support.google.com
+core/ungoogled-chromium/disable-domain-reliability.patch         # no Google Domain Reliability uploads
+core/ungoogled-chromium/disable-profile-avatar-downloading.patch # no profile-avatar fetch from Google
+
+# --- bromite ---
+core/bromite/disable-fetching-field-trials.patch                 # never fetch variations/field-trials from Google
+
+# --- extra: fingerprinting / discovery / nags ---
+extra/inox-patchset/0019-disable-battery-status-service.patch    # remove Battery Status API (fingerprinting surface)
+extra/debian/disable/google-api-warning.patch                    # suppress "Google API keys are missing" nag (Xplorer ships empty keys)
+extra/inox-patchset/0013-disable-missing-key-warning.patch       # suppress the missing-API-key warning (companion to above)
+extra/ungoogled-chromium/default-webrtc-ip-handling-policy.patch # [BEHAVIORAL] default WebRTC IP policy that avoids local-IP leak
+extra/ungoogled-chromium/disable-dial-repeating-discovery.patch  # stop repeating DIAL/Cast discovery
+extra/ungoogled-chromium/disable-intranet-redirect-detector.patch # stop random-hostname captive-portal DNS probes

--- a/scripts/apply_ungoogled.ps1
+++ b/scripts/apply_ungoogled.ps1
@@ -1,0 +1,39 @@
+# Apply Xplorer's vendored ungoogled-chromium degoogling series (Windows).
+# Mirror of scripts/apply_ungoogled.sh: runs AFTER apply_integration.py, best-effort and
+# idempotent (already-applied -> skip, drifted -> log + continue, never fatal).
+# See patches/ungoogled/series and docs/UNGOOGLED.md.
+param(
+  [string]$Src,
+  [string]$Series
+)
+$ErrorActionPreference = "Continue"
+$Xplorer = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+if (-not $Src)    { $Src = Join-Path $Xplorer "..\chromium\src" }
+if (-not $Series) { $Series = Join-Path $Xplorer "patches\ungoogled\series" }
+$PDir = Join-Path $Xplorer "patches\ungoogled"
+
+if (-not (Test-Path (Join-Path $Src "chrome"))) { throw "apply_ungoogled: Chromium src not found at $Src" }
+if (-not (Test-Path $Series)) { throw "apply_ungoogled: series not found at $Series" }
+
+$applied = 0; $skipped = 0; $failed = 0; $failedList = @()
+Write-Host "Applying ungoogled degoogling series -> $Src"
+foreach ($raw in Get-Content $Series) {
+  $line = ($raw -replace '#.*$', '').Trim()
+  if ([string]::IsNullOrWhiteSpace($line)) { continue }
+  $patch = Join-Path $PDir $line
+  if (-not (Test-Path $patch)) { Write-Warning "  MISSING  $line"; $failed++; $failedList += $line; continue }
+  & git -C $Src apply --reverse --check -p1 --ignore-whitespace $patch 2>$null
+  if ($LASTEXITCODE -eq 0) { Write-Host "  skip     $line (already applied)"; $skipped++; continue }
+  & git -C $Src apply --check -p1 --ignore-whitespace $patch 2>$null
+  if ($LASTEXITCODE -eq 0) {
+    & git -C $Src apply -p1 --ignore-whitespace $patch
+    Write-Host "  apply    $line"; $applied++
+  } else {
+    Write-Warning "  FAILED   $line (does not apply to this Chromium pin — left unapplied)"
+    $failed++; $failedList += $line
+  }
+}
+Write-Host "ungoogled: applied=$applied skipped=$skipped failed=$failed"
+if ($failed -gt 0) { Write-Warning ("ungoogled: did not apply: " + ($failedList -join ' ')) }
+# Best-effort by design.
+exit 0

--- a/scripts/apply_ungoogled.sh
+++ b/scripts/apply_ungoogled.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Apply Xplorer's vendored ungoogled-chromium degoogling series to the Chromium checkout.
+#
+# Runs AFTER patches/apply_integration.py (see apply.sh) so Xplorer's Grok + branding edits
+# are authoritative. Application is BEST-EFFORT and IDEMPOTENT:
+#   - already applied (reverse-check passes) -> skipped
+#   - applies cleanly                        -> applied
+#   - drifted against this Chromium pin      -> logged as FAILED, NOT fatal (overlay continues)
+# These patches only remove Google phone-home channels; a missing one degrades privacy
+# coverage, it does not break Xplorer. See docs/UNGOOGLED.md and patches/ungoogled/series.
+set -u
+
+XPLORER="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="${1:-$XPLORER/../chromium/src}"
+SERIES="${2:-$XPLORER/patches/ungoogled/series}"
+PDIR="$XPLORER/patches/ungoogled"
+
+[ -d "$SRC/chrome" ] || { echo "apply_ungoogled: Chromium src not found at $SRC" >&2; exit 1; }
+[ -f "$SERIES" ]     || { echo "apply_ungoogled: series not found at $SERIES" >&2; exit 1; }
+
+applied=0 skipped=0 failed=0
+failed_list=""
+
+echo "Applying ungoogled degoogling series ($(basename "$SERIES")) -> $SRC"
+while IFS= read -r raw; do
+  # strip inline '# ...' comments and surrounding whitespace; skip blanks/comments
+  line="${raw%%#*}"
+  line="$(printf '%s' "$line" | tr -d '[:space:]')"
+  [ -n "$line" ] || continue
+  patch="$PDIR/$line"
+  if [ ! -f "$patch" ]; then
+    echo "  MISSING  $line" >&2; failed=$((failed+1)); failed_list="$failed_list $line"; continue
+  fi
+  if git -C "$SRC" apply --reverse --check -p1 --ignore-whitespace "$patch" >/dev/null 2>&1; then
+    echo "  skip     $line (already applied)"; skipped=$((skipped+1))
+  elif git -C "$SRC" apply --check -p1 --ignore-whitespace "$patch" >/dev/null 2>&1; then
+    git -C "$SRC" apply -p1 --ignore-whitespace "$patch"
+    echo "  apply    $line"; applied=$((applied+1))
+  else
+    echo "  FAILED   $line (does not apply to this Chromium pin — left unapplied)" >&2
+    failed=$((failed+1)); failed_list="$failed_list $line"
+  fi
+done < "$SERIES"
+
+echo "ungoogled: applied=$applied skipped=$skipped failed=$failed"
+if [ "$failed" -gt 0 ]; then
+  echo "ungoogled: NOTE — these did not apply (run scripts/check_ungoogled_patches.sh):$failed_list" >&2
+fi
+# Best-effort by design: never fail the overlay over a drifted privacy patch.
+exit 0

--- a/scripts/check_ungoogled_patches.sh
+++ b/scripts/check_ungoogled_patches.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Read-only validation gate for the vendored ungoogled-chromium patches.
+#
+# Loops the series (and optionally quarantine.series) and runs `git apply --check` against
+# the Chromium checkout — it NEVER modifies the tree. This is Xplorer's lightweight analog of
+# ungoogled's devutils/validate_patches.py. Run it whenever you bump the Chromium pin or
+# refresh the vendored patches; any newly-failing patch should move to quarantine.series.
+#
+# Usage: scripts/check_ungoogled_patches.sh [SRC] [--all]
+#   SRC     Chromium checkout (default ../chromium/src)
+#   --all   also check quarantine.series
+set -u
+
+XPLORER="$(cd "$(dirname "$0")/.." && pwd)"
+PDIR="$XPLORER/patches/ungoogled"
+SRC="$XPLORER/../chromium/src"
+CHECK_QUARANTINE=0
+for a in "$@"; do
+  case "$a" in
+    --all) CHECK_QUARANTINE=1 ;;
+    *) SRC="$a" ;;
+  esac
+done
+[ -d "$SRC/chrome" ] || { echo "check_ungoogled: Chromium src not found at $SRC" >&2; exit 1; }
+
+check_series() {
+  local series="$1" label="$2" applies=0 fails=0
+  echo "== $label ($(basename "$series")) =="
+  while IFS= read -r raw; do
+    local line="${raw%%#*}"; line="$(printf '%s' "$line" | tr -d '[:space:]')"
+    [ -n "$line" ] || continue
+    local patch="$PDIR/$line"
+    if [ ! -f "$patch" ]; then echo "  MISSING  $line"; fails=$((fails+1)); continue; fi
+    if git -C "$SRC" apply --reverse --check -p1 --ignore-whitespace "$patch" >/dev/null 2>&1; then
+      echo "  APPLIED  $line (already in tree)"; applies=$((applies+1))
+    elif git -C "$SRC" apply --check -p1 --ignore-whitespace "$patch" >/dev/null 2>&1; then
+      echo "  APPLIES  $line"; applies=$((applies+1))
+    else
+      echo "  FAILS    $line"; fails=$((fails+1))
+    fi
+  done < "$series"
+  echo "  -> applies=$applies fails=$fails"
+  echo
+  RET_APPLIES=$applies RET_FAILS=$fails
+}
+
+echo "ungoogled patch check against: $SRC"
+echo
+check_series "$PDIR/series" "ACTIVE"
+a_ap=$RET_APPLIES; a_fl=$RET_FAILS
+if [ "$CHECK_QUARANTINE" -eq 1 ] && [ -f "$PDIR/quarantine.series" ]; then
+  check_series "$PDIR/quarantine.series" "QUARANTINE"
+fi
+echo "SUMMARY active: applies=$a_ap fails=$a_fl"
+# Non-zero exit if any ACTIVE patch fails — useful as a CI/pre-bump gate.
+[ "$a_fl" -eq 0 ]


### PR DESCRIPTION
## What

Borrows the **degoogling patches** from [ungoogled-chromium](https://github.com/ungoogled-software/ungoogled-chromium) to strip the remaining Google phone-home / telemetry / tracking out of the Chromium base — **without touching Xplorer's Grok integration or branding**.

Full write-up: [`docs/UNGOOGLED.md`](../blob/feat/ungoogled-degoogle/docs/UNGOOGLED.md).

## Scope (as agreed)

- ✅ **Patch series only.** ❌ **No** domain substitution (`qjz9zk`) and ❌ **no** binary pruning — those break legit Google sign-in / Chrome Web Store / Translate for little gain.
- ❌ Skipped every patch touching **default search / new-tab / branding** — they fight Xplorer's Grok-as-default + branding edits in `apply_integration.py`.
- Grok runs over `grok.com` / `x.com` (not Google domains) → unaffected by everything here.

## Version-skew reality

ungoogled's newest release is **149.0.7827.155-1**; they have **no 150/151**. We pin **Chromium 151.0.7897.0** — ~2 milestones ahead. So patches were selected by validating each against our **real 151 tree** with `git apply --check`; drifted ones are quarantined, not applied. Pins recorded in [`VERSIONS`](../blob/feat/ungoogled-degoogle/VERSIONS).

## What's in

- **`patches/ungoogled/` — 24 active patches** (vendored verbatim), all verified **APPLIES clean** to 151 after our overlay. RLZ, GCM, GAIA, crash/WebRTC-log/domain-reliability/avatar uploads, update pings, field-trial fetching, fonts.googleapis, battery-status fingerprinting, DIAL/intranet probes, missing-API-key nags, etc. **+ 11 quarantined** (vendored, not applied).
- **`scripts/apply_ungoogled.sh` / `.ps1`** — best-effort, idempotent apply pass, wired into `apply.sh` / `apply.ps1` **after** `apply_integration.py` so Grok + branding stay authoritative; a drifted patch is logged, never fatal.
- **`scripts/check_ungoogled_patches.sh`** — read-only `git apply --check` gate (CI / pre-bump).
- **`build/args.gn{,.x64,.win,.linux}`** — 7 build-safe degoogling GN flags.
- **README** — generic Acknowledgements credit (BSD-3-Clause).

## ⚠️ Needs your review / decision

- **Not built.** Patches are *applies-clean* only; **build verification is pending** (per request, I did not compile). Cumulative-apply + link still need a real build.
- **3 behavioral patches** in the active series (flagged `[B]` in `docs/UNGOOGLED.md`): `disable-gaia` (no browser-level Google sign-in/sync — does *not* affect website "Sign in with Google"), `doh-changes` (Secure-DNS defaults), `default-webrtc-ip-handling-policy`. Drop any line from `patches/ungoogled/series` to opt out.
- **`safe_browsing_mode=0` held back** — its companion build-fix patches fail on 151 (quarantined); enabling it alone would break the link. Runtime SB *reporting* is already removed by the active iridium patches.

## Verification

```
$ scripts/check_ungoogled_patches.sh --all
SUMMARY active: applies=24 fails=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
