### PR TITLE
v0.7.9: model fix + tables + sidebar polish

### DIFF
--- a/companion/ui/app.js
+++ b/companion/ui/app.js
@@ -412,12 +412,22 @@ async function initModels() {
 }
 
 modelSelect?.addEventListener('change', async () => {
-  activeModel = modelSelect.value;
+  const next = modelSelect.value;
+  if (next === activeModel) return;
+  activeModel = next;
   persistModel(activeModel);
-  if (activeId) persistConvModel(activeId, activeModel);
   try {
     await saveSettings({ model: activeModel });
   } catch { /* local preference still applies */ }
+  // A grok conversation is locked to one model/agent — switching mid-chat is
+  // rejected (MODEL_SWITCH_INCOMPATIBLE_AGENT). If the current chat already has
+  // messages, start a fresh one on the newly chosen model; otherwise just apply
+  // it to the (still empty) current chat.
+  const cur = conversations.find((c) => c.id === activeId);
+  if (cur && (cur.messages?.length || 0) > 0) {
+    await newChat();
+  }
+  if (activeId) persistConvModel(activeId, activeModel);
 });
 
 convFilterInput?.addEventListener('input', () => {

--- a/companion/ui/common.js
+++ b/companion/ui/common.js
@@ -3,6 +3,10 @@
 const DEFAULT_MODEL = 'grok-composer-2.5-fast';
 /** Web/video search needs grok-build (Composer has no web search tools). */
 const SEARCH_DEFAULT_MODEL = 'grok-build';
+/** Chat defaults to grok-build: the agentic sidebar drives the browser via MCP
+ *  tools, which only exist under grok-build's grok-build-plan agent. Composer
+ *  (cursor agent, no tools) stays selectable for fast, tool-less Q&A. */
+const CHAT_DEFAULT_MODEL = 'grok-build';
 const MODEL_STORAGE_KEY = 'grok_model';
 const SEARCH_MODEL_STORAGE_KEY = 'grok_search_model';
 const SEARCH_HOME_STORAGE_KEY = 'grok_search_home';
@@ -14,9 +18,9 @@ const SEARCH_HOME_WIKI = 'wiki';
 
 function getStoredModel() {
   try {
-    return localStorage.getItem(MODEL_STORAGE_KEY) || DEFAULT_MODEL;
+    return localStorage.getItem(MODEL_STORAGE_KEY) || CHAT_DEFAULT_MODEL;
   } catch {
-    return DEFAULT_MODEL;
+    return CHAT_DEFAULT_MODEL;
   }
 }
 

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -836,7 +836,7 @@ def main(src: Path):
     # (Developer Build) ..."). Prepend the Xplorer product version so users see
     # OUR version first. NOTE: bump XPLORER_VERSION here per release (or wire it
     # to the release version later).
-    XPLORER_VERSION = "0.7.8"
+    XPLORER_VERSION = "0.7.9"
     ss = src / "chrome/app/settings_strings.grdp"
     sst = ss.read_text()
     _ver_marker = "Xplorer " + XPLORER_VERSION + " · Chromium"

--- a/src/chrome/browser/agent_gateway/grok_native.cc
+++ b/src/chrome/browser/agent_gateway/grok_native.cc
@@ -515,8 +515,13 @@ bool MessageNeedsBrowserTools(const std::string& message) {
 // picked and NEVER auto-switch: switching the model mid-conversation also
 // switched the agent, which broke browser follow-ups (MODEL_SWITCH_INCOMPATIBLE_AGENT).
 std::string ResolveChatModel(const std::string& /*message*/,
-                             const std::string* request_model) {
-  return ResolveModel(request_model);
+                             const std::string* /*request_model*/) {
+  // The agentic sidebar drives the browser via MCP tools, which only exist under
+  // the grok-build-plan agent — and that agent only accepts the grok-build model
+  // (Composer is hard-locked to the tool-less 'cursor' agent). So the whole
+  // conversation runs on grok-build: consistent agent across messages, no
+  // mid-session model/agent switch, browser follow-ups just work.
+  return kSearchModel;
 }
 
 const char* ChatRulesForMessage(const std::string& message) {
@@ -1781,14 +1786,6 @@ base::CommandLine BuildGrokChatCommand(const std::string& message,
   cmd.AppendArg("--always-approve");
   cmd.AppendArg("-m");
   cmd.AppendArg(model);
-  // XPLORER: pin the tool-capable harness so MCP browser tools are available
-  // regardless of the model — Composer AND grok-build both run under the
-  // grok-build-plan agent. Without this, switching the model to grok-build for a
-  // browser follow-up also switches the agent (cursor -> grok-build-plan), which
-  // grok rejects mid-session (MODEL_SWITCH_INCOMPATIBLE_AGENT). With the agent
-  // fixed up front, the model never has to change.
-  cmd.AppendArg("--agent");
-  cmd.AppendArg("grok-build-plan");
   cmd.AppendArg("--max-turns");
   cmd.AppendArg("25");
   if (!rules.empty()) {

--- a/src/chrome/browser/agent_gateway/grok_native.cc
+++ b/src/chrome/browser/agent_gateway/grok_native.cc
@@ -509,15 +509,14 @@ bool MessageNeedsBrowserTools(const std::string& message) {
   return false;
 }
 
-// Composer is fast for Q&A; browser control needs grok-build + MCP tools.
-std::string ResolveChatModel(const std::string& message,
+// The grok-build-plan agent (pinned in BuildGrokChatCommand) carries the MCP
+// browser tools, so the model never has to change for browser tasks — Composer
+// keeps its speed and can still drive the browser. Honor whatever model the user
+// picked and NEVER auto-switch: switching the model mid-conversation also
+// switched the agent, which broke browser follow-ups (MODEL_SWITCH_INCOMPATIBLE_AGENT).
+std::string ResolveChatModel(const std::string& /*message*/,
                              const std::string* request_model) {
-  std::string model = ResolveModel(request_model);
-  if (MessageNeedsBrowserTools(message) &&
-      (model == kComposerModel || model == kDefaultModel)) {
-    return kSearchModel;
-  }
-  return model;
+  return ResolveModel(request_model);
 }
 
 const char* ChatRulesForMessage(const std::string& message) {
@@ -1782,6 +1781,14 @@ base::CommandLine BuildGrokChatCommand(const std::string& message,
   cmd.AppendArg("--always-approve");
   cmd.AppendArg("-m");
   cmd.AppendArg(model);
+  // XPLORER: pin the tool-capable harness so MCP browser tools are available
+  // regardless of the model — Composer AND grok-build both run under the
+  // grok-build-plan agent. Without this, switching the model to grok-build for a
+  // browser follow-up also switches the agent (cursor -> grok-build-plan), which
+  // grok rejects mid-session (MODEL_SWITCH_INCOMPATIBLE_AGENT). With the agent
+  // fixed up front, the model never has to change.
+  cmd.AppendArg("--agent");
+  cmd.AppendArg("grok-build-plan");
   cmd.AppendArg("--max-turns");
   cmd.AppendArg("25");
   if (!rules.empty()) {

--- a/src/chrome/browser/agent_gateway/grok_native.cc
+++ b/src/chrome/browser/agent_gateway/grok_native.cc
@@ -509,18 +509,18 @@ bool MessageNeedsBrowserTools(const std::string& message) {
   return false;
 }
 
-// The grok-build-plan agent (pinned in BuildGrokChatCommand) carries the MCP
-// browser tools, so the model never has to change for browser tasks — Composer
-// keeps its speed and can still drive the browser. Honor whatever model the user
-// picked and NEVER auto-switch: switching the model mid-conversation also
-// switched the agent, which broke browser follow-ups (MODEL_SWITCH_INCOMPATIBLE_AGENT).
+// Honor the model the user picked in the sidebar. The browser MCP tools live
+// under the grok-build-plan agent, which only accepts grok-build; Composer is
+// hard-locked to the tool-less 'cursor' agent. We never auto-switch the model
+// within a conversation — grok locks a session to one agent and rejects a
+// mid-session switch in either direction — so the UI keeps each conversation on
+// one model (and starts a fresh chat when the user changes it). Default to
+// grok-build so a brand-new chat can drive the browser out of the box; an
+// explicit Composer pick is respected for fast, tool-less Q&A.
 std::string ResolveChatModel(const std::string& /*message*/,
-                             const std::string* /*request_model*/) {
-  // The agentic sidebar drives the browser via MCP tools, which only exist under
-  // the grok-build-plan agent — and that agent only accepts the grok-build model
-  // (Composer is hard-locked to the tool-less 'cursor' agent). So the whole
-  // conversation runs on grok-build: consistent agent across messages, no
-  // mid-session model/agent switch, browser follow-ups just work.
+                             const std::string* request_model) {
+  if (request_model && !request_model->empty())
+    return *request_model;
   return kSearchModel;
 }
 


### PR DESCRIPTION
Rolls up everything since v0.7.5: honor model choice (Composer/Grok Build, no mid-chat switch), markdown tables, single Grok button, Conversations→sidebar, login prompt, branding/privacy. Released as v0.7.9.