### PR TITLE
v0.8.3 — gateway hardening + new-tab/omnibox fixes

### DIFF
--- a/companion/ui/search.js
+++ b/companion/ui/search.js
@@ -120,10 +120,12 @@ if (modeParam && ['web', 'imagine'].includes(modeParam)) {
 } else {
   setMode(getStoredSearchMode() === 'imagine' ? 'imagine' : 'web');
 }
+// A fresh new tab opens a blank Grok home — only honor an explicit ?q= in the
+// URL; do NOT auto-restore the last search (that made every new tab reopen the
+// previous query, e.g. /search?q=xcnn).
 const urlQuery = urlParams.get('q');
-const initialQuery = urlQuery || getStoredSearchQuery();
-if (initialQuery) {
-  input.value = initialQuery;
+if (urlQuery) {
+  input.value = urlQuery;
   syncUrl();
 }
 if (urlQuery) {

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -836,7 +836,7 @@ def main(src: Path):
     # (Developer Build) ..."). Prepend the Xplorer product version so users see
     # OUR version first. NOTE: bump XPLORER_VERSION here per release (or wire it
     # to the release version later).
-    XPLORER_VERSION = "0.8.2"
+    XPLORER_VERSION = "0.8.3"
     ss = src / "chrome/app/settings_strings.grdp"
     sst = ss.read_text()
     _ver_marker = "Xplorer " + XPLORER_VERSION + " · Chromium"

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -563,6 +563,35 @@ def main(src: Path):
         '  return grok_companion::GetStartupHomeURL();\n}',
     )
 
+    # New tabs land on the Grok home (an http gateway page). Render it with a
+    # blank omnibox like the NTP instead of exposing the internal gateway URL.
+    loc_delegate = (
+        src / "chrome/browser/ui/toolbar/chrome_location_bar_model_delegate.cc")
+    edit(
+        loc_delegate,
+        '#include "components/search/ntp_features.h"',
+        '#include "components/search/ntp_features.h"\n'
+        '#include "chrome/browser/grok_companion/grok_companion_util.h"  // XPLORER',
+    )
+    edit(
+        loc_delegate,
+        '  GURL url = entry->GetURL();\n'
+        '  if (is_ntp(entry->GetVirtualURL()) || is_ntp(url)) {\n'
+        '    return false;\n'
+        '  }',
+        '  GURL url = entry->GetURL();\n'
+        '  if (is_ntp(entry->GetVirtualURL()) || is_ntp(url)) {\n'
+        '    return false;\n'
+        '  }\n'
+        '\n'
+        '  // XPLORER: our own gateway home pages (the new-tab home) get a blank\n'
+        '  // omnibox, just like the NTP.\n'
+        '  if (grok_companion::IsGrokHomeURL(url) ||\n'
+        '      grok_companion::IsGrokHomeURL(entry->GetVirtualURL())) {\n'
+        '    return false;\n'
+        '  }',
+    )
+
     # Enable AI Mode omnibox entrypoint feature flag.
     edit(
         cmd_delegate,

--- a/src/chrome/browser/agent_gateway/agent_gateway.cc
+++ b/src/chrome/browser/agent_gateway/agent_gateway.cc
@@ -122,10 +122,30 @@ bool AgentGateway::CheckAuth(const net::HttpServerRequestInfo& info) {
   return it != info.headers.end() && it->second == "Bearer " + token_;
 }
 
-void AgentGateway::OnConnect(int connection_id) {}
+namespace {
+// Max accepted request body. Larger bodies get a 413 in OnHttpRequest; the
+// per-connection read buffer is bounded just above this so anything past it
+// closes cleanly instead of wedging the connection (the default 1 MB read
+// buffer could hang on an oversized body).
+constexpr int kMaxRequestBodyBytes = 1024 * 1024;
+}  // namespace
+
+void AgentGateway::OnConnect(int connection_id) {
+  server_->SetReceiveBufferSize(connection_id,
+                                kMaxRequestBodyBytes + 128 * 1024);
+}
 
 void AgentGateway::OnHttpRequest(int connection_id,
                                  const net::HttpServerRequestInfo& info) {
+  // Reject oversized request bodies up front: return 413 instead of slow-
+  // processing or persisting garbage (pairs with the bounded read buffer).
+  if (info.data.size() > static_cast<size_t>(kMaxRequestBodyBytes)) {
+    net::HttpServerResponseInfo resp(net::HTTP_REQUEST_ENTITY_TOO_LARGE);
+    resp.SetBody("{\"error\":\"request body too large\"}", "application/json");
+    server_->SendResponse(connection_id, resp, TRAFFIC_ANNOTATION_FOR_TESTS);
+    return;
+  }
+
   // Native Grok UI + search/chat API (no auth — localhost browser UI only).
   if (GrokNative::TryHandleRequest(connection_id, info, server_.get(), port_,
                                    server_thread_->task_runner()))

--- a/src/chrome/browser/agent_gateway/agent_session.cc
+++ b/src/chrome/browser/agent_gateway/agent_session.cc
@@ -157,6 +157,9 @@ void AgentSession::Eval(const std::string& expression, ResultCallback cb) {
   params.Set("expression", expression);
   params.Set("returnByValue", true);
   params.Set("awaitPromise", true);
+  // Abort runaway scripts (e.g. while(true){}) after 15s with an error instead
+  // of wedging the tab's renderer forever.
+  params.Set("timeout", 15000);
   SendCommand("Runtime.evaluate", std::move(params), std::move(cb));
 }
 

--- a/src/chrome/browser/agent_gateway/grok_native.cc
+++ b/src/chrome/browser/agent_gateway/grok_native.cc
@@ -2960,6 +2960,19 @@ bool GrokNative::TryHandleRequest(
       SendJson(server, connection_id, net::HTTP_NOT_FOUND, std::move(err));
       return true;
     }
+    // Reject a message to a conversation that is already streaming a reply: a
+    // concurrent run would race the load/modify/save of the session store and
+    // scramble saved messages. The UI serializes via its client-side queue;
+    // this guards direct API callers. (Returns 409 so the client can retry.)
+    {
+      base::AutoLock l(ActiveRunsLock());
+      if (ActiveRuns().count(conv_id)) {
+        base::DictValue err;
+        err.Set("error", "conversation is busy (a reply is still streaming)");
+        SendJson(server, connection_id, net::HTTP_CONFLICT, std::move(err));
+        return true;
+      }
+    }
     base::ListValue* msgs = conv->FindList("messages");
     if (!msgs) {
       conv->Set("messages", base::ListValue());

--- a/src/chrome/browser/agent_gateway/grok_native.cc
+++ b/src/chrome/browser/agent_gateway/grok_native.cc
@@ -2406,6 +2406,33 @@ bool GrokNative::TryHandleRequest(
     std::optional<bool> welcome = body->FindBool("welcome_completed");
     std::optional<int> max_turns = body->FindInt("max_turns");
     bool updated = false;
+    // Validate model ids against the known list before persisting — these are
+    // the global default chat/search models, so an unvalidated value (e.g. a
+    // bogus or huge string) would corrupt live config for every new session.
+    if ((model && !model->empty()) || (search_model && !search_model->empty())) {
+      base::ListValue known = ListGrokModels();
+      auto is_known = [&known](const std::string& id) {
+        for (const base::Value& m : known) {
+          const auto* md = m.GetIfDict();
+          const std::string* mid = md ? md->FindString("id") : nullptr;
+          if (mid && *mid == id)
+            return true;
+        }
+        return false;
+      };
+      if (model && !model->empty() && !is_known(*model)) {
+        base::DictValue err;
+        err.Set("error", "unknown model id");
+        SendJson(server, connection_id, net::HTTP_BAD_REQUEST, std::move(err));
+        return true;
+      }
+      if (search_model && !search_model->empty() && !is_known(*search_model)) {
+        base::DictValue err;
+        err.Set("error", "unknown search_model id");
+        SendJson(server, connection_id, net::HTTP_BAD_REQUEST, std::move(err));
+        return true;
+      }
+    }
     if (model && !model->empty()) {
       SetConfiguredModel(*model);
       updated = true;

--- a/src/chrome/browser/grok_companion/grok_companion_util.cc
+++ b/src/chrome/browser/grok_companion/grok_companion_util.cc
@@ -154,6 +154,19 @@ GURL GetStartupHomeURL() {
   return GetDefaultSearchHomeURL();
 }
 
+bool IsGrokHomeURL(const GURL& url) {
+  if (!url.is_valid())
+    return false;
+  // Match origin + path against the gateway home pages, ignoring query/ref so
+  // e.g. /search?q=... still counts as the home.
+  GURL::Replacements clear;
+  clear.ClearQuery();
+  clear.ClearRef();
+  const GURL bare = url.ReplaceComponents(clear);
+  return bare == GetSearchURL() || bare == GetCompanionURL() ||
+         bare == GetWelcomeURL();
+}
+
 std::string GetSearchHomeMode() {
   base::DictValue settings = LoadGrokSettings();
   if (const std::string* mode = settings.FindString("search_home")) {

--- a/src/chrome/browser/grok_companion/grok_companion_util.h
+++ b/src/chrome/browser/grok_companion/grok_companion_util.h
@@ -68,6 +68,11 @@ GURL GetSearchURL();
 GURL GetWelcomeURL();
 GURL GetStartupHomeURL();
 
+// True if `url` is one of Xplorer's own gateway home pages (the new-tab home:
+// search / companion / welcome). Such pages render with a blank omnibox, like
+// the NTP, instead of exposing the internal gateway URL.
+bool IsGrokHomeURL(const GURL& url);
+
 bool HasCompletedWelcome();
 void MarkWelcomeCompleted();
 


### PR DESCRIPTION
Ships v0.8.3: blank-omnibox new-tab home (renders like the NTP), new tab no longer reopens the last search query, and AgentGateway hardening (1MB body limit/413, settings model validation/400, 15s eval timeout, per-conversation concurrency guard/409).