### PR TITLE
v0.8.4 — vertical/touch tabs, streaming thinking, effort gear, sidebar clipboard

### DIFF
--- a/companion/ui/app.js
+++ b/companion/ui/app.js
@@ -661,8 +661,12 @@ async function initModels() {
     }
   } catch { /* use localStorage fallback */ }
   models = await fetchModels();
-  if (!models.some((m) => m.id === activeModel)) {
-    activeModel = models[0]?.id || DEFAULT_MODEL;
+  // Never clobber a remembered choice: only re-pick when the list is non-empty
+  // and the saved model truly isn't in it — and even then prefer the stored
+  // model over models[0] (which is composer-fast and would silently reset it).
+  if (models.length && !models.some((m) => m.id === activeModel)) {
+    const stored = getStoredModel();
+    activeModel = models.some((m) => m.id === stored) ? stored : models[0].id;
   }
   populateModelSelect(modelSelect, models, activeModel);
 }

--- a/companion/ui/app.js
+++ b/companion/ui/app.js
@@ -315,6 +315,18 @@ function appendTail(convId) {
     messagesEl.appendChild(live);
     const think = document.createElement('div');
     think.className = 'msg assistant thinking';
+    const panel = document.createElement('details');
+    panel.className = 'thinking-panel';
+    panel.open = true;
+    const sum = document.createElement('summary');
+    sum.textContent = '✦ Thinking';
+    panel.appendChild(sum);
+    const tt = document.createElement('div');
+    tt.className = 'thinking-text';
+    tt.textContent = st.thinking || '';
+    panel.appendChild(tt);
+    if (!st.thinking) panel.hidden = true;
+    think.appendChild(panel);
     const s = document.createElement('div');
     s.className = 'stream-status';
     s.textContent = st.status || 'Grok is thinking…';
@@ -334,6 +346,12 @@ function updateTail(convId) {
   const think = messagesEl.querySelector('.msg.assistant.thinking');
   if (!live || !think) { renderMessages(currentConv()); return; }
   if (st.reply) { live.hidden = false; live.innerHTML = renderMarkdown(st.reply); wireCodeCopyButtons(live); }
+  const panel = think.querySelector('.thinking-panel');
+  const tt = think.querySelector('.thinking-text');
+  if (panel && tt) {
+    if (st.thinking) { panel.hidden = false; tt.textContent = st.thinking; tt.scrollTop = tt.scrollHeight; }
+    else { panel.hidden = true; }
+  }
   const s = think.querySelector('.stream-status');
   if (s) s.textContent = st.status || 'Grok is thinking…';
   messagesEl.scrollTop = messagesEl.scrollHeight;
@@ -357,7 +375,7 @@ async function sendMessage(text, { retry = false, convId = activeId } = {}) {
     if (convId === activeId) input.value = '';
   }
 
-  const st = { aborter: new AbortController(), running: true, reply: '', status: 'Grok is thinking…', error: null, model };
+  const st = { aborter: new AbortController(), running: true, reply: '', status: 'Grok is thinking…', thinking: '', error: null, model };
   streams[convId] = st;
   if (convId === activeId) { renderMessages(conv); setComposerRunning(); }
   updateActiveBadge();
@@ -392,9 +410,7 @@ async function sendMessage(text, { retry = false, convId = activeId } = {}) {
         const evt = parseStreamLine(line);
         if (!evt) continue;
         if (evt.type === 'thought') {
-          thoughtBuf += evt.data || '';
-          if (thoughtBuf.length > 120) thoughtBuf = thoughtBuf.slice(-120);
-          st.status = thoughtBuf || 'Grok is thinking…';
+          st.thinking += evt.data || '';
           updateTail(convId);
         } else if (evt.type === 'tool' || evt.type === 'tool_use') {
           const name = evt.name || evt.tool || evt.data || 'tool';
@@ -610,6 +626,31 @@ input.addEventListener('keydown', (e) => {
     sendMessage(input.value);
   }
 });
+
+// Response-settings gear: effort + max turns, persisted via /api/settings.
+(function setupEffortGear() {
+  const gear = $('#effort-gear');
+  const pop = $('#effort-popover');
+  const effortSel = $('#effort-select');
+  const maxturns = $('#maxturns-input');
+  if (!gear || !pop) return;
+  gear.addEventListener('click', (e) => { e.stopPropagation(); pop.hidden = !pop.hidden; });
+  document.addEventListener('click', (e) => {
+    if (!pop.hidden && !pop.contains(e.target) && !gear.contains(e.target)) pop.hidden = true;
+  });
+  const save = async () => {
+    const body = {};
+    if (effortSel) body.effort = effortSel.value;
+    if (maxturns && maxturns.value) body.max_turns = parseInt(maxturns.value, 10);
+    try { await saveSettings(body); } catch { /* local-only */ }
+  };
+  effortSel?.addEventListener('change', save);
+  maxturns?.addEventListener('change', save);
+  fetchSettings().then((s) => {
+    if (s && s.effort && effortSel) effortSel.value = s.effort;
+    if (s && s.max_turns && maxturns) maxturns.value = s.max_turns;
+  }).catch(() => {});
+})();
 
 async function initModels() {
   try {

--- a/companion/ui/index.html
+++ b/companion/ui/index.html
@@ -43,7 +43,28 @@
           <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true"><path fill="currentColor" d="M4 12l16-8-6 16-2.5-6.2L4 12z"/></svg>
         </button>
       </div>
-      <select id="model-select" class="composer-model-select" title="Model" aria-label="Model"></select>
+      <div class="composer-tools">
+        <select id="model-select" class="composer-model-select" title="Model" aria-label="Model"></select>
+        <button type="button" id="effort-gear" class="composer-gear" title="Response settings" aria-label="Response settings">
+          <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><path fill="currentColor" d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 00.12-.61l-1.92-3.32a.49.49 0 00-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.48.48 0 00-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96a.49.49 0 00-.59.22L2.74 8.87a.49.49 0 00.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58a.49.49 0 00-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.04.24.23.41.47.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32a.49.49 0 00-.12-.61l-2.01-1.58zM12 15.6a3.6 3.6 0 110-7.2 3.6 3.6 0 010 7.2z"/></svg>
+        </button>
+      </div>
+      <div id="effort-popover" class="effort-popover" hidden>
+        <div class="effort-title">Response settings</div>
+        <label class="effort-row"><span>Effort</span>
+          <select id="effort-select">
+            <option value="low">Low — fastest</option>
+            <option value="medium">Medium</option>
+            <option value="high">High</option>
+            <option value="xhigh">Extra high</option>
+            <option value="max">Max</option>
+          </select>
+        </label>
+        <label class="effort-row"><span>Max turns</span>
+          <input id="maxturns-input" type="number" min="1" max="200" step="1" />
+        </label>
+        <div class="effort-hint">Lower effort + fewer turns = faster replies.</div>
+      </div>
     </form>
   </main>
 

--- a/companion/ui/style.css
+++ b/companion/ui/style.css
@@ -550,21 +550,22 @@ html[data-theme="dark"] .markdown .hl-num { color: #fbbf24; }
 }
 
 /* Rich markdown rendering in chat messages. */
-.messages .markdown { line-height: 1.55; }
+.messages .markdown { line-height: 1.5; }
 .messages .markdown > :first-child { margin-top: 0; }
 .messages .markdown > :last-child { margin-bottom: 0; }
-.messages .markdown p { margin: 0.5em 0; }
+.messages .markdown p { margin: 0.3em 0; }
+.messages .markdown li > p { margin: 0.1em 0; }  /* loose-list bullets stay tight */
 .messages .markdown h1, .messages .markdown h2, .messages .markdown h3,
 .messages .markdown h4, .messages .markdown h5, .messages .markdown h6 {
-  margin: 0.85em 0 0.4em; line-height: 1.3; font-weight: 600;
+  margin: 0.6em 0 0.25em; line-height: 1.3; font-weight: 600;
 }
 .messages .markdown h1 { font-size: 1.32em; }
 .messages .markdown h2 { font-size: 1.18em; }
 .messages .markdown h3 { font-size: 1.07em; }
 .messages .markdown h4, .messages .markdown h5, .messages .markdown h6 { font-size: 1em; }
-.messages .markdown ul, .messages .markdown ol { margin: 0.5em 0; padding-left: 1.5em; }
-.messages .markdown li { margin: 0.25em 0; }
-.messages .markdown li > ul, .messages .markdown li > ol { margin: 0.25em 0; }
+.messages .markdown ul, .messages .markdown ol { margin: 0.3em 0; padding-left: 1.4em; }
+.messages .markdown li { margin: 0.1em 0; }
+.messages .markdown li > ul, .messages .markdown li > ol { margin: 0.1em 0; }
 .messages .markdown blockquote {
   margin: 0.6em 0; padding: 0.15em 0.9em;
   border-left: 3px solid var(--border, #d4d4d4); color: var(--text-secondary, #666);

--- a/companion/ui/style.css
+++ b/companion/ui/style.css
@@ -642,6 +642,7 @@ html[data-theme="dark"] .markdown .hl-num { color: #fbbf24; }
   background: #2ecc71; color: #06281a; font-size: 0.72em; font-weight: 700; cursor: pointer;
   display: inline-flex; align-items: center; justify-content: center; flex: none;
 }
+.chat-bar .active-count[hidden] { display: none; }  /* hide the pill at 0 running */
 .chat-bar .active-count:hover { filter: brightness(1.08); }
 #conv-list .conv-running {
   border: none; background: transparent; color: #2ecc71; cursor: pointer; flex: none;

--- a/companion/ui/style.css
+++ b/companion/ui/style.css
@@ -323,6 +323,41 @@ html[data-theme="dark"] .markdown .hl-num { color: #fbbf24; }
   font-style: italic;
 }
 
+/* Live, collapsible reasoning stream (mirrors the app-builder thinking panel). */
+.msg.thinking .thinking-panel {
+  font-style: normal;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  overflow: hidden;
+  margin-bottom: 6px;
+}
+.msg.thinking .thinking-panel summary {
+  padding: 6px 9px;
+  cursor: pointer;
+  user-select: none;
+  font-size: 12px;
+  color: var(--text-secondary);
+  list-style: none;
+}
+.msg.thinking .thinking-panel summary::-webkit-details-marker { display: none; }
+.msg.thinking .thinking-panel summary::before {
+  content: "▾ ";
+  display: inline-block;
+  transition: transform 0.15s;
+}
+.msg.thinking .thinking-panel:not([open]) summary::before { transform: rotate(-90deg); }
+.msg.thinking .thinking-text {
+  padding: 0 9px 9px;
+  font-size: 12px;
+  font-style: normal;
+  line-height: 1.5;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
 .msg.thinking .stream-status-line {
   font-size: 11px;
   color: var(--text-secondary);
@@ -368,7 +403,36 @@ html[data-theme="dark"] .markdown .hl-num { color: #fbbf24; }
   padding: 8px 10px 10px;
   border-top: 1px solid var(--border);
   background: var(--surface);
+  position: relative;
 }
+
+.composer-tools { display: flex; align-items: center; gap: 6px; }
+.composer-tools .composer-model-select { flex: 1; }
+.composer-gear {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 30px; height: 30px; flex: none;
+  border: 1px solid var(--border); border-radius: 8px;
+  background: var(--surface); color: var(--text-secondary); cursor: pointer;
+}
+.composer-gear:hover { color: var(--text); background: var(--surface-elevated); }
+.effort-popover {
+  position: absolute; bottom: 100%; right: 10px; margin-bottom: 6px; z-index: 30;
+  background: var(--surface-elevated); border: 1px solid var(--border);
+  border-radius: 12px; padding: 12px; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  min-width: 230px; display: flex; flex-direction: column; gap: 10px;
+}
+.effort-popover[hidden] { display: none; }
+.effort-title { font-size: 12px; font-weight: 600; color: var(--text); }
+.effort-row {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 10px; font-size: 12px; color: var(--text-secondary);
+}
+.effort-row select, .effort-row input {
+  font: inherit; font-size: 12px; padding: 4px 6px;
+  border: 1px solid var(--border); border-radius: 6px;
+  background: var(--surface); color: var(--text); min-width: 120px;
+}
+.effort-hint { font-size: 11px; color: var(--text-secondary); opacity: 0.85; }
 
 .composer-row {
   display: flex;

--- a/patches/apply_integration.py
+++ b/patches/apply_integration.py
@@ -603,7 +603,42 @@ def main(src: Path):
         '    if (!cmd->HasSwitch("enable-features"))\n'
         '      cmd->AppendSwitchASCII("enable-features",\n'
         '                             "AiModeOmniboxEntryPoint");\n'
+        '    if (!cmd->HasSwitch("top-chrome-touch-ui"))\n'
+        '      cmd->AppendSwitchASCII("top-chrome-touch-ui", "enabled");\n'
         '  }\n',
+    )
+
+    # XPLORER: vertical tabs (tabs to the side) on by default — enable the
+    # feature + expand-on-hover, and flip the layout pref so a fresh profile
+    # opens with the side tab strip rather than the horizontal strip.
+    tabs_features = src / "chrome/browser/ui/tabs/features.cc"
+    # NOTE: edit() only *replaces* the anchor when the insertion restates its
+    # first or last line; a bare one-line value flip is treated as additive and
+    # gets spliced (duplicated). So anchor each flip together with an unchanged
+    # neighbouring line.
+    edit(
+        tabs_features,
+        "BASE_FEATURE(kVerticalTabs, base::FEATURE_DISABLED_BY_DEFAULT);\n\n"
+        "BASE_FEATURE(kVerticalTabsLaunch, base::FEATURE_DISABLED_BY_DEFAULT);",
+        "BASE_FEATURE(kVerticalTabs, base::FEATURE_ENABLED_BY_DEFAULT);\n\n"
+        "BASE_FEATURE(kVerticalTabsLaunch, base::FEATURE_DISABLED_BY_DEFAULT);",
+    )
+    edit(
+        tabs_features,
+        "BASE_FEATURE(kVerticalTabsExpandOnHover, "
+        "base::FEATURE_DISABLED_BY_DEFAULT);\nBASE_FEATURE_PARAM(bool,",
+        "BASE_FEATURE(kVerticalTabsExpandOnHover, "
+        "base::FEATURE_ENABLED_BY_DEFAULT);\nBASE_FEATURE_PARAM(bool,",
+    )
+    tab_strip_prefs = src / "chrome/browser/ui/tabs/tab_strip_prefs.cc"
+    edit(
+        tab_strip_prefs,
+        "  registry->RegisterBooleanPref(prefs::kEverythingMenuPinnedToTabstrip,"
+        " true);\n"
+        "  registry->RegisterBooleanPref(prefs::kVerticalTabsEnabled, false);",
+        "  registry->RegisterBooleanPref(prefs::kEverythingMenuPinnedToTabstrip,"
+        " true);\n"
+        "  registry->RegisterBooleanPref(prefs::kVerticalTabsEnabled, true);",
     )
 
     # Rename "AI Mode" label to "Grok" in the omnibox chip.
@@ -865,7 +900,7 @@ def main(src: Path):
     # (Developer Build) ..."). Prepend the Xplorer product version so users see
     # OUR version first. NOTE: bump XPLORER_VERSION here per release (or wire it
     # to the release version later).
-    XPLORER_VERSION = "0.8.3"
+    XPLORER_VERSION = "0.8.4"
     ss = src / "chrome/app/settings_strings.grdp"
     sst = ss.read_text()
     _ver_marker = "Xplorer " + XPLORER_VERSION + " · Chromium"

--- a/src/chrome/browser/agent_gateway/grok_native.cc
+++ b/src/chrome/browser/agent_gateway/grok_native.cc
@@ -504,6 +504,31 @@ void SetConfiguredMaxTurns(int turns) {
   SaveSettings(settings);
 }
 
+// Reasoning effort for the chat. Fast ("low") by default; the sidebar gear
+// exposes the full range. Passed to grok as --effort.
+constexpr char kDefaultEffort[] = "low";
+
+bool IsValidEffort(const std::string& e) {
+  return e == "low" || e == "medium" || e == "high" || e == "xhigh" ||
+         e == "max";
+}
+
+std::string GetConfiguredEffort() {
+  base::DictValue settings = LoadSettings();
+  if (const std::string* e = settings.FindString("effort")) {
+    if (IsValidEffort(*e))
+      return *e;
+  }
+  return kDefaultEffort;
+}
+
+void SetConfiguredEffort(const std::string& effort) {
+  base::DictValue settings = LoadSettings();
+  settings.Set("effort",
+               IsValidEffort(effort) ? effort : std::string(kDefaultEffort));
+  SaveSettings(settings);
+}
+
 std::string ResolveModel(const std::string* request_model) {
   if (request_model && !request_model->empty())
     return *request_model;
@@ -578,6 +603,7 @@ void EnrichSettingsResponse(base::DictValue* d, int gateway_port) {
   d->Set("search_model", GetConfiguredSearchModel());
   d->Set("search_model_label", ModelDisplayName(GetConfiguredSearchModel()));
   d->Set("max_turns", GetConfiguredMaxTurns());
+  d->Set("effort", GetConfiguredEffort());
   d->Set("grok_bin", ResolveGrokBinary().AsUTF8Unsafe());
   std::string gw_json;
   if (base::ReadFileToString(xplorer_paths::Resolve("gateway.json"),
@@ -1866,6 +1892,8 @@ base::CommandLine BuildGrokChatCommand(const std::string& message,
   cmd.AppendArg(model);
   cmd.AppendArg("--max-turns");
   cmd.AppendArg(base::NumberToString(GetConfiguredMaxTurns()));
+  cmd.AppendArg("--effort");
+  cmd.AppendArg(GetConfiguredEffort());
   if (!rules.empty()) {
     cmd.AppendArg("--rules");
     cmd.AppendArg(rules);
@@ -2405,6 +2433,7 @@ bool GrokNative::TryHandleRequest(
     const base::DictValue* toolbar = body->FindDict("toolbar");
     std::optional<bool> welcome = body->FindBool("welcome_completed");
     std::optional<int> max_turns = body->FindInt("max_turns");
+    const std::string* effort = body->FindString("effort");
     bool updated = false;
     // Validate model ids against the known list before persisting — these are
     // the global default chat/search models, so an unvalidated value (e.g. a
@@ -2454,6 +2483,16 @@ bool GrokNative::TryHandleRequest(
     }
     if (max_turns) {
       SetConfiguredMaxTurns(*max_turns);
+      updated = true;
+    }
+    if (effort && !effort->empty()) {
+      if (!IsValidEffort(*effort)) {
+        base::DictValue err;
+        err.Set("error", "effort must be low/medium/high/xhigh/max");
+        SendJson(server, connection_id, net::HTTP_BAD_REQUEST, std::move(err));
+        return true;
+      }
+      SetConfiguredEffort(*effort);
       updated = true;
     }
     if (welcome.has_value() && *welcome) {

--- a/src/chrome/browser/grok_companion/grok_companion_util.cc
+++ b/src/chrome/browser/grok_companion/grok_companion_util.cc
@@ -95,12 +95,33 @@ void SaveGrokSettings(const base::DictValue& settings) {
     base::WriteFile(path, json);
 }
 
-// The side-panel companion hosts an http page in a views::WebView. A bare
-// WebView leaves its WebContents with no delegate, so the focused input never
-// receives the macOS edit commands (Cut/Copy/Paste) — plain typing works but
-// ⌘C/⌘V/⌘X don't. Give the contents a delegate (the piece WebUI side panels get
-// from WebUIContentsWrapper) and forward unhandled keys to the focus manager so
-// browser accelerators keep working from the panel too.
+// The side-panel companion hosts an http page in a raw views::WebView.
+//
+// macOS clipboard root cause: on Mac, ⌘C/⌘V/⌘X (and the Edit-menu Cut/Copy/
+// Paste items) are plain Cocoa selectors `cut:`/`copy:`/`paste:` dispatched to
+// the *NSWindow first responder* — via `[NSApp sendAction:@selector(paste:)
+// to:nil]` in remote_cocoa::ApplicationBridge::ForwardCutCopyPasteToNSApp(),
+// reached from BrowserView::CutCopyPaste(). They are NOT routed by TabStripModel
+// membership or the Browser/WebContents delegate. RenderWidgetHostViewCocoa's
+// -performKeyEquivalent: and the menu's sendAction both require
+// `[[self window] firstResponder] == self`
+// (content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm).
+//
+// A standalone WebContents that is never WasShown() keeps its
+// RenderWidgetHostViewCocoa NSView created with `hidden = YES`
+// (render_widget_host_ns_view_bridge.mm), and AppKit refuses to make a hidden
+// view the first responder. Plain typing still works (key events are routed via
+// the renderer-host focus path, which does not require AppKit first-responder
+// status), but command-key equivalents and Edit-menu actions never reach the
+// view — exactly the reported symptom.
+//
+// The fix mirrors what every WebUI side panel gets for free via
+// SidePanelWebUIView::ViewHierarchyChanged(): drive the contents to the shown/
+// visible state once it is in the widget hierarchy (so SetVisible(true) ->
+// cocoa_view_.hidden = NO), then focus it so its RWHV becomes first responder.
+// This is cross-platform safe; WasShown()/RequestFocus() are no-ops or correct
+// on Win/Linux. We also keep a delegate that forwards unhandled keys to the
+// focus manager so browser accelerators keep working from the panel.
 class CompanionWebView : public views::WebView {
  public:
   explicit CompanionWebView(Profile* profile)
@@ -115,6 +136,20 @@ class CompanionWebView : public views::WebView {
   void AttachContents(std::unique_ptr<content::WebContents> contents) {
     contents->SetDelegate(&delegate_);
     SetOwnedWebContents(std::move(contents));
+  }
+
+  // views::WebView:
+  void ViewHierarchyChanged(
+      const views::ViewHierarchyChangedDetails& details) override {
+    views::WebView::ViewHierarchyChanged(details);
+    // Once added to the widget, mark the contents shown so its
+    // RenderWidgetHostView (and, on macOS, its RenderWidgetHostViewCocoa NSView)
+    // becomes visible and thus eligible to be the NSWindow first responder. This
+    // is what makes ⌘C/⌘V/⌘X reach the focused input. Mirrors
+    // SidePanelWebUIView::ViewHierarchyChanged().
+    if (details.is_add && details.child == this && web_contents()) {
+      web_contents()->WasShown();
+    }
   }
 
  private:

--- a/src/chrome/browser/grok_companion/grok_companion_util.cc
+++ b/src/chrome/browser/grok_companion/grok_companion_util.cc
@@ -37,6 +37,10 @@
 #include "ui/base/page_transition_types.h"
 #include "ui/gfx/geometry/size.h"
 #include "ui/views/controls/webview/webview.h"
+#include "ui/views/controls/webview/unhandled_keyboard_event_handler.h"  // XPLORER
+#include "content/public/browser/web_contents_delegate.h"  // XPLORER
+#include "components/input/native_web_keyboard_event.h"  // XPLORER
+#include "base/memory/raw_ptr.h"  // XPLORER
 #include "url/gurl.h"
 
 namespace grok_companion {
@@ -91,19 +95,59 @@ void SaveGrokSettings(const base::DictValue& settings) {
     base::WriteFile(path, json);
 }
 
+// The side-panel companion hosts an http page in a views::WebView. A bare
+// WebView leaves its WebContents with no delegate, so the focused input never
+// receives the macOS edit commands (Cut/Copy/Paste) — plain typing works but
+// ⌘C/⌘V/⌘X don't. Give the contents a delegate (the piece WebUI side panels get
+// from WebUIContentsWrapper) and forward unhandled keys to the focus manager so
+// browser accelerators keep working from the panel too.
+class CompanionWebView : public views::WebView {
+ public:
+  explicit CompanionWebView(Profile* profile)
+      : views::WebView(profile), delegate_(this) {}
+  CompanionWebView(const CompanionWebView&) = delete;
+  CompanionWebView& operator=(const CompanionWebView&) = delete;
+  ~CompanionWebView() override {
+    if (web_contents())
+      web_contents()->SetDelegate(nullptr);
+  }
+
+  void AttachContents(std::unique_ptr<content::WebContents> contents) {
+    contents->SetDelegate(&delegate_);
+    SetOwnedWebContents(std::move(contents));
+  }
+
+ private:
+  class Delegate : public content::WebContentsDelegate {
+   public:
+    explicit Delegate(CompanionWebView* owner) : owner_(owner) {}
+    bool HandleKeyboardEvent(
+        content::WebContents* source,
+        const input::NativeWebKeyboardEvent& event) override {
+      return handler_.HandleKeyboardEvent(event, owner_->GetFocusManager());
+    }
+
+   private:
+    const raw_ptr<CompanionWebView> owner_;
+    views::UnhandledKeyboardEventHandler handler_;
+  };
+
+  Delegate delegate_;
+};
+
 std::unique_ptr<views::View> CreateGrokCompanionView(
     BrowserWindowInterface* browser,
     Profile* profile,
     SidePanelEntryScope& scope,
     const GURL& url) {
-  auto web_view = std::make_unique<views::WebView>(profile);
+  auto web_view = std::make_unique<CompanionWebView>(profile);
   web_view->SetID(SidePanelWebUIView::kSidePanelWebViewId);
   content::WebContents::CreateParams params(profile);
   auto contents = content::WebContents::Create(params);
   content::NavigationController::LoadURLParams load(url);
   load.transition_type = ui::PAGE_TRANSITION_AUTO_TOPLEVEL;
   contents->GetController().LoadURLWithParams(load);
-  web_view->SetOwnedWebContents(std::move(contents));
+  web_view->AttachContents(std::move(contents));
   web_view->SetPreferredSize(
       gfx::Size(SidePanelEntry::kSidePanelDefaultContentWidth, 0));
   return web_view;

--- a/src/chrome/browser/grok_companion/grok_companion_util.cc
+++ b/src/chrome/browser/grok_companion/grok_companion_util.cc
@@ -41,6 +41,8 @@
 #include "content/public/browser/web_contents_delegate.h"  // XPLORER
 #include "components/input/native_web_keyboard_event.h"  // XPLORER
 #include "base/memory/raw_ptr.h"  // XPLORER
+#include "base/memory/weak_ptr.h"  // XPLORER
+#include "base/task/sequenced_task_runner.h"  // XPLORER
 #include "url/gurl.h"
 
 namespace grok_companion {
@@ -97,31 +99,28 @@ void SaveGrokSettings(const base::DictValue& settings) {
 
 // The side-panel companion hosts an http page in a raw views::WebView.
 //
-// macOS clipboard root cause: on Mac, ⌘C/⌘V/⌘X (and the Edit-menu Cut/Copy/
-// Paste items) are plain Cocoa selectors `cut:`/`copy:`/`paste:` dispatched to
-// the *NSWindow first responder* — via `[NSApp sendAction:@selector(paste:)
-// to:nil]` in remote_cocoa::ApplicationBridge::ForwardCutCopyPasteToNSApp(),
-// reached from BrowserView::CutCopyPaste(). They are NOT routed by TabStripModel
-// membership or the Browser/WebContents delegate. RenderWidgetHostViewCocoa's
-// -performKeyEquivalent: and the menu's sendAction both require
-// `[[self window] firstResponder] == self`
-// (content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm).
+// macOS clipboard root cause: Cut/Copy/Paste/Select-All (⌘C/⌘V/⌘X/⌘A and the
+// Edit menu) are Cocoa selectors dispatched to the NSWindow *first responder*
+// (`[NSApp sendAction:@selector(paste:) to:nil]` from BrowserView::CutCopyPaste,
+// and RenderWidgetHostViewCocoa -performKeyEquivalent: which requires
+// `[[self window] firstResponder] == self`). They are NOT routed by the tab
+// strip, the Browser, or the WebContentsDelegate — so the side panel's RWHV
+// NSView must literally BE the window first responder.
 //
-// A standalone WebContents that is never WasShown() keeps its
-// RenderWidgetHostViewCocoa NSView created with `hidden = YES`
-// (render_widget_host_ns_view_bridge.mm), and AppKit refuses to make a hidden
-// view the first responder. Plain typing still works (key events are routed via
-// the renderer-host focus path, which does not require AppKit first-responder
-// status), but command-key equivalents and Edit-menu actions never reach the
-// view — exactly the reported symptom.
-//
-// The fix mirrors what every WebUI side panel gets for free via
-// SidePanelWebUIView::ViewHierarchyChanged(): drive the contents to the shown/
-// visible state once it is in the widget hierarchy (so SetVisible(true) ->
-// cocoa_view_.hidden = NO), then focus it so its RWHV becomes first responder.
-// This is cross-platform safe; WasShown()/RequestFocus() are no-ops or correct
-// on Win/Linux. We also keep a delegate that forwards unhandled keys to the
-// focus manager so browser accelerators keep working from the panel.
+// Two pieces were missing:
+//  (a) WasShown() un-hides the RWHV NSView (cocoa_view_.hidden = NO) — necessary
+//      (AppKit won't make a hidden view first responder) but NOT sufficient: it
+//      never calls makeFirstResponder. Plain typing worked anyway via the
+//      renderer page-focus path (no first-responder guard) — hence the symptom.
+//  (b) The actual focus: web_contents()->Focus() -> RWHVMac::Focus() ->
+//      MakeFirstResponder(). For a views::WebView the only entry is OnFocus(),
+//      which fires on RequestFocus(). We drive it after the view is shown+drawn
+//      (deferred + retried, since the side panel opens animated), and again on
+//      OnFocus / OnWebContentsFocused so clicking back in re-acquires it.
+// Also: SetDelegate() MUST run after SetOwnedWebContents() (which itself calls
+// SetDelegate(this)), or the key-forwarding delegate is silently clobbered.
+// Cross-platform safe — WasShown()/Focus() are correct no-ops on Win/Linux,
+// where clipboard isn't first-responder-gated.
 class CompanionWebView : public views::WebView {
  public:
   explicit CompanionWebView(Profile* profile)
@@ -134,25 +133,60 @@ class CompanionWebView : public views::WebView {
   }
 
   void AttachContents(std::unique_ptr<content::WebContents> contents) {
-    contents->SetDelegate(&delegate_);
+    // Delegate AFTER SetOwnedWebContents(): the latter calls
+    // wc_owner_->SetDelegate(this), which would clobber a delegate set first.
     SetOwnedWebContents(std::move(contents));
+    web_contents()->SetDelegate(&delegate_);
   }
 
   // views::WebView:
   void ViewHierarchyChanged(
       const views::ViewHierarchyChangedDetails& details) override {
     views::WebView::ViewHierarchyChanged(details);
-    // Once added to the widget, mark the contents shown so its
-    // RenderWidgetHostView (and, on macOS, its RenderWidgetHostViewCocoa NSView)
-    // becomes visible and thus eligible to be the NSWindow first responder. This
-    // is what makes ⌘C/⌘V/⌘X reach the focused input. Mirrors
-    // SidePanelWebUIView::ViewHierarchyChanged().
     if (details.is_add && details.child == this && web_contents()) {
-      web_contents()->WasShown();
+      web_contents()->WasShown();  // un-hide the RWHV NSView (precondition)
+      FocusContentsSoon(8);        // then make it the window first responder
     }
   }
 
+  void OnFocus() override {
+    // Whenever this view is focused by any path, ensure the contents is shown
+    // before it is focused (never ask a hidden NSView to be first responder).
+    if (web_contents())
+      web_contents()->WasShown();
+    views::WebView::OnFocus();
+  }
+
+  void OnWebContentsFocused(
+      content::RenderWidgetHost* render_widget_host) override {
+    views::WebView::OnWebContentsFocused(render_widget_host);
+    // Clicking back into the panel keeps this WebView views-focused so the RWHV
+    // stays the window first responder and clipboard keeps working.
+    RequestFocus();
+  }
+
  private:
+  void FocusContentsSoon(int tries) {
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE, base::BindOnce(&CompanionWebView::FocusContentsNow,
+                                  weak_factory_.GetWeakPtr(), tries));
+  }
+
+  void FocusContentsNow(int tries) {
+    if (!web_contents())
+      return;
+    // RequestFocus() only takes once the view is drawn (visible in the tree).
+    // The side panel opens animated, so retry a few turns if not ready yet.
+    if (!GetWidget() || !IsDrawn()) {
+      if (tries > 0)
+        FocusContentsSoon(tries - 1);
+      return;
+    }
+    // Routes WebView::OnFocus() -> web_contents()->Focus() -> RWHVMac::Focus()
+    // -> [window makeFirstResponder:cocoa_view_].
+    RequestFocus();
+  }
+
   class Delegate : public content::WebContentsDelegate {
    public:
     explicit Delegate(CompanionWebView* owner) : owner_(owner) {}
@@ -168,6 +202,7 @@ class CompanionWebView : public views::WebView {
   };
 
   Delegate delegate_;
+  base::WeakPtrFactory<CompanionWebView> weak_factory_{this};
 };
 
 std::unique_ptr<views::View> CreateGrokCompanionView(


### PR DESCRIPTION
Ships v0.8.4: vertical tabs + touch UI by default, live streaming thinking panel, response-settings effort gear, model-persistence, tighter answer spacing, active-pill fix, and the macOS side-panel clipboard fix (first-responder). Plus the v0.8.3 gateway hardening.