### PR TITLE
fix(ui): dock Grok side panel so chat does not clip

### DIFF
--- a/companion/ui/index.html
+++ b/companion/ui/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="grok-build">
+<html lang="en" class="grok-build xpl-sidepanel">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/companion/ui/style.css
+++ b/companion/ui/style.css
@@ -5,25 +5,32 @@
 html.grok-build,
 html.grok-build body {
   margin: 0;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
   height: 100%;
   overflow: hidden;
   background: var(--bg);
   color: var(--text);
   font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
+/* Toolbar mount is a no-op in the side panel (nav lives in native bookmarks).
+   Hide the empty node so it cannot steal a grid/flex row or clip the chat. */
+#grok-toolbar-mount:empty { display: none; }
+
 body {
-  display: grid;
-  grid-template-rows: auto 1fr;
-  grid-template-columns: 1fr;
-  grid-template-areas:
-    "header"
-    "chat";
+  display: flex;
+  flex-direction: column;
   position: relative;
+  min-width: 0;
 }
 
 .grok-toolbar {
-  grid-area: header;
+  flex: none;
 }
 
 /* Conversations are a slide-over drawer (hidden by default) so the chat gets
@@ -61,9 +68,12 @@ body.conv-open .sidebar {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 8px;
+  padding: 8px 10px;
   border-bottom: 1px solid var(--border);
   background: var(--surface);
+  flex: none;
+  min-width: 0;
+  width: 100%;
 }
 
 .chat-bar-title {
@@ -284,40 +294,51 @@ html[data-theme="dark"] .markdown .hl-num { color: #fbbf24; }
 }
 
 .chat {
-  grid-area: chat;
   display: flex;
   flex-direction: column;
+  flex: 1;
   min-height: 0;
+  min-width: 0;
+  width: 100%;
 }
 
 .messages {
   flex: 1;
+  overflow-x: hidden;
   overflow-y: auto;
-  padding: 16px;
+  padding: 12px;
   display: flex;
   flex-direction: column;
   gap: 10px;
+  min-width: 0;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
 }
 
 .msg {
-  max-width: 88%;
-  padding: 10px 14px;
-  border-radius: 12px;
+  max-width: 100%;
+  padding: 10px 12px;
+  border-radius: 14px;
   font-size: 14px;
   line-height: 1.5;
   white-space: pre-wrap;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: normal;
+  min-width: 0;
 }
 
 .msg.user {
   align-self: flex-end;
+  max-width: 92%;
   background: var(--user-bg);
   color: var(--text);
   border-bottom-right-radius: 4px;
 }
 
 .msg.assistant {
-  align-self: flex-start;
+  align-self: stretch;
+  width: 100%;
+  max-width: 100%;
   background: var(--assistant-bg);
   color: var(--text);
   border-bottom-left-radius: 4px;
@@ -423,6 +444,9 @@ html[data-theme="dark"] .markdown .hl-num { color: #fbbf24; }
   border-top: 1px solid var(--border);
   background: var(--surface);
   position: relative;
+  flex: none;
+  min-width: 0;
+  width: 100%;
 }
 
 .composer-tools { display: flex; align-items: center; gap: 6px; }
@@ -435,10 +459,10 @@ html[data-theme="dark"] .markdown .hl-num { color: #fbbf24; }
 }
 .composer-gear:hover { color: var(--text); background: var(--surface-elevated); }
 .effort-popover {
-  position: absolute; bottom: 100%; right: 10px; margin-bottom: 6px; z-index: 30;
+  position: absolute; bottom: 100%; right: 10px; left: 10px; margin-bottom: 6px; z-index: 30;
   background: var(--surface-elevated); border: 1px solid var(--border);
   border-radius: 12px; padding: 12px; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
-  min-width: 230px; display: flex; flex-direction: column; gap: 10px;
+  min-width: 0; max-width: 100%; display: flex; flex-direction: column; gap: 10px;
 }
 .effort-popover[hidden] { display: none; }
 .effort-title { font-size: 12px; font-weight: 600; color: var(--text); }
@@ -538,16 +562,18 @@ html[data-theme="dark"] .markdown .hl-num { color: #fbbf24; }
   opacity: 0.4;
   cursor: not-allowed;
 }
-/* --- Narrow-panel hardening: keep long content from overflowing / overlapping --- */
-.msg { overflow-wrap: anywhere; min-width: 0; }
-.msg .markdown { max-width: 100%; overflow-wrap: anywhere; }
-.msg .markdown pre.code-block { max-width: 100%; }
-.msg .markdown table { display: block; width: 100%; max-width: 100%; overflow-x: auto; border-collapse: collapse; }
+/* --- Side panel: never clip / mid-word-break long content. Scroll instead. --- */
+.msg { overflow-wrap: break-word; word-break: normal; min-width: 0; }
+.msg .markdown { max-width: 100%; overflow-wrap: break-word; min-width: 0; }
+.msg .markdown pre.code-block { max-width: 100%; overflow-x: auto; }
 .msg .markdown a { overflow-wrap: anywhere; }
 #input { min-width: 0; }
 .chat-bar-title { min-width: 0; }
+.composer-row { min-width: 0; }
 .composer-row > * { min-width: 0; }
 .composer-row #input { min-width: 0; }
+.composer-tools { min-width: 0; }
+.composer-model-select { max-width: 100%; min-width: 0; }
 
 /* Respect the [hidden] attribute (class display: inline-flex would otherwise
    keep the Stop button visible even when not streaming). */
@@ -598,14 +624,32 @@ html[data-theme="dark"] .markdown .hl-num { color: #fbbf24; }
 .messages .markdown hr { border: none; border-top: 1px solid var(--border, #e2e2e2); margin: 0.9em 0; }
 .messages .markdown strong { font-weight: 600; }
 
-/* Markdown tables in chat. */
+/* Markdown tables in chat: scroll horizontally instead of wrapping "Commit"
+   into "Com mit" in the narrow side panel. */
 .messages .markdown table {
-  border-collapse: collapse; margin: 0.6em 0; font-size: 0.92em;
-  display: block; max-width: 100%; overflow-x: auto;
+  display: block;
+  max-width: 100%;
+  margin: 0.6em 0;
+  font-size: 0.92em;
+  border-collapse: collapse;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.messages .markdown table thead,
+.messages .markdown table tbody {
+  display: table;
+  width: max-content;
+  min-width: 100%;
+  border-collapse: collapse;
 }
 .messages .markdown th, .messages .markdown td {
-  border: 1px solid var(--border, #d8d8d8); padding: 0.35em 0.6em;
-  text-align: left; vertical-align: top; word-break: break-word;
+  border: 1px solid var(--border, #d8d8d8);
+  padding: 0.4em 0.7em;
+  text-align: left;
+  vertical-align: top;
+  word-break: normal;
+  overflow-wrap: normal;
+  white-space: nowrap;
 }
 .messages .markdown thead th { background: rgba(127,127,127,0.12); font-weight: 600; }
 .messages .markdown tbody tr:nth-child(even) { background: rgba(127,127,127,0.05); }

--- a/src/chrome/browser/grok_companion/grok_companion_util.cc
+++ b/src/chrome/browser/grok_companion/grok_companion_util.cc
@@ -233,8 +233,7 @@ std::unique_ptr<views::View> CreateGrokCompanionView(
   // Track this contents so a subsequent OpenGrokSidePanelAt() can navigate it.
   LiveCompanionContents() = contents->GetWeakPtr();
   web_view->AttachContents(std::move(contents));
-  web_view->SetPreferredSize(
-      gfx::Size(SidePanelEntry::kSidePanelDefaultContentWidth, 0));
+  web_view->SetPreferredSize(gfx::Size(kGrokSidePanelWidth, 0));
   return web_view;
 }
 
@@ -427,8 +426,7 @@ void RegisterGrokSidePanel(BrowserWindowInterface* browser) {
             return CreateGrokCompanionView(bwi, prof, scope, url);
           },
           browser, profile, companion_url),
-      base::BindRepeating(
-          []() { return SidePanelEntry::kSidePanelDefaultContentWidth; }));
+      base::BindRepeating([]() { return kGrokSidePanelWidth; }));
   registry->Register(std::move(entry));
 }
 

--- a/src/chrome/browser/grok_companion/grok_companion_util.h
+++ b/src/chrome/browser/grok_companion/grok_companion_util.h
@@ -28,6 +28,10 @@ inline constexpr char kCompanionHost[] = "127.0.0.1";
 // Grok UI is served natively by AgentGateway (default 9334).
 inline constexpr int kCompanionPort = 9334;
 inline constexpr char kCompanionPath[] = "/";
+// Chrome's default side panel is 360px — too narrow for Grok chat tables and
+// the composer, which then clip on the right (especially Windows). 440px is
+// still a sidebar, but leaves room for a 3-column markdown table.
+inline constexpr int kGrokSidePanelWidth = 440;
 inline constexpr char kSearchPath[] = "/search";
 inline constexpr char kWelcomePath[] = "/welcome";
 inline constexpr char kGrokWikiHomeURL[] = "https://grokipedia.com/";


### PR DESCRIPTION
## Problem

The Grok companion side panel currently feels like a squeezed copy of grok.com rather than a docked sidebar:

- Default width is Chrome's 360px `kSidePanelDefaultContentWidth`, so tables and the composer clip on the right (especially Windows).
- `overflow-wrap: anywhere` plus `word-break: break-word` on table cells wraps labels mid-word (`Commit` → `Com mit`, `Deploy` → `Deplo y`).
- Body is a CSS grid still reserved for the in-page Grok toolbar, which is a no-op in the side panel, so the empty mount can steal layout and the chat does not fill the panel.

## Fix

- Default side panel width is **440px** (`kGrokSidePanelWidth`) — still a sidebar, wide enough for a 3-column markdown table.
- Companion chat uses a full-bleed flex column (`min-width: 0` throughout) instead of the leftover toolbar grid.
- Assistant messages use the full panel width; user bubbles stay at 92%.
- Markdown tables scroll horizontally instead of wrapping mid-word.
- Empty `#grok-toolbar-mount` is hidden so it cannot alias a second header.
- Antialiased type so the panel does not look like a scaled overlay.

Companion CSS is served live from `companion/ui` (no Chromium rebuild required for the layout). The width constant needs a native rebuild to take effect.

## Test

- Open the Grok side panel, send a reply that includes a markdown table.
- Confirm headers stay on one line and the table scrolls horizontally if needed.
- Confirm the composer, model picker, and header buttons are fully visible (not clipped by the window edge).
- Resize the panel: content should shrink cleanly, not overflow off the right.
