### PR TITLE
v0.8.0: concurrent agents, kill switch, crash fix, max-turns, model fixes

### DIFF
--- a/companion/ui/app.js
+++ b/companion/ui/app.js
@@ -7,11 +7,10 @@ const modelSelect = $('#model-select');
 
 let conversations = [];
 let activeId = null;
-let busy = false;
-let streamAbort = null;
+const streams = {};   // convId -> { aborter, running, reply, status, error }
+const queues = {};    // convId -> [ {id, text} ]
 let models = [];
 let activeModel = getStoredModel();
-let messageQueue = [];
 let queueSeq = 0;
 let convFilterQuery = '';
 
@@ -48,6 +47,7 @@ function renderMessages(conv) {
     }
     messagesEl.appendChild(div);
   }
+  appendTail(conv.id);
   messagesEl.scrollTop = messagesEl.scrollHeight;
 }
 
@@ -99,6 +99,22 @@ function renderConvList() {
     title.className = 'conv-title';
     title.textContent = c.title || 'Chat';
     li.appendChild(title);
+
+    if (isRunning(c.id)) {
+      const dot = document.createElement('button');
+      dot.type = 'button';
+      dot.className = 'conv-running';
+      dot.title = 'Agent running — click to stop';
+      dot.textContent = '●';
+      dot.onclick = (e) => { e.stopPropagation(); stopChat(c.id); };
+      li.appendChild(dot);
+    } else if (queues[c.id] && queues[c.id].length) {
+      const q = document.createElement('span');
+      q.className = 'conv-queued';
+      q.title = queues[c.id].length + ' queued';
+      q.textContent = '⋯';
+      li.appendChild(q);
+    }
 
     const del = document.createElement('button');
     del.type = 'button';
@@ -190,6 +206,9 @@ function selectConv(id) {
   const conv = conversations.find((c) => c.id === id);
   renderConvList();
   renderMessages(conv);
+  setComposerRunning();
+  renderQueue();
+  updateActiveBadge();
 }
 
 async function refresh() {
@@ -213,11 +232,7 @@ async function newChat() {
   input.focus();
 }
 
-function setStreamingUi(active) {
-  busy = active;
-  sendBtn.disabled = false;  // stays enabled so a 2nd message queues
-  if (stopBtn) stopBtn.hidden = !active;
-}
+// (setStreamingUi replaced by setComposerRunning, defined below)
 
 function appendStatusLine(container, text) {
   const line = document.createElement('div');
@@ -230,56 +245,129 @@ function appendStatusLine(container, text) {
   messagesEl.scrollTop = messagesEl.scrollHeight;
 }
 
-async function sendMessage(text, { retry = false } = {}) {
-  if (!text.trim() || !activeId) return;
-  if (busy) { enqueueMessage(text); input.value = ''; return; }
-  const conv = conversations.find((c) => c.id === activeId);
-  if (!conv) return;
-  if (!(await ensureGrokReady())) return;  // Grok Build required to build/modify
+const currentConv = () => conversations.find((c) => c.id === activeId);
+function isRunning(convId) { return !!(streams[convId] && streams[convId].running); }
+function activeRunCount() { return Object.values(streams).filter((s) => s.running).length; }
 
-  // Use the model the user picked — EVERY model can call the browser MCP tools
-  // (they come from the global `xplorer` MCP server, not a specific model/agent).
-  // No auto-upgrade: that silently turned Composer chats into grok-build.
-  const model = activeModel;
-  if (activeId) persistConvModel(activeId, model);  // record the chat's real model
+function updateActiveBadge() {
+  const el = document.getElementById('active-count');
+  if (!el) return;
+  const n = activeRunCount();
+  el.textContent = n ? String(n) : '';
+  el.hidden = !n;
+  el.title = n ? (n + ' chat' + (n > 1 ? 's' : '') + ' running') : '';
+}
+
+// Send stays enabled (a 2nd message queues); Stop shows when the ACTIVE chat runs.
+function setComposerRunning() {
+  if (sendBtn) sendBtn.disabled = false;
+  if (stopBtn) stopBtn.hidden = !isRunning(activeId);
+}
+
+// Kill an agent: abort the UI stream AND terminate the grok process on the gateway.
+async function stopChat(convId) {
+  const st = streams[convId];
+  if (st && st.aborter) st.aborter.abort();
+  try { await api('/api/conversations/' + convId + '/stop', { method: 'POST' }); } catch (e) { /* best effort */ }
+}
+
+function appendError(convId) {
+  const st = streams[convId];
+  if (!st || !st.error) return;
+  const box = document.createElement('div');
+  box.className = 'msg assistant thinking error';
+  const errText = document.createElement('div');
+  if (st.error.needsLogin) {
+    errText.className = 'auth-expired';
+    errText.innerHTML = '\U0001F511 <b>Connect to Grok to continue.</b><br>' +
+      'In a terminal, make sure Grok Build is installed, then run ' +
+      '<code>grok login</code> to sign in — and Retry.';
+  } else {
+    errText.textContent = 'Error: ' + (st.error.msg || '');
+  }
+  box.appendChild(errText);
+  const retryBtn = document.createElement('button');
+  retryBtn.type = 'button';
+  retryBtn.className = 'retry-btn';
+  retryBtn.textContent = 'Retry';
+  const text = st.error.text;
+  retryBtn.onclick = () => { delete streams[convId]; renderMessages(currentConv()); sendMessage(text, { retry: true, convId }); };
+  box.appendChild(retryBtn);
+  messagesEl.appendChild(box);
+}
+
+// Streaming/error tail for a conversation (only painted when it is active).
+function appendTail(convId) {
+  const st = streams[convId];
+  if (!st) return;
+  if (st.running) {
+    const live = document.createElement('div');
+    live.className = 'msg assistant streaming markdown';
+    if (st.reply) { live.innerHTML = renderMarkdown(st.reply); wireCodeCopyButtons(live); } else { live.hidden = true; }
+    messagesEl.appendChild(live);
+    const think = document.createElement('div');
+    think.className = 'msg assistant thinking';
+    const s = document.createElement('div');
+    s.className = 'stream-status';
+    s.textContent = st.status || 'Grok is thinking…';
+    think.appendChild(s);
+    messagesEl.appendChild(think);
+  } else if (st.error) {
+    appendError(convId);
+  }
+}
+
+// Incremental update of the active tail during streaming (no full re-render).
+function updateTail(convId) {
+  if (convId !== activeId) return;
+  const st = streams[convId];
+  if (!st || !st.running) return;
+  const live = messagesEl.querySelector('.msg.assistant.streaming');
+  const think = messagesEl.querySelector('.msg.assistant.thinking');
+  if (!live || !think) { renderMessages(currentConv()); return; }
+  if (st.reply) { live.hidden = false; live.innerHTML = renderMarkdown(st.reply); wireCodeCopyButtons(live); }
+  const s = think.querySelector('.stream-status');
+  if (s) s.textContent = st.status || 'Grok is thinking…';
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+}
+
+// Each conversation streams independently — switching/closing never interrupts it.
+async function sendMessage(text, { retry = false, convId = activeId } = {}) {
+  text = (text || '').trim();
+  if (!text || !convId) return;
+  const conv = conversations.find((c) => c.id === convId);
+  if (!conv) return;
+  if (isRunning(convId)) { enqueueMessage(convId, text); if (convId === activeId) input.value = ''; return; }
+  if (!(await ensureGrokReady())) return;
+
+  const model = getConvModel(convId) || activeModel;
+  persistConvModel(convId, model);
 
   if (!retry) {
     conv.messages = conv.messages || [];
     conv.messages.push({ role: 'user', content: text });
-    renderMessages(conv);
-    input.value = '';
+    if (convId === activeId) input.value = '';
   }
 
-  setStreamingUi(true);
-  streamAbort = new AbortController();
-
-  const thinking = document.createElement('div');
-  thinking.className = 'msg assistant thinking';
-  const status = document.createElement('div');
-  status.className = 'stream-status';
-  status.textContent = 'Grok is thinking…';
-  thinking.appendChild(status);
-  messagesEl.appendChild(thinking);
-  messagesEl.scrollTop = messagesEl.scrollHeight;
+  const st = { aborter: new AbortController(), running: true, reply: '', status: 'Grok is thinking…', error: null, model };
+  streams[convId] = st;
+  if (convId === activeId) { renderMessages(conv); setComposerRunning(); }
+  updateActiveBadge();
+  renderConvList();
 
   let reply = '';
   try {
-    const res = await fetch(`/api/conversations/${activeId}/message/stream`, {
+    const res = await fetch('/api/conversations/' + convId + '/message/stream', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ message: text, model }),
-      signal: streamAbort.signal,
+      signal: st.aborter.signal,
     });
-    if (!res.ok) {
-      const err = await res.json().catch(() => ({}));
-      throw new Error(err.error || res.statusText);
-    }
-
+    if (!res.ok) { const err = await res.json().catch(() => ({})); throw new Error(err.error || res.statusText); }
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
     let buffer = '';
     let thoughtBuf = '';
-
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
@@ -291,137 +379,94 @@ async function sendMessage(text, { retry = false } = {}) {
         if (!line) continue;
         const evt = parseStreamLine(line);
         if (!evt) continue;
-        if (evt.type === 'meta') {
-          if (evt.model_label) {
-            appendStatusLine(status, `Model: ${evt.model_label}`);
-          }
-        } else if (evt.type === 'thought') {
+        if (evt.type === 'thought') {
           thoughtBuf += evt.data || '';
           if (thoughtBuf.length > 120) thoughtBuf = thoughtBuf.slice(-120);
-          status.textContent = thoughtBuf || 'Grok is thinking…';
+          st.status = thoughtBuf || 'Grok is thinking…';
+          updateTail(convId);
         } else if (evt.type === 'tool' || evt.type === 'tool_use') {
           const name = evt.name || evt.tool || evt.data || 'tool';
-          appendStatusLine(status, `Using ${name}…`);
+          st.status = 'Using ' + name + '…';
+          updateTail(convId);
         } else if (evt.type === 'text') {
           reply += evt.data || '';
-          const div = messagesEl.querySelector('.msg.assistant.streaming') ||
-            (() => {
-              const el = document.createElement('div');
-              el.className = 'msg assistant streaming markdown';
-              messagesEl.insertBefore(el, thinking);
-              return el;
-            })();
-          div.innerHTML = renderMarkdown(reply);
-          wireCodeCopyButtons(div);
-          messagesEl.scrollTop = messagesEl.scrollHeight;
+          st.reply = reply;
+          updateTail(convId);
         } else if (evt.type === 'result') {
-          if (evt.reply) reply = evt.reply;
+          if (evt.reply) { reply = evt.reply; st.reply = reply; }
           if (evt.sessionId) conv.session_id = evt.sessionId;
         } else if (evt.type === 'error') {
-          // The error event carries its text in `message` (the gateway) or
-          // `error` (the grok process) — read both so detection sees the real
-          // error, not the literal "chat failed" fallback.
           throw new Error(evt.message || evt.error || 'chat failed');
         }
       }
     }
-
-    thinking.remove();
-    messagesEl.querySelector('.msg.assistant.streaming')?.remove();
-    if (reply.trim()) {
-      conv.messages.push({ role: 'assistant', content: reply, model });
-      renderMessages(conv);
-      renderConvList();
-    } else {
-      throw new Error('empty response from Grok');
-    }
+    if (reply.trim()) { conv.messages.push({ role: 'assistant', content: reply, model }); delete streams[convId]; }
+    else { throw new Error('empty response from Grok'); }
   } catch (e) {
     if (e.name === 'AbortError') {
-      thinking.remove();
-      // Keep whatever Grok generated before Stop instead of discarding it.
-      const partial = messagesEl.querySelector('.msg.assistant.streaming');
-      if (reply.trim()) {
-        if (partial) partial.remove();
-        conv.messages.push({ role: 'assistant', content: reply.trim() + '\n\n_(stopped)_', model });
-        renderMessages(conv);
-        renderConvList();
-      } else if (partial) {
-        partial.remove();
-      }
-      return;
-    }
-    thinking.classList.add('error');
-    thinking.innerHTML = '';
-    const msg = e.message || '';
-    // Grok isn't authenticated → show a clear "sign in" prompt instead of a
-    // cryptic error. Covers BOTH cases: an expired token (upstream 401) and a
-    // logged-out state (no token → grok can't fetch models → "unknown model id"
-    // / "Couldn't set model").
-    const needsLogin = /Unauthorized \(401\)|expired credentials|no auth context|grok login|PermissionDenied|not logged in|unknown model id|Couldn't set model|Run 'grok models'/i.test(msg);
-    const errText = document.createElement('div');
-    if (needsLogin) {
-      errText.className = 'auth-expired';
-      errText.innerHTML = '🔑 <b>Connect to Grok to continue.</b><br>' +
-        'In a terminal, make sure Grok Build is installed, then run ' +
-        '<code>grok login</code> to sign in — and Retry.';
+      if (reply.trim()) conv.messages.push({ role: 'assistant', content: reply.trim() + '\n\n_(stopped)_', model });
+      delete streams[convId];
     } else {
-      errText.textContent = `Error: ${msg}`;
+      const msg = e.message || '';
+      const needsLogin = /Unauthorized \(401\)|expired credentials|no auth context|grok login|PermissionDenied|not logged in|unknown model id|Couldn't set model|Run 'grok models'/i.test(msg);
+      st.error = { msg, needsLogin, text };
     }
-    thinking.appendChild(errText);
-    const retryBtn = document.createElement('button');
-    retryBtn.type = 'button';
-    retryBtn.className = 'retry-btn';
-    retryBtn.textContent = 'Retry';
-    retryBtn.onclick = () => {
-      thinking.remove();
-      sendMessage(text, { retry: true });
-    };
-    thinking.appendChild(retryBtn);
   } finally {
-    streamAbort = null;
-    setStreamingUi(false);
-    drainQueue();
-    input.focus();
+    if (streams[convId]) streams[convId].running = false;
+    updateActiveBadge();
+    renderConvList();
+    if (convId === activeId) { renderMessages(currentConv()); setComposerRunning(); input.focus(); }
+    drainQueue(convId);
   }
 }
 
 // ---- Xplorer: message queue + per-chat info panel -------------------------
-function enqueueMessage(text) {
+function enqueueMessage(convId, text) {
   const t = (text || '').trim();
   if (!t) return;
-  messageQueue.push({ id: ++queueSeq, text: t });
-  renderQueue();
+  (queues[convId] = queues[convId] || []).push({ id: ++queueSeq, text: t });
+  if (convId === activeId) renderQueue();
+  renderConvList();
 }
 
-function drainQueue() {
-  if (busy || !messageQueue.length) return;
-  const next = messageQueue.shift();
-  renderQueue();
-  if (next) sendMessage(next.text);
+function drainQueue(convId) {
+  if (isRunning(convId)) return;
+  const q = queues[convId];
+  if (!q || !q.length) return;
+  const next = q.shift();
+  if (convId === activeId) renderQueue();
+  renderConvList();
+  if (next) sendMessage(next.text, { convId });
 }
 
 function cancelQueued(id) {
-  messageQueue = messageQueue.filter((m) => m.id !== id);
+  const q = queues[activeId];
+  if (!q) return;
+  queues[activeId] = q.filter((m) => m.id !== id);
   renderQueue();
+  renderConvList();
 }
 
 function interruptWith(id) {
-  const item = messageQueue.find((m) => m.id === id);
+  const q = queues[activeId];
+  if (!q) return;
+  const item = q.find((m) => m.id === id);
   if (!item) return;
-  messageQueue = messageQueue.filter((m) => m.id !== id);
-  messageQueue.unshift(item);        // jump to the front of the queue
+  queues[activeId] = q.filter((m) => m.id !== id);
+  queues[activeId].unshift(item);
   renderQueue();
-  if (busy) streamAbort?.abort();    // finally -> drainQueue sends it next
-  else drainQueue();
+  if (isRunning(activeId)) stopChat(activeId);  // finally -> drainQueue sends it next
+  else drainQueue(activeId);
 }
 
 function renderQueue() {
   const el = document.getElementById('msg-queue');
   if (!el) return;
   el.innerHTML = '';
-  if (!messageQueue.length) { el.hidden = true; return; }
+  const q = queues[activeId] || [];
+  if (!q.length) { el.hidden = true; return; }
   el.hidden = false;
-  for (const item of messageQueue) {
+  for (const item of q) {
     const chip = document.createElement('div');
     chip.className = 'queue-chip';
     chip.title = item.text;
@@ -544,7 +589,7 @@ $('#composer').onsubmit = (e) => {
 $('#new-chat').onclick = newChat;
 
 stopBtn?.addEventListener('click', () => {
-  streamAbort?.abort();
+  if (activeId) stopChat(activeId);
 });
 
 input.addEventListener('keydown', (e) => {
@@ -639,7 +684,7 @@ initModels().then(() => refresh().then(() => {
 // On reopen, re-render the active conversation from its saved messages (errors
 // aren't persisted, so they clear) — keeping the last conversation but clean.
 document.addEventListener('visibilitychange', () => {
-  if (document.visibilityState !== 'visible' || streamAbort) return;
+  if (document.visibilityState !== 'visible' || isRunning(activeId)) return;
   if (!activeId) return;
   const conv = conversations.find((c) => c.id === activeId);
   if (conv) renderMessages(conv);

--- a/companion/ui/app.js
+++ b/companion/ui/app.js
@@ -233,9 +233,11 @@ async function sendMessage(text, { retry = false } = {}) {
   if (!conv) return;
   if (!(await ensureGrokReady())) return;  // Grok Build required to build/modify
 
-  const model = messageNeedsBrowserTools(text)
-    ? modelForSearchMode('web', activeModel, models)
-    : activeModel;
+  // Use the model the user picked — EVERY model can call the browser MCP tools
+  // (they come from the global `xplorer` MCP server, not a specific model/agent).
+  // No auto-upgrade: that silently turned Composer chats into grok-build.
+  const model = activeModel;
+  if (activeId) persistConvModel(activeId, model);  // record the chat's real model
 
   if (!retry) {
     conv.messages = conv.messages || [];

--- a/companion/ui/app.js
+++ b/companion/ui/app.js
@@ -514,6 +514,13 @@ function renderChatInfo() {
     actions.append(btn, code);
     el.appendChild(actions);
   }
+  const settingsLink = document.createElement('a');
+  settingsLink.className = 'info-settings-link';
+  settingsLink.href = '/settings';
+  settingsLink.target = '_blank';
+  settingsLink.rel = 'noopener';
+  settingsLink.textContent = 'Open Grok settings (models, max-turns, toolbar) →';
+  el.appendChild(settingsLink);
 }
 
 (function wireChatInfo() {

--- a/companion/ui/app.js
+++ b/companion/ui/app.js
@@ -11,6 +11,8 @@ let busy = false;
 let streamAbort = null;
 let models = [];
 let activeModel = getStoredModel();
+let messageQueue = [];
+let queueSeq = 0;
 let convFilterQuery = '';
 
 const convFilterInput = document.getElementById('conv-filter');
@@ -40,6 +42,7 @@ function renderMessages(conv) {
       div.innerHTML = renderMarkdown(m.content || '');
       div.classList.add('markdown');
       wireCodeCopyButtons(div);
+      appendMsgMeta(div, m);
     } else {
       div.textContent = m.content || '';
     }
@@ -212,7 +215,7 @@ async function newChat() {
 
 function setStreamingUi(active) {
   busy = active;
-  sendBtn.disabled = active;
+  sendBtn.disabled = false;  // stays enabled so a 2nd message queues
   if (stopBtn) stopBtn.hidden = !active;
 }
 
@@ -228,7 +231,8 @@ function appendStatusLine(container, text) {
 }
 
 async function sendMessage(text, { retry = false } = {}) {
-  if (!text.trim() || busy || !activeId) return;
+  if (!text.trim() || !activeId) return;
+  if (busy) { enqueueMessage(text); input.value = ''; return; }
   const conv = conversations.find((c) => c.id === activeId);
   if (!conv) return;
   if (!(await ensureGrokReady())) return;  // Grok Build required to build/modify
@@ -325,7 +329,7 @@ async function sendMessage(text, { retry = false } = {}) {
     thinking.remove();
     messagesEl.querySelector('.msg.assistant.streaming')?.remove();
     if (reply.trim()) {
-      conv.messages.push({ role: 'assistant', content: reply });
+      conv.messages.push({ role: 'assistant', content: reply, model });
       renderMessages(conv);
       renderConvList();
     } else {
@@ -338,7 +342,7 @@ async function sendMessage(text, { retry = false } = {}) {
       const partial = messagesEl.querySelector('.msg.assistant.streaming');
       if (reply.trim()) {
         if (partial) partial.remove();
-        conv.messages.push({ role: 'assistant', content: reply.trim() + '\n\n_(stopped)_' });
+        conv.messages.push({ role: 'assistant', content: reply.trim() + '\n\n_(stopped)_', model });
         renderMessages(conv);
         renderConvList();
       } else if (partial) {
@@ -376,9 +380,154 @@ async function sendMessage(text, { retry = false } = {}) {
   } finally {
     streamAbort = null;
     setStreamingUi(false);
+    drainQueue();
     input.focus();
   }
 }
+
+// ---- Xplorer: message queue + per-chat info panel -------------------------
+function enqueueMessage(text) {
+  const t = (text || '').trim();
+  if (!t) return;
+  messageQueue.push({ id: ++queueSeq, text: t });
+  renderQueue();
+}
+
+function drainQueue() {
+  if (busy || !messageQueue.length) return;
+  const next = messageQueue.shift();
+  renderQueue();
+  if (next) sendMessage(next.text);
+}
+
+function cancelQueued(id) {
+  messageQueue = messageQueue.filter((m) => m.id !== id);
+  renderQueue();
+}
+
+function interruptWith(id) {
+  const item = messageQueue.find((m) => m.id === id);
+  if (!item) return;
+  messageQueue = messageQueue.filter((m) => m.id !== id);
+  messageQueue.unshift(item);        // jump to the front of the queue
+  renderQueue();
+  if (busy) streamAbort?.abort();    // finally -> drainQueue sends it next
+  else drainQueue();
+}
+
+function renderQueue() {
+  const el = document.getElementById('msg-queue');
+  if (!el) return;
+  el.innerHTML = '';
+  if (!messageQueue.length) { el.hidden = true; return; }
+  el.hidden = false;
+  for (const item of messageQueue) {
+    const chip = document.createElement('div');
+    chip.className = 'queue-chip';
+    chip.title = item.text;
+    const txt = document.createElement('span');
+    txt.className = 'queue-text';
+    txt.textContent = item.text;
+    const send = document.createElement('button');
+    send.type = 'button';
+    send.className = 'queue-send';
+    send.title = 'Send now (interrupt current)';
+    send.textContent = '↩';
+    send.addEventListener('click', () => interruptWith(item.id));
+    const del = document.createElement('button');
+    del.type = 'button';
+    del.className = 'queue-del';
+    del.title = 'Remove from queue';
+    del.textContent = '×';
+    del.addEventListener('click', () => cancelQueued(item.id));
+    chip.append(txt, send, del);
+    el.appendChild(chip);
+  }
+}
+
+function appendMsgMeta(div, m) {
+  const meta = document.createElement('div');
+  meta.className = 'msg-meta';
+  if (m.model) {
+    const badge = document.createElement('span');
+    badge.className = 'msg-model';
+    badge.textContent = modelLabel(m.model, models);
+    meta.appendChild(badge);
+  }
+  const copy = document.createElement('button');
+  copy.type = 'button';
+  copy.className = 'msg-copy';
+  copy.textContent = 'Copy';
+  copy.title = 'Copy response';
+  copy.addEventListener('click', () => {
+    navigator.clipboard?.writeText(m.content || '');
+    copy.textContent = 'Copied ✓';
+    setTimeout(() => { copy.textContent = 'Copy'; }, 1200);
+  });
+  meta.appendChild(copy);
+  div.appendChild(meta);
+}
+
+function renderChatInfo() {
+  const el = document.getElementById('chat-info');
+  if (!el) return;
+  el.innerHTML = '';
+  const conv = conversations.find((c) => c.id === activeId);
+  if (!conv) {
+    const e = document.createElement('div');
+    e.className = 'info-empty';
+    e.textContent = 'No active chat.';
+    el.appendChild(e);
+    return;
+  }
+  const sid = conv.session_id || '';
+  const rows = [
+    ['Model', modelLabel(getConvModel(conv.id), models)],
+    ['Messages', String((conv.messages || []).length)],
+    ['Conversation ID', conv.id],
+    ['Grok session', sid || '— (send a message first)'],
+  ];
+  const dl = document.createElement('dl');
+  dl.className = 'info-grid';
+  for (const [k, v] of rows) {
+    const dt = document.createElement('dt'); dt.textContent = k;
+    const dd = document.createElement('dd'); dd.textContent = v;
+    dl.append(dt, dd);
+  }
+  el.appendChild(dl);
+  if (sid) {
+    const cmd = `grok -r ${sid}`;
+    const actions = document.createElement('div');
+    actions.className = 'info-actions';
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'info-copy';
+    btn.textContent = 'Copy CLI resume';
+    btn.addEventListener('click', () => {
+      navigator.clipboard?.writeText(cmd);
+      btn.textContent = 'Copied ✓';
+      setTimeout(() => { btn.textContent = 'Copy CLI resume'; }, 1500);
+    });
+    const code = document.createElement('code');
+    code.className = 'info-cmd';
+    code.textContent = cmd;
+    actions.append(btn, code);
+    el.appendChild(actions);
+  }
+}
+
+(function wireChatInfo() {
+  const btn = document.getElementById('chat-info-btn');
+  const panel = document.getElementById('chat-info');
+  if (!btn || !panel) return;
+  btn.addEventListener('click', () => {
+    const show = panel.hidden;
+    if (show) renderChatInfo();
+    panel.hidden = !show;
+    btn.setAttribute('aria-expanded', show ? 'true' : 'false');
+  });
+})();
+// ---------------------------------------------------------------------------
 
 $('#composer').onsubmit = (e) => {
   e.preventDefault();

--- a/companion/ui/common.js
+++ b/companion/ui/common.js
@@ -18,9 +18,9 @@ const SEARCH_HOME_WIKI = 'wiki';
 
 function getStoredModel() {
   try {
-    return localStorage.getItem(MODEL_STORAGE_KEY) || CHAT_DEFAULT_MODEL;
+    return localStorage.getItem(MODEL_STORAGE_KEY) || DEFAULT_MODEL;
   } catch {
-    return CHAT_DEFAULT_MODEL;
+    return DEFAULT_MODEL;
   }
 }
 

--- a/companion/ui/index.html
+++ b/companion/ui/index.html
@@ -18,6 +18,7 @@
         <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M3 6h18v2H3zM3 11h18v2H3zM3 16h18v2H3z"/></svg>
       </button>
       <div class="chat-bar-title" id="chat-title">Grok</div>
+      <button type="button" id="active-count" class="active-count" hidden title="Chats running — open list"></button>
       <button type="button" id="chat-info-btn" class="iconbtn" title="Chat info" aria-label="Chat info" aria-expanded="false">
         <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 00.12-.61l-1.92-3.32a.49.49 0 00-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.48.48 0 00-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96a.49.49 0 00-.59.22L2.74 8.87a.49.49 0 00.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58a.49.49 0 00-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6a3.6 3.6 0 110-7.2 3.6 3.6 0 010 7.2z"/></svg>
       </button>
@@ -85,6 +86,9 @@
         body.classList.contains('conv-open') ? close() : open();
       });
       backdrop && backdrop.addEventListener('click', close);
+      // Active-chat count badge opens the conversations list to manage running chats.
+      var activeCount = document.getElementById('active-count');
+      activeCount && activeCount.addEventListener('click', open);
       // Header "+" starts a new chat (reusing the drawer's handler) and closes the drawer.
       newTop && newChat && newTop.addEventListener('click', function () { newChat.click(); close(); });
       // Picking a conversation closes the drawer so the chat gets the full width.

--- a/companion/ui/index.html
+++ b/companion/ui/index.html
@@ -18,12 +18,19 @@
         <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M3 6h18v2H3zM3 11h18v2H3zM3 16h18v2H3z"/></svg>
       </button>
       <div class="chat-bar-title" id="chat-title">Grok</div>
+      <button type="button" id="chat-info-btn" class="iconbtn" title="Chat info" aria-label="Chat info" aria-expanded="false">
+        <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 00.12-.61l-1.92-3.32a.49.49 0 00-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.48.48 0 00-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96a.49.49 0 00-.59.22L2.74 8.87a.49.49 0 00.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58a.49.49 0 00-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6a3.6 3.6 0 110-7.2 3.6 3.6 0 010 7.2z"/></svg>
+      </button>
       <button type="button" id="new-chat-top" class="iconbtn" title="New conversation" aria-label="New conversation">
         <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M11 5h2v6h6v2h-6v6h-2v-6H5v-2h6z"/></svg>
       </button>
     </header>
 
+    <div id="chat-info" class="chat-info" hidden></div>
+
     <div id="messages" class="messages"></div>
+
+    <div id="msg-queue" class="msg-queue" hidden></div>
 
     <form id="composer" class="composer">
       <div class="composer-row">

--- a/companion/ui/settings.html
+++ b/companion/ui/settings.html
@@ -50,6 +50,17 @@
         </section>
 
         <section class="settings-card">
+          <h2>Grok Build agent</h2>
+          <label class="settings-field">
+            <span>Max turns per request</span>
+            <input type="number" id="max-turns" min="1" max="200" step="1">
+            <small>How many tool/reasoning steps the agent may take to answer one
+              message. Raise it for bigger multi-step tasks (open &amp; organize
+              many tabs); lower it to cap cost/latency. 1–200, default 50.</small>
+          </label>
+        </section>
+
+        <section class="settings-card">
           <h2>Browser appearance</h2>
           <label class="settings-field">
             <span>Chrome color scheme</span>

--- a/companion/ui/settings.js
+++ b/companion/ui/settings.js
@@ -3,6 +3,7 @@ const searchHome = document.getElementById('search-home');
 const chatModel = document.getElementById('chat-model');
 const searchModel = document.getElementById('search-model');
 const browserTheme = document.getElementById('browser-theme');
+const maxTurns = document.getElementById('max-turns');
 
 function setStatus(msg, kind = '') {
   if (!statusEl) return;
@@ -41,6 +42,7 @@ async function init() {
   if (searchHome) searchHome.value = settings.search_home || SEARCH_HOME_BUILD;
   fillSelect(chatModel, models, settings.model || DEFAULT_MODEL);
   fillSelect(searchModel, models, settings.search_model || SEARCH_DEFAULT_MODEL);
+  if (maxTurns) maxTurns.value = settings.max_turns || 50;
 
   document.getElementById('info-companion')?.replaceChildren(
     document.createTextNode(settings.companion_url || location.origin),
@@ -82,6 +84,14 @@ chatModel?.addEventListener('change', () => {
 searchModel?.addEventListener('change', () => {
   persistSearchModel(searchModel.value);
   persist({ search_model: searchModel.value });
+});
+
+maxTurns?.addEventListener('change', () => {
+  let n = parseInt(maxTurns.value, 10);
+  if (!Number.isFinite(n)) n = 50;
+  n = Math.min(200, Math.max(1, n));
+  maxTurns.value = String(n);
+  persist({ max_turns: n });
 });
 
 browserTheme?.addEventListener('change', async () => {

--- a/companion/ui/style.css
+++ b/companion/ui/style.css
@@ -525,3 +525,41 @@ html[data-theme="dark"] .markdown .hl-num { color: #fbbf24; }
 }
 .messages .markdown thead th { background: rgba(127,127,127,0.12); font-weight: 600; }
 .messages .markdown tbody tr:nth-child(even) { background: rgba(127,127,127,0.05); }
+
+/* ---- Xplorer: per-chat info panel (gear) ---- */
+.chat-info {
+  border-bottom: 1px solid var(--border, #d8d8d8);
+  padding: 10px 14px; font-size: 0.85em; background: rgba(127,127,127,0.06);
+}
+.chat-info .info-empty { opacity: 0.7; }
+.chat-info .info-grid { display: grid; grid-template-columns: auto 1fr; gap: 4px 12px; margin: 0; }
+.chat-info .info-grid dt { opacity: 0.6; white-space: nowrap; }
+.chat-info .info-grid dd { margin: 0; word-break: break-all; font-variant-numeric: tabular-nums; }
+.chat-info .info-actions { display: flex; align-items: center; gap: 8px; margin-top: 8px; flex-wrap: wrap; }
+.chat-info .info-copy {
+  border: 1px solid var(--border, #d8d8d8); background: transparent; color: inherit;
+  border-radius: 6px; padding: 3px 10px; cursor: pointer; font-size: 0.95em;
+}
+.chat-info .info-copy:hover { background: rgba(127,127,127,0.12); }
+.chat-info .info-cmd { font-family: ui-monospace, monospace; opacity: 0.75; word-break: break-all; }
+
+/* ---- Xplorer: queued messages ---- */
+.msg-queue { display: flex; flex-direction: column; gap: 4px; padding: 6px 12px; border-top: 1px solid var(--border, #d8d8d8); }
+.queue-chip {
+  display: flex; align-items: center; gap: 6px; background: rgba(127,127,127,0.1);
+  border-radius: 8px; padding: 4px 6px 4px 10px; font-size: 0.88em;
+}
+.queue-chip .queue-text { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; opacity: 0.85; }
+.queue-chip .queue-send, .queue-chip .queue-del {
+  border: none; background: transparent; color: inherit; cursor: pointer; border-radius: 5px;
+  width: 22px; height: 22px; line-height: 1; font-size: 1em; opacity: 0; flex: none;
+}
+.queue-chip:hover .queue-send, .queue-chip:hover .queue-del { opacity: 0.7; }
+.queue-chip .queue-send:hover, .queue-chip .queue-del:hover { opacity: 1; background: rgba(127,127,127,0.2); }
+
+/* ---- Xplorer: per-message model badge + copy ---- */
+.msg.assistant .msg-meta { display: flex; align-items: center; gap: 8px; margin-top: 6px; opacity: 0; transition: opacity 0.12s; }
+.msg.assistant:hover .msg-meta { opacity: 1; }
+.msg-meta .msg-model { font-size: 0.72em; opacity: 0.6; border: 1px solid var(--border, #d8d8d8); border-radius: 999px; padding: 1px 8px; }
+.msg-meta .msg-copy { border: none; background: transparent; color: inherit; cursor: pointer; font-size: 0.78em; opacity: 0.6; padding: 1px 6px; border-radius: 5px; }
+.msg-meta .msg-copy:hover { opacity: 1; background: rgba(127,127,127,0.15); }

--- a/companion/ui/style.css
+++ b/companion/ui/style.css
@@ -570,3 +570,18 @@ html[data-theme="dark"] .markdown .hl-num { color: #fbbf24; }
   opacity: 0.8; text-decoration: none; border-bottom: 1px dotted currentColor;
 }
 .chat-info .info-settings-link:hover { opacity: 1; }
+
+/* ---- Xplorer: concurrent-chat indicators ---- */
+.chat-bar .active-count {
+  min-width: 20px; height: 20px; padding: 0 6px; border: none; border-radius: 10px;
+  background: #2ecc71; color: #06281a; font-size: 0.72em; font-weight: 700; cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center; flex: none;
+}
+.chat-bar .active-count:hover { filter: brightness(1.08); }
+#conv-list .conv-running {
+  border: none; background: transparent; color: #2ecc71; cursor: pointer; flex: none;
+  font-size: 0.7em; line-height: 1; padding: 0 4px; animation: xpl-pulse 1.4s ease-in-out infinite;
+}
+#conv-list .conv-running:hover { color: #e74c3c; animation: none; }  /* hover = will stop */
+#conv-list .conv-queued { opacity: 0.55; font-size: 0.95em; padding: 0 4px; flex: none; }
+@keyframes xpl-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.3; } }

--- a/companion/ui/style.css
+++ b/companion/ui/style.css
@@ -563,3 +563,10 @@ html[data-theme="dark"] .markdown .hl-num { color: #fbbf24; }
 .msg-meta .msg-model { font-size: 0.72em; opacity: 0.6; border: 1px solid var(--border, #d8d8d8); border-radius: 999px; padding: 1px 8px; }
 .msg-meta .msg-copy { border: none; background: transparent; color: inherit; cursor: pointer; font-size: 0.78em; opacity: 0.6; padding: 1px 6px; border-radius: 5px; }
 .msg-meta .msg-copy:hover { opacity: 1; background: rgba(127,127,127,0.15); }
+
+/* Xplorer: settings link in the chat-info panel */
+.chat-info .info-settings-link {
+  display: inline-block; margin-top: 10px; font-size: 0.92em; color: inherit;
+  opacity: 0.8; text-decoration: none; border-bottom: 1px dotted currentColor;
+}
+.chat-info .info-settings-link:hover { opacity: 1; }

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -836,7 +836,7 @@ def main(src: Path):
     # (Developer Build) ..."). Prepend the Xplorer product version so users see
     # OUR version first. NOTE: bump XPLORER_VERSION here per release (or wire it
     # to the release version later).
-    XPLORER_VERSION = "0.7.9"
+    XPLORER_VERSION = "0.8.0"
     ss = src / "chrome/app/settings_strings.grdp"
     sst = ss.read_text()
     _ver_marker = "Xplorer " + XPLORER_VERSION + " · Chromium"

--- a/scripts/release_arch.sh
+++ b/scripts/release_arch.sh
@@ -31,6 +31,15 @@ echo "==> [$ARCH] Applying overlay"
 echo "==> [$ARCH] Building"
 "$XPLORER/build.sh" "$SRC" "$ARCH"
 
+# The build does not refresh the bundled companion UI (it persists across builds),
+# so copy the current companion/ui into the bundle BEFORE signing — otherwise the
+# release ships stale sidebar UI.
+echo "==> [$ARCH] Refreshing bundled companion UI"
+UI_DST="$APP/Contents/Resources/companion/ui"
+mkdir -p "$(dirname "$UI_DST")"
+rm -rf "$UI_DST"
+cp -R "$XPLORER/companion/ui" "$UI_DST"
+
 echo "==> [$ARCH] Signing app"
 if [ -n "$SIGN_ONLY" ]; then
   "$XPLORER/scripts/sign_and_notarize.sh" "$APP" xplorer-notary --sign-only

--- a/src/chrome/browser/agent_gateway/browser_api.cc
+++ b/src/chrome/browser/agent_gateway/browser_api.cc
@@ -3,6 +3,7 @@
 
 #include "chrome/browser/agent_gateway/browser_api.h"
 
+#include <algorithm>
 #include <map>
 #include <optional>
 #include <string>
@@ -289,6 +290,26 @@ tab_groups::TabGroupColorId ColorForCategory(const std::string& category) {
   return tab_groups::TabGroupColorId::kOrange;
 }
 
+namespace {
+// TabStripModel::AddToNewGroup() CHECK-aborts the entire browser process on
+// duplicate or out-of-range indices. A model driving the browser can easily pass
+// repeated, reordered, or stale tab ids (especially after opening many tabs), so
+// always dedupe, drop anything no longer in the strip, and sort ascending before
+// grouping — a bad tool argument must degrade gracefully, never crash.
+std::vector<int> SanitizeTabIndices(TabStripModel* model,
+                                    std::vector<int> indices) {
+  std::vector<int> clean;
+  for (int i : indices) {
+    if (model->ContainsIndex(i) &&
+        std::find(clean.begin(), clean.end(), i) == clean.end()) {
+      clean.push_back(i);
+    }
+  }
+  std::sort(clean.begin(), clean.end());
+  return clean;
+}
+}  // namespace
+
 void BrowserApi::OrganizeTabs(DictCallback callback) {
   base::DictValue result;
   base::ListValue groups_out;
@@ -309,6 +330,7 @@ void BrowserApi::OrganizeTabs(DictCallback callback) {
       buckets[category].push_back(i);
     }
     for (auto& [category, indices] : buckets) {
+      indices = SanitizeTabIndices(model, std::move(indices));
       if (indices.empty())
         continue;
       tab_groups::TabGroupId group = model->AddToNewGroup(indices);
@@ -365,6 +387,12 @@ void BrowserApi::GroupTabs(const std::vector<std::string>& tab_ids,
       return;
     }
     indices.push_back(index);
+  }
+  indices = SanitizeTabIndices(model, std::move(indices));
+  if (indices.empty()) {
+    result.Set("error", "no valid tabs to group");
+    std::move(callback).Run(std::move(result));
+    return;
   }
   tab_groups::TabGroupId group = model->AddToNewGroup(indices);
   if (!title.empty()) {

--- a/src/chrome/browser/agent_gateway/grok_native.cc
+++ b/src/chrome/browser/agent_gateway/grok_native.cc
@@ -477,6 +477,27 @@ void SetSearchHomeMode(const std::string& mode) {
   SaveSettings(settings);
 }
 
+// Agent turn budget for a single chat/search request. 25 was too low for
+// multi-step browser tasks (open many tabs, then group) which ran out mid-task;
+// default higher and let the user tune it in Settings.
+constexpr int kDefaultMaxTurns = 50;
+
+int GetConfiguredMaxTurns() {
+  base::DictValue settings = LoadSettings();
+  if (const std::optional<int> n = settings.FindInt("max_turns")) {
+    if (*n >= 1 && *n <= 200)
+      return *n;
+  }
+  return kDefaultMaxTurns;
+}
+
+void SetConfiguredMaxTurns(int turns) {
+  base::DictValue settings = LoadSettings();
+  const int clamped = turns < 1 ? 1 : (turns > 200 ? 200 : turns);
+  settings.Set("max_turns", clamped);
+  SaveSettings(settings);
+}
+
 std::string ResolveModel(const std::string* request_model) {
   if (request_model && !request_model->empty())
     return *request_model;
@@ -550,6 +571,7 @@ void EnrichSettingsResponse(base::DictValue* d, int gateway_port) {
          "http://127.0.0.1:" + base::NumberToString(gateway_port));
   d->Set("search_model", GetConfiguredSearchModel());
   d->Set("search_model_label", ModelDisplayName(GetConfiguredSearchModel()));
+  d->Set("max_turns", GetConfiguredMaxTurns());
   d->Set("grok_bin", ResolveGrokBinary().AsUTF8Unsafe());
   std::string gw_json;
   if (base::ReadFileToString(xplorer_paths::Resolve("gateway.json"),
@@ -1792,7 +1814,7 @@ base::CommandLine BuildGrokChatCommand(const std::string& message,
   cmd.AppendArg("-m");
   cmd.AppendArg(model);
   cmd.AppendArg("--max-turns");
-  cmd.AppendArg("25");
+  cmd.AppendArg(base::NumberToString(GetConfiguredMaxTurns()));
   if (!rules.empty()) {
     cmd.AppendArg("--rules");
     cmd.AppendArg(rules);
@@ -2331,6 +2353,7 @@ bool GrokNative::TryHandleRequest(
     const std::string* home = body->FindString("search_home");
     const base::DictValue* toolbar = body->FindDict("toolbar");
     std::optional<bool> welcome = body->FindBool("welcome_completed");
+    std::optional<int> max_turns = body->FindInt("max_turns");
     bool updated = false;
     if (model && !model->empty()) {
       SetConfiguredModel(*model);
@@ -2349,6 +2372,10 @@ bool GrokNative::TryHandleRequest(
         return true;
       }
       SetSearchHomeMode(*home);
+      updated = true;
+    }
+    if (max_turns) {
+      SetConfiguredMaxTurns(*max_turns);
       updated = true;
     }
     if (welcome.has_value() && *welcome) {

--- a/src/chrome/browser/agent_gateway/grok_native.cc
+++ b/src/chrome/browser/agent_gateway/grok_native.cc
@@ -1861,7 +1861,19 @@ void RunGrokChatStream(
     std::string message,
     std::string session_id,
     std::string model) {
-  const char* rules = ChatRulesForMessage(message);
+  // Tell the model who it is. Otherwise it digs through ~/.grok session files to
+  // answer "what model are you", or misreports itself and name-drops Cursor
+  // (Composer is Cursor's model, agent type 'cursor') — confusing in a browser.
+  std::string rules =
+      std::string(ChatRulesForMessage(message)) +
+      "\n\nIDENTITY: You are Grok, the AI assistant built into Xplorer — an "
+      "AI-native web browser (NOT Cursor or any code editor). You are running as "
+      "the \"" +
+      ModelDisplayName(model) + "\" model (" + model +
+      "). If the user asks which model or assistant you are, answer \"" +
+      ModelDisplayName(model) +
+      "\" directly and concisely — do not read files or session metadata to find "
+      "out, and never describe yourself as being inside Cursor or an IDE.";
   base::ThreadPool::CreateSequencedTaskRunner(
       {base::MayBlock(), base::TaskPriority::USER_VISIBLE})
       ->PostTask(FROM_HERE,

--- a/src/chrome/browser/agent_gateway/grok_native.cc
+++ b/src/chrome/browser/agent_gateway/grok_native.cc
@@ -1282,6 +1282,47 @@ std::string FormatOrganizeTabsReply(const base::DictValue& result) {
           server, io_task_runner, connection_id, std::move(conv_id)));
 }
 
+// Registry of in-flight grok runs keyed by conversation id, so a chat's agent
+// can be stopped on demand (kill switch) even after its UI stream is closed.
+// Touched from many PumpGrokStream sequences AND the request thread → locked.
+base::Lock& ActiveRunsLock() {
+  static base::NoDestructor<base::Lock> lock;
+  return *lock;
+}
+std::map<std::string, base::ProcessId>& ActiveRuns() {
+  static base::NoDestructor<std::map<std::string, base::ProcessId>> runs;
+  return *runs;
+}
+void RegisterActiveRun(const std::string& conv_id, base::ProcessId pid) {
+  if (conv_id.empty())
+    return;
+  base::AutoLock l(ActiveRunsLock());
+  ActiveRuns()[conv_id] = pid;
+}
+void UnregisterActiveRun(const std::string& conv_id) {
+  if (conv_id.empty())
+    return;
+  base::AutoLock l(ActiveRunsLock());
+  ActiveRuns().erase(conv_id);
+}
+// Terminate the grok process for |conv_id| if one is running. Returns whether a
+// run was found. Cross-platform via base::Process::Open(pid).Terminate().
+bool StopActiveRun(const std::string& conv_id) {
+  base::ProcessId pid = base::kNullProcessId;
+  {
+    base::AutoLock l(ActiveRunsLock());
+    auto it = ActiveRuns().find(conv_id);
+    if (it == ActiveRuns().end())
+      return false;
+    pid = it->second;
+    ActiveRuns().erase(it);
+  }
+  base::Process p = base::Process::Open(pid);
+  if (p.IsValid())
+    p.Terminate(/*exit_code=*/0, /*wait=*/false);
+  return true;
+}
+
 void PumpGrokStream(net::HttpServer* server,
                     scoped_refptr<base::SingleThreadTaskRunner> io_task_runner,
                     int connection_id,
@@ -1396,6 +1437,9 @@ void PumpGrokStream(net::HttpServer* server,
     return;  // read_handle / read_file RAII-close the read end here.
   }
 
+  // Track this run so the kill switch / per-chat Stop can terminate it.
+  RegisterActiveRun(conv_id, process.Pid());
+
   RecordGatewayLog("info", log_source, app_id, "start",
                    log_source == "build" ? "app build started"
                                          : "grok run started",
@@ -1460,6 +1504,7 @@ void PumpGrokStream(net::HttpServer* server,
 
   int exit_code = -1;
   process.WaitForExit(&exit_code);
+  UnregisterActiveRun(conv_id);
 
   // Recover the otherwise-discarded stderr so failures show a real reason.
   std::string stderr_tail;
@@ -2794,6 +2839,21 @@ bool GrokNative::TryHandleRequest(
     convs->Append(conv.Clone());
     SaveSessions(data);
     SendJson(server, connection_id, net::HTTP_OK, std::move(conv));
+    return true;
+  }
+
+  // Kill switch: stop the running grok agent for a chat.
+  // POST /api/conversations/{id}/stop
+  if (info.method == "POST" && base::StartsWith(path, "/api/conversations/") &&
+      base::EndsWith(path, "/stop")) {
+    const std::string prefix = "/api/conversations/";
+    std::string id = path.substr(prefix.size());
+    id = id.substr(0, id.size() - std::string("/stop").size());
+    const bool stopped = StopActiveRun(id);
+    base::DictValue d;
+    d.Set("ok", true);
+    d.Set("stopped", stopped);
+    SendJson(server, connection_id, net::HTTP_OK, std::move(d));
     return true;
   }
 

--- a/src/chrome/browser/agent_gateway/grok_native.cc
+++ b/src/chrome/browser/agent_gateway/grok_native.cc
@@ -384,8 +384,13 @@ constexpr char kChatRules[] =
     "control the browser through MCP tools.";
 
 constexpr char kBrowserChatRules[] =
-    "You are Grok, the native AI companion built into Xplorer (Chromium). "
-    "You MUST control the real browser through MCP tools — never give manual "
+    "You are Grok, the native AI companion built into Xplorer, an AI-native web "
+    "browser. Your browser-control tools (tabs, navigation, bookmarks, history, "
+    "tab groups, click/type, screenshots, theme) are ALREADY loaded and ready in "
+    "this session — call them directly and immediately. Do NOT announce that you "
+    "are checking what tools are available, and do NOT run a tool-discovery/list "
+    "step first; just act. "
+    "You MUST control the real browser through these tools — never give manual "
     "instructions the user must follow themselves. "
     "To organize/group tabs: FIRST call xplorer_tabs to list every open tab, "
     "decide sensible groups yourself from each tab's real content/topic, then "


### PR DESCRIPTION
Locks in the full verified stack since v0.7.9: concurrent background chats + per-chat kill switch, honor-picked-model + model identity, message queue + gear panel, tab-grouping crash fix, configurable max-turns, and the Mac UI-refresh build fix. Released as v0.8.0.